### PR TITLE
fix: renamed chat name is changed after page refresh

### DIFF
--- a/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
@@ -94,10 +94,13 @@ const ConversationListWrapper = () => {
       getConversation: authHandler(getConversationApi),
       getFileBlob: authHandler(getFileBlobApi),
       renameConversation: authHandler(
-        (source: string, destination: string): any => {
-          renameConversationApi(source, destination).then(() =>
-            router.push(`/${destination.replace(locale, '')}`),
-          );
+        async (
+          source: string,
+          destination: string,
+        ): Promise<ApiResponse<void>> => {
+          const response = await renameConversationApi(source, destination);
+          router.push(`/${destination.replace(locale, '')}`);
+          return response;
         },
       ),
     }),


### PR DESCRIPTION
### Applicable issues

[Renamed chat name is changed after page refresh](https://github.com/epam/statgpt-global-trusted-data-commons/issues/106)

### Description of changes

Wait until the rename is completed on the server side before updating the Conversation List.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
