### PR TITLE
fix: full conversation rename

### DIFF
--- a/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
@@ -94,10 +94,13 @@ const ConversationListWrapper = () => {
       getConversation: authHandler(getConversationApi),
       getFileBlob: authHandler(getFileBlobApi),
       renameConversation: authHandler(
-        (source: string, destination: string): any => {
-          renameConversationApi(source, destination).then(() =>
-            router.push(`/${destination.replace(locale, '')}`),
-          );
+        async (
+          source: string,
+          destination: string,
+        ): Promise<ApiResponse<void>> => {
+          const response = await renameConversationApi(source, destination);
+          router.push(`/${destination.replace(locale, '')}`);
+          return response;
         },
       ),
     }),

--- a/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
@@ -30,7 +30,6 @@ import {
   deleteConversationApi,
   getConversationsApi,
   getConversationApi,
-  renameConversationApi,
 } from '../../app/api/conversations/client';
 import { getSharedConversationsApi } from '../../app/api/share/client';
 import { ApplicationRoute } from '../../types/application-routes';
@@ -57,6 +56,8 @@ import { SIGN_IN_LINK } from '../../constants/auth';
 import { ApiResponse } from '@epam/statgpt-shared-toolkit';
 import { wrapWithAuthHandler } from '../../utils/auth/requests-wrapper';
 import { signOut, useSession } from 'next-auth/react';
+import { ConversationInfo } from '@epam/ai-dial-shared';
+import { renameConversationAndSyncContent as renameConversationAndSyncContentFlow } from '../../utils/conversation/rename-conversation-and-sync-content';
 
 const ConversationListWrapper = () => {
   const t = useI18n();
@@ -95,16 +96,26 @@ const ConversationListWrapper = () => {
       getFileBlob: authHandler(getFileBlobApi),
       renameConversation: authHandler(
         async (
-          source: string,
-          destination: string,
-        ): Promise<ApiResponse<void>> => {
-          const response = await renameConversationApi(source, destination);
-          router.push(`/${destination.replace(locale, '')}`);
+          sourceUrl: string,
+          destinationUrl: string,
+        ): Promise<ApiResponse<void | ConversationInfo>> => {
+          const { navPath, response } =
+            await renameConversationAndSyncContentFlow(
+              sourceUrl,
+              destinationUrl,
+            );
+
+          if (response.success && navPath) {
+            router.replace(
+              `/${locale}${ApplicationRoute.Conversations}/${navPath}`,
+            );
+          }
+
           return response;
         },
       ),
     }),
-    [authHandler, locale, router],
+    [authHandler],
   );
 
   const titles: ConversationListTitles = {

--- a/apps/portals-example/src/utils/conversation/rename-conversation-and-sync-content.ts
+++ b/apps/portals-example/src/utils/conversation/rename-conversation-and-sync-content.ts
@@ -1,0 +1,79 @@
+import { ConversationInfo } from '@epam/ai-dial-shared';
+import {
+  getConversationFolderIdFromConversationId,
+  getConversationIdFromResourceUrl,
+  getConversationNameFromConversationId,
+  getConversationNavPath,
+  ApiResponse,
+} from '@epam/statgpt-shared-toolkit';
+import {
+  getConversationApi,
+  renameConversationApi,
+  updateConversationApi,
+} from '../../app/api/conversations/client';
+import { UpdateConversationRequest } from '@epam/statgpt-dial-toolkit';
+
+interface RenameConversationAndSyncContentResult {
+  navPath?: string;
+  response: ApiResponse<ConversationInfo>;
+}
+
+export const renameConversationAndSyncContent = async (
+  sourceUrl: string,
+  destinationUrl: string,
+): Promise<RenameConversationAndSyncContentResult> => {
+  const renameResponse = await renameConversationApi(sourceUrl, destinationUrl);
+
+  if (!renameResponse.success) {
+    return {
+      response: renameResponse as ApiResponse<ConversationInfo>,
+    };
+  }
+
+  const renamedConversationId =
+    getConversationIdFromResourceUrl(destinationUrl);
+  const renamedConversationFolderId = getConversationFolderIdFromConversationId(
+    renamedConversationId,
+  );
+  const renamedConversationName = getConversationNameFromConversationId(
+    renamedConversationId,
+  );
+  const renamedConversationResponse = await getConversationApi(
+    renamedConversationId,
+  );
+
+  if (!renamedConversationResponse.success) {
+    return {
+      response: renamedConversationResponse as ApiResponse<ConversationInfo>,
+    };
+  }
+
+  const renamedConversation = renamedConversationResponse.data;
+
+  if (!renamedConversation) {
+    throw new Error('Renamed conversation payload is missing');
+  }
+
+  const updateConversationRequest: UpdateConversationRequest = {
+    ...renamedConversation,
+    id: renamedConversationId,
+    folderId: renamedConversationFolderId,
+    name: renamedConversationName,
+    messages: renamedConversation.messages,
+  };
+
+  const updateConversationResponse = await updateConversationApi(
+    renamedConversationId,
+    updateConversationRequest,
+  );
+
+  return {
+    navPath: updateConversationResponse.success
+      ? getConversationNavPath(
+          renamedConversationFolderId,
+          renamedConversationId,
+        )
+      : undefined,
+    response: updateConversationResponse,
+  };
+};

--- a/libs/dial-toolkit/src/models/conversation.ts
+++ b/libs/dial-toolkit/src/models/conversation.ts
@@ -19,6 +19,7 @@ export interface CreateConversationRequest {
 
 export interface UpdateConversationRequest {
   name?: string;
+  id?: string;
   folderId?: string;
   model?: ModelInfo;
   prompt?: string;

--- a/libs/shared-toolkit/src/utils/conversation-mapping.ts
+++ b/libs/shared-toolkit/src/utils/conversation-mapping.ts
@@ -1,10 +1,10 @@
 import { ConversationInfo } from '@epam/ai-dial-shared';
-import { stripConversationVersionSuffix } from './conversation-name';
+import { deleteConversationNamePostfix } from './conversation-name';
 
 export const cleanConversationNames = (
   conversations: ConversationInfo[],
 ): ConversationInfo[] =>
   conversations.map((conversation) => ({
     ...conversation,
-    name: stripConversationVersionSuffix(conversation.name),
+    name: deleteConversationNamePostfix(conversation.name),
   }));

--- a/libs/shared-toolkit/src/utils/conversation-mapping.ts
+++ b/libs/shared-toolkit/src/utils/conversation-mapping.ts
@@ -1,9 +1,10 @@
 import { ConversationInfo } from '@epam/ai-dial-shared';
+import { stripConversationVersionSuffix } from './conversation-name';
 
 export const cleanConversationNames = (
   conversations: ConversationInfo[],
 ): ConversationInfo[] =>
   conversations.map((conversation) => ({
     ...conversation,
-    name: conversation.name.split(/-\d+$/)[0],
+    name: stripConversationVersionSuffix(conversation.name),
   }));

--- a/libs/shared-toolkit/src/utils/conversation-name.ts
+++ b/libs/shared-toolkit/src/utils/conversation-name.ts
@@ -1,4 +1,4 @@
-export const stripConversationVersionSuffix = (
+export const deleteConversationNamePostfix = (
   conversationName?: string,
 ): string => conversationName?.split(/-\d+$/)[0] ?? '';
 

--- a/libs/shared-toolkit/src/utils/conversation-name.ts
+++ b/libs/shared-toolkit/src/utils/conversation-name.ts
@@ -1,3 +1,7 @@
+export const stripConversationVersionSuffix = (
+  conversationName?: string,
+): string => conversationName?.split(/-\d+$/)[0] ?? '';
+
 export const getClearedConversationName = (
   conversationName?: string,
 ): string => {

--- a/libs/shared-toolkit/src/utils/conversation-url.ts
+++ b/libs/shared-toolkit/src/utils/conversation-url.ts
@@ -1,3 +1,5 @@
+import { stripConversationVersionSuffix } from './conversation-name';
+
 export const getConversationUrlWithoutLocale = (
   resourceUrl: string,
   locale: string,
@@ -7,3 +9,17 @@ export const getConversationUrlWithoutLocale = (
     ?.filter((item: string) => item !== locale)
     ?.join('/');
 };
+
+export const getConversationIdFromResourceUrl = (resourceUrl: string): string =>
+  resourceUrl.replace(/^conversations\//, '');
+
+export const getConversationFolderIdFromConversationId = (
+  conversationId: string,
+): string => conversationId.split('/').slice(0, -1).join('/');
+
+export const getConversationNameFromConversationId = (
+  conversationId: string,
+): string =>
+  stripConversationVersionSuffix(
+    decodeURIComponent(conversationId.split('/').at(-1) ?? ''),
+  );

--- a/libs/shared-toolkit/src/utils/conversation-url.ts
+++ b/libs/shared-toolkit/src/utils/conversation-url.ts
@@ -1,4 +1,4 @@
-import { stripConversationVersionSuffix } from './conversation-name';
+import { deleteConversationNamePostfix } from './conversation-name';
 
 export const getConversationUrlWithoutLocale = (
   resourceUrl: string,
@@ -20,6 +20,6 @@ export const getConversationFolderIdFromConversationId = (
 export const getConversationNameFromConversationId = (
   conversationId: string,
 ): string =>
-  stripConversationVersionSuffix(
+  deleteConversationNamePostfix(
     decodeURIComponent(conversationId.split('/').at(-1) ?? ''),
   );


### PR DESCRIPTION
### Applicable issues

[Invalid conversation name in duplicate chat](https://github.com/epam/statgpt-global-trusted-data-commons/issues/34)

### Description of changes

Rewrite conversation content after file rename to keep conversation metadata in sync.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
