### PR TITLE
fix: show code samples tab per dataset. hide cursor in monaco code attachment

### DIFF
--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CodeAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CodeAttachment.tsx
@@ -12,7 +12,12 @@ export const CodeAttachment = ({
   const { data, language } = attachment;
 
   return (
-    <div className={mergeClasses(['h-full w-full', className])}>
+    <div
+      className={mergeClasses([
+        'h-full w-full [&_.cursors-layer]:hidden',
+        className,
+      ])}
+    >
       <Editor
         value={data}
         language={language}

--- a/libs/conversation-view/src/context/AttachmentsData.tsx
+++ b/libs/conversation-view/src/context/AttachmentsData.tsx
@@ -245,8 +245,11 @@ export function useAttachmentsData(
 
   useEffect(() => {
     if (rawAttachments?.length) {
+      const urn = dataQuery?.urn;
+
       const mdParsedAttachments = rawAttachments
         .filter((a) => a.type === AttachmentType.MARKDOWN)
+        .filter((a) => !urn || a.title?.includes(urn))
         .map((a) => {
           const parsed = unwrapMarkdownCode(a.data ?? '');
           return {
@@ -262,7 +265,7 @@ export function useAttachmentsData(
 
       setCodeAttachments(mdParsedAttachments);
     }
-  }, [rawAttachments, titles]);
+  }, [rawAttachments, titles, dataQuery]);
 
   const attachments = useMemo(
     () => [customGridAttachment, customChartAttachment, ...codeAttachments],


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
