### PR TITLE
fix: show columns button only when cross dataset mod is active

### DIFF
--- a/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
@@ -15,6 +15,7 @@ import AttachmentTabs from './Tabs/AttachmentTabs/AttachmentTabs';
 import { AttachmentsStyles } from '../../models/attachments-styles';
 import { ConversationViewTitles } from '../../models/titles';
 import ColumnsIcon from '../../assets/icons/columns.svg';
+import { useCrossDatasetMode } from '../../context/CrossDatasetModeContext';
 
 interface Props {
   attachments: (
@@ -51,7 +52,10 @@ const AttachmentsViewModePanel: FC<Props> = ({
   isTableSettingsOpen,
   onTableSettingsOpen,
 }) => {
+  const { isCrossDatasetModeOn } = useCrossDatasetMode();
+
   const shouldShowColumnsButton =
+    isCrossDatasetModeOn &&
     !showAdvancedView &&
     !!onTableSettingsOpen &&
     !!(selectedAttachment && isCustomGridAttachment(selectedAttachment));


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #205 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
