### PR TITLE
fix: disable welcome screen input/buttons

### DIFF
--- a/libs/conversation-view/src/components/ConversationOnboarding/ChoiceButtons/ChoiceButtons.tsx
+++ b/libs/conversation-view/src/components/ConversationOnboarding/ChoiceButtons/ChoiceButtons.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import classNames from 'classnames';
 import { FC } from 'react';
 import {
   DialSchemaProperties,
@@ -9,15 +10,27 @@ import { CUSTOM_CHOICE_ID } from '../../../constants/custom-content-properties';
 
 interface Props {
   choiceButtons: FormSchemaButtonOption[];
+  disabled?: boolean;
   onClick: (message?: string, choiceId?: string) => void;
 }
 
-export const ChoiceButtons: FC<Props> = ({ choiceButtons, onClick }) => {
+export const ChoiceButtons: FC<Props> = ({
+  choiceButtons,
+  disabled,
+  onClick,
+}) => {
+  const choiceButtonClassName = classNames(
+    'flex w-full min-h-[72px] flex-col items-start justify-center rounded border px-4 py-2 text-left',
+    'border-hues-200 hover:bg-hues-100',
+    'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+  );
+
   return choiceButtons.map((item) => (
     <div className="mt-4" key={item.title}>
       <button
         type="button"
-        className="flex flex-col items-start justify-center text-left w-full rounded border-hues-200 hover:bg-hues-100 min-h-[72px] border px-4 py-2"
+        className={choiceButtonClassName}
+        disabled={disabled}
         onClick={() =>
           onClick(
             item[DialSchemaProperties.DialWidgetOptions]?.populateText,

--- a/libs/conversation-view/src/components/ConversationOnboarding/ConversationOnboarding.tsx
+++ b/libs/conversation-view/src/components/ConversationOnboarding/ConversationOnboarding.tsx
@@ -10,6 +10,7 @@ interface Props {
   titles?: ConversationViewTitles;
   messageContent: string;
   choiceButtons: FormSchemaButtonOption[];
+  disabled?: boolean;
   onClick: (message?: string, choiceId?: string) => void;
   handleOnboardingSkip?: (isSkippedOnboarding?: boolean) => void;
 }
@@ -18,6 +19,7 @@ export const ConversationOnboarding: FC<Props> = ({
   titles,
   messageContent,
   choiceButtons,
+  disabled,
   onClick,
   handleOnboardingSkip,
 }) => {
@@ -33,18 +35,24 @@ export const ConversationOnboarding: FC<Props> = ({
       <div className="onboarding-content flex flex-col">
         <MessageContent content={messageContent} />
         <div className="mt-4">
-          <ChoiceButtons choiceButtons={choiceButtons} onClick={onClick} />
+          <ChoiceButtons
+            choiceButtons={choiceButtons}
+            disabled={disabled}
+            onClick={onClick}
+          />
         </div>
         <div className="flex mt-8">
           <Button
             title={titles?.skipOnboardingNow}
             buttonClassName="text-button-secondary mr-4"
+            disabled={disabled}
             onClick={() => handleOnboardingSkip?.()}
             isSmallButton={true}
           />
           <Button
             title={titles?.refuseOnboarding}
             buttonClassName="text-button-tertiary"
+            disabled={disabled}
             onClick={() => handleOnboardingSkip?.(true)}
             isSmallButton={true}
           />

--- a/libs/conversation-view/src/components/ConversationWelcome/ConversationWelcome.tsx
+++ b/libs/conversation-view/src/components/ConversationWelcome/ConversationWelcome.tsx
@@ -82,8 +82,9 @@ export const ConversationWelcome: FC<Props> = ({
   setSharedConversations,
 }) => {
   const [bucket, setBucket] = useState<string | null>(null);
+  const [isBucketLoading, setIsBucketLoading] = useState(true);
   const [isCreatingConversation, setIsCreatingConversation] =
-    useState<boolean>();
+    useState<boolean>(false);
   const {
     onboardingFileSchema,
     onboardingFileName,
@@ -103,6 +104,8 @@ export const ConversationWelcome: FC<Props> = ({
         setBucket(bucketData.bucket);
       } catch (err) {
         console.error(err instanceof Error ? err.message : 'Request error');
+      } finally {
+        setIsBucketLoading(false);
       }
     };
 
@@ -111,15 +114,17 @@ export const ConversationWelcome: FC<Props> = ({
 
   const createConversation = useCallback(
     async (message?: string, choiceId?: string) => {
-      setIsCreatingConversation(true);
       if (!bucket) {
         console.error('No bucket');
+        return;
       }
+
+      setIsCreatingConversation(true);
 
       try {
         const conversationRequestData = isShowOnboarding
           ? generateOnboardingConversation(
-              bucket || '',
+              bucket,
               locale,
               titles?.onboardingTitle ?? 'Introducing the AI assistant',
               onboardingMessageSchema?.properties?.choice?.description ?? '',
@@ -127,7 +132,7 @@ export const ConversationWelcome: FC<Props> = ({
               choiceId,
             )
           : getCreateConversationRequest(
-              bucket || '',
+              bucket,
               locale,
               titles.newChat ?? 'New chat',
               message,
@@ -223,6 +228,8 @@ export const ConversationWelcome: FC<Props> = ({
   }, [bucket, prompt]);
 
   const getContent = () => {
+    const isConversationCreationDisabled = !bucket;
+
     if (!isAgentAvailable) {
       return (
         <InlineAlert type={InlineAlertType.Error}>
@@ -239,6 +246,7 @@ export const ConversationWelcome: FC<Props> = ({
             isBottomInputPosition && 'order-3 mt-auto',
           )}
           inputClasses="mr-2"
+          disabled={isConversationCreationDisabled}
           placeholder={titles?.askAnything ?? 'Ask anything...'}
           sendMessageIcon={inputMessageStyles.sendMessageIcon}
           onSendMessage={createConversation}
@@ -257,6 +265,7 @@ export const ConversationWelcome: FC<Props> = ({
                 text={
                   item[DialSchemaProperties.DialWidgetOptions]?.populateText
                 }
+                disabled={isConversationCreationDisabled}
                 onClick={createConversation}
               />
             ))}
@@ -268,7 +277,7 @@ export const ConversationWelcome: FC<Props> = ({
 
   return (
     <div className="flex flex-col h-full w-full">
-      {prompt || isCreatingConversation ? (
+      {isCreatingConversation || (prompt && isBucketLoading) ? (
         <Loader />
       ) : isShowOnboarding ? (
         <ConversationOnboarding
@@ -279,6 +288,7 @@ export const ConversationWelcome: FC<Props> = ({
           choiceButtons={
             onboardingMessageSchema?.properties?.choice?.oneOf || []
           }
+          disabled={!bucket}
           handleOnboardingSkip={handleOnboardingSkip}
           onClick={createConversation}
         />

--- a/libs/conversation-view/src/components/InputForAsk/InputForAsk.tsx
+++ b/libs/conversation-view/src/components/InputForAsk/InputForAsk.tsx
@@ -13,6 +13,7 @@ interface Props {
   containerClasses?: string;
   inputClasses?: string;
   inProcess?: boolean;
+  disabled?: boolean;
   placeholder?: string;
   sendMessageIcon?: ReactNode;
   isLastFailed?: boolean;
@@ -24,6 +25,7 @@ interface Props {
 
 const InputForAsk: FC<Props> = ({
   inProcess,
+  disabled,
   containerClasses,
   inputClasses,
   placeholder,
@@ -44,7 +46,7 @@ const InputForAsk: FC<Props> = ({
   );
 
   const onSend = (value: string) => {
-    if (inProcess) {
+    if (inProcess || disabled) {
       return;
     }
 
@@ -53,6 +55,10 @@ const InputForAsk: FC<Props> = ({
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
+
     if (event.key === KeyboardKey.Enter && !event.shiftKey) {
       if (isLastFailed) {
         onRetryFailed?.();
@@ -63,6 +69,10 @@ const InputForAsk: FC<Props> = ({
   };
 
   const getIcon = () => {
+    if (disabled) {
+      return null;
+    }
+
     if (isLastFailed) {
       return (
         <IconButton
@@ -101,6 +111,7 @@ const InputForAsk: FC<Props> = ({
       placeholder={placeholder}
       onChange={onInputChange}
       onKeyDown={onKeyDown}
+      disabled={disabled}
       cssClass={classNames(inputClasses, 'input-for-ask')}
       value={inputData}
       iconAfterInput={getIcon()}

--- a/libs/ui-components/src/components/Tag/Tag.tsx
+++ b/libs/ui-components/src/components/Tag/Tag.tsx
@@ -1,18 +1,24 @@
 'use client';
 
+import classNames from 'classnames';
 import { FC } from 'react';
 
 interface Props {
   title?: string;
   text?: string;
+  disabled?: boolean;
   onClick?: (text?: string) => void;
 }
 
-export const Tag: FC<Props> = ({ title, text, onClick }) => {
+export const Tag: FC<Props> = ({ title, text, disabled, onClick }) => {
   return (
     <button
       type="button"
-      className="tag flex items-center justify-center"
+      className={classNames(
+        'tag flex items-center justify-center',
+        'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-neutrals-100',
+      )}
+      disabled={disabled}
       onClick={() => onClick?.(text || title)}
       aria-label="button"
     >


### PR DESCRIPTION
### Applicable issues

[Error if send any request while conversations in loading](https://github.com/epam/statgpt-global-trusted-data-commons/issues/53)

### Description of changes

Disable input and action buttons on the welcome screen until the user bucket is loaded, preventing chat creation requests from being sent without a bucket and failing during bucket initialization.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
