### PR TITLE
feat: ship raw tailwind with ui-components package

### DIFF
--- a/apps/portals-example/src/app/layout.tsx
+++ b/apps/portals-example/src/app/layout.tsx
@@ -1,7 +1,5 @@
-import { Inter, Open_Sans } from 'next/font/google';
 import './globals.scss';
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import '../../../../libs/ui-components/src/scss/styles-tailwind.scss';
+import { Inter, Open_Sans } from 'next/font/google';
 import classNames from 'classnames';
 import { ReactNode } from 'react';
 import { getServerSession } from 'next-auth';

--- a/apps/portals-example/src/scss/styles.scss
+++ b/apps/portals-example/src/scss/styles.scss
@@ -1,36 +1,41 @@
-@use 'tailwindcss/base';
-@use 'tailwindcss/components';
-@use 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-@use 'scroll.scss';
-@use 'buttons.scss';
-@use 'input.scss';
-@use 'fonts.scss';
-@use 'grid.scss';
-@use 'loader.scss';
-@use 'calendar.scss';
-@use 'attachments-container.scss';
-@use 'dataset-tabs.scss';
-@use 'messages.scss';
-@use 'conversation-list.scss';
-@use 'share.scss';
-@use 'metadata.scss';
-@use 'download.scss';
-@use 'advance-view.scss';
-@use 'alert.scss';
-@use 'chart-attachment.scss';
+@import 'scroll.scss';
+@import 'buttons.scss';
+@import 'input.scss';
+@import 'fonts.scss';
+@import 'grid.scss';
+@import 'loader.scss';
+@import 'calendar.scss';
+@import 'attachments-container.scss';
+@import 'dataset-tabs.scss';
+@import 'messages.scss';
+@import 'conversation-list.scss';
+@import 'share.scss';
+@import 'metadata.scss';
+@import 'download.scss';
+@import 'advance-view.scss';
+@import 'alert.scss';
+@import 'chart-attachment.scss';
 
 @import 'flatpickr/dist/themes/light.css';
+@import '../../../../libs/ui-components/src/scss/styles-tailwind.scss';
 
-body {
-  font-family: var(--open-sans);
+@layer base {
+  body {
+    font-family: var(--open-sans);
+  }
 }
 
-.main-layout {
-  background-image: url('/images/chat/layout.svg');
-  background-size: cover;
-}
+@layer components {
+  .main-layout {
+    background-image: url('/images/chat/layout.svg');
+    background-size: cover;
+  }
 
-.dropdown-menu-shadow {
-  box-shadow: 0px 1px 4px 0px #3161b04d;
+  .dropdown-menu-shadow {
+    box-shadow: 0px 1px 4px 0px #3161b04d;
+  }
 }

--- a/libs/conversation-list/src/index.ts
+++ b/libs/conversation-list/src/index.ts
@@ -1,5 +1,3 @@
-import './scss/styles.scss';
-
 export * from './models/titles';
 export * from './types/action-menu-item';
 export * from './utils/shared-conversations';

--- a/libs/conversation-list/src/scss/styles.scss
+++ b/libs/conversation-list/src/scss/styles.scss
@@ -1,3 +1,0 @@
-@use 'tailwindcss/base';
-@use 'tailwindcss/components';
-@use 'tailwindcss/utilities';

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -1,5 +1,3 @@
-import './scss/styles.scss';
-
 export {
   AdvancedViewProvider,
   useAdvancedView,

--- a/libs/conversation-view/src/scss/styles.scss
+++ b/libs/conversation-view/src/scss/styles.scss
@@ -1,3 +1,0 @@
-@use 'tailwindcss/base';
-@use 'tailwindcss/components';
-@use 'tailwindcss/utilities';

--- a/libs/ui-components/package.json
+++ b/libs/ui-components/package.json
@@ -4,11 +4,13 @@
   "license": "MIT",
   "dependencies": {
     "react-flatpickr": "^4.0.11",
-    "react": "^19.2.1",
     "classnames": "^2.5.1",
     "@epam/statgpt-shared-toolkit": "*",
     "@tabler/icons-react": "^3.34.1",
     "@floating-ui/react": "^0.27.14"
+  },
+  "peerDependencies": {
+    "react": "^19.2.1"
   },
   "exports": {
     ".": {
@@ -16,7 +18,7 @@
       "require": "./index.js",
       "types": "./index.d.ts"
     },
-    "./index.css": "./index.css"
+    "./styles-tailwind.scss": "./styles-tailwind.scss"
   },
   "main": "index",
   "browser": "index.js",

--- a/libs/ui-components/project.json
+++ b/libs/ui-components/project.json
@@ -21,6 +21,11 @@
             "glob": "LICENSE",
             "input": ".",
             "output": "."
+          },
+          {
+            "glob": "styles-tailwind.scss",
+            "input": "libs/ui-components/src/scss",
+            "output": "."
           }
         ]
       },

--- a/libs/ui-components/src/components/index.ts
+++ b/libs/ui-components/src/components/index.ts
@@ -1,5 +1,3 @@
-import '../scss/styles.scss';
-
 export { Alert } from './Alert/Alert';
 export { Button } from './Button/Button';
 export { Calendar } from './Calendar/Calendar';

--- a/libs/ui-components/src/scss/styles-tailwind.scss
+++ b/libs/ui-components/src/scss/styles-tailwind.scss
@@ -1,5 +1,4 @@
 @layer base {
-
   html,
   body {
     @apply h-full w-full text-neutrals-1000 overflow-hidden;

--- a/libs/ui-components/src/scss/styles-tailwind.scss
+++ b/libs/ui-components/src/scss/styles-tailwind.scss
@@ -1,97 +1,99 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@layer base {
 
-body,
-html {
-  @apply h-full w-full text-neutrals-1000 overflow-hidden;
-}
+  html,
+  body {
+    @apply h-full w-full text-neutrals-1000 overflow-hidden;
+  }
 
-.base-icon-button {
-  @apply flex flex-row items-center justify-center;
-  @apply border border-solid;
+  input {
+    -moz-appearance: textfield;
 
-  &:disabled {
-    @apply pointer-events-none;
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
   }
 }
 
-.base-button {
-  @apply flex flex-row items-center justify-center;
-  @apply border border-solid;
+@layer components {
+  .base-icon-button {
+    @apply flex flex-row items-center justify-center border border-solid;
 
-  &:disabled {
-    @apply pointer-events-none;
+    &:disabled {
+      @apply pointer-events-none;
+    }
   }
-}
 
-.text-button-primary {
-  @apply bg-primary text-white border-primary;
-  &:hover {
+  .base-button {
+    @apply flex flex-row items-center justify-center border border-solid;
+
+    &:disabled {
+      @apply pointer-events-none;
+    }
+  }
+
+  .text-button-primary {
+    @apply bg-primary text-white border-primary;
+
+    &:hover {
+      @apply text-primary;
+    }
+  }
+
+  .text-button-secondary {
+    @apply bg-transparent text-primary border-primary;
+  }
+
+  .text-button-tertiary {
+    @apply bg-transparent text-primary border-transparent;
+  }
+
+  .base-link {
     @apply text-primary;
+
+    &:hover {
+      @apply underline;
+    }
+  }
+
+  .flatpickr-input {
+    @apply text-neutrals-1000 border-b-2 border-solid border-b-primary w-full h-[40px] py-[8px] px-[6px];
+
+    &:focus-visible {
+      @apply outline-none;
+    }
+
+    &:hover,
+    &:active {
+      @apply border-neutrals-1000;
+    }
   }
 }
 
-.text-button-secondary {
-  @apply bg-transparent text-primary border-primary;
-}
+@layer utilities {
+  .padding-0 {
+    padding: 0 !important;
+  }
 
-.text-button-tertiary {
-  @apply bg-transparent text-primary border-transparent;
-}
+  .two-lines {
+    @apply block first-line:overflow-hidden text-ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
 
-.loader {
-  animation: spin 1s infinite linear;
+  .loader {
+    animation: spin 1s infinite linear;
+
+    &::before {
+      content: '';
+      @apply block;
+    }
+  }
 
   @keyframes spin {
     100% {
       transform: rotate(360deg);
     }
-  }
-  &::before {
-    content: '';
-    @apply block;
-  }
-}
-
-.two-lines {
-  @apply block first-line:overflow-hidden text-ellipsis;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
-.base-link {
-  @apply text-primary;
-  &:hover {
-    @apply underline;
-  }
-}
-
-input {
-  -moz-appearance: textfield; /* Firefox */
-
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-}
-
-.padding-0 {
-  @apply p-0 !important;
-}
-
-.flatpickr-input {
-  @apply text-neutrals-1000;
-  @apply border-b-2 border-solid border-b-primary;
-  @apply w-full h-[40px] py-[8px] px-[6px];
-
-  &:focus-visible {
-    @apply outline-none;
-  }
-
-  &:hover,
-  &:active {
-    @apply border-neutrals-1000;
   }
 }

--- a/libs/ui-components/src/scss/styles.scss
+++ b/libs/ui-components/src/scss/styles.scss
@@ -1,3 +1,5 @@
-@use 'tailwindcss/base';
-@use 'tailwindcss/components';
-@use 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import './styles-tailwind.scss';

--- a/libs/ui-components/vite.config.ts
+++ b/libs/ui-components/vite.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
           src: '../../LICENSE',
           dest: '',
         },
+        {
+          src: 'src/scss/styles-tailwind.scss',
+          dest: '',
+        },
       ],
     }),
   ],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:write": "prettier --write .",
     "typecheck": "nx run-many --target=typecheck --all",
     "graph": "nx graph",
-    "build:styles": "tailwindcss -m -i ./libs/ui-components/src/scss/styles-tailwind.scss -o ./dist/libs/ui-components/index.css",
+    "build:styles": "tailwindcss -m -i ./libs/ui-components/src/scss/styles.scss -o ./dist/libs/ui-components/index.css",
     "publish": "nx run-many -t publish",
     "publish:dry": "nx run-many -t publish --output-style=static --dry",
     "affected:build": "nx affected --target=build",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

This change adds raw Tailwind layer styles to the ui-components library alongside the compiled CSS.
This allows consuming applications to process these styles in their own Tailwind build, so shared semantic classes (for example, text-button-secondary) can be safely used with @apply and layered consistently.
The compiled CSS still might be used at runtime, while the raw Tailwind source enables easier extension and theming in consumer applications.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
