### PR TITLE
feat: wire table settings panel and multi grid in cross dataset mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Commands
+
+```bash
+# Development
+npm run start                   # Start Next.js dev server on port 4001
+npm run build                   # Build all projects + compile Tailwind CSS
+
+# Testing
+npm run test                    # Run all tests (monorepo-wide)
+npx nx test <project>           # Run tests for a specific project (e.g., ui-components, dial-toolkit)
+npx nx test <project> --testFile=<path>  # Run a single test file
+npx nx test <project> -- --testNamePattern="test name"  # Filter by test name
+
+# Quality
+npm run lint                    # Lint all projects
+npm run lint:fix                # Lint and auto-fix
+npm run format                  # Check formatting (Prettier)
+npm run format:write            # Auto-format
+npm run typecheck               # TypeScript type-check all projects
+```
+
+Project names for `nx` commands: `portals-example`, `ui-components`, `conversation-view`, `conversation-list`, `dial-toolkit`, `sdmx-toolkit`, `shared-toolkit`, `download-panel`, `share-conversation`, `user-info`.
+
+## Architecture
+
+**Nx monorepo** with one deployable Next.js 15 app (`apps/portals-example`) and multiple library packages (`libs/`).
+
+### App (`apps/portals-example`)
+
+Next.js App Router with i18n prefix (`/en/`). Key routes:
+
+- `/en/conversations/` — welcome/conversation list view
+- `/en/conversations/[...id]/` — individual conversation (catch-all: `bucketId` + `conversationId`)
+- `/en/share/[invitationId]/` — shared conversation view
+- `/api/dial/:path*` — proxied to `DIAL_API_URL/api/:path*` (see `next.config.js` rewrites)
+- `/api/auth/[...nextauth]` — NextAuth.js (auth is optional, toggled via `ENABLE_AUTH` env var)
+
+The `[locale]/layout.tsx` is a **Server Component** that fetches deployment config, conversation list, and SDMX metadata at render time and injects them into Context providers. All data fetching for initial page load happens here.
+
+### Libraries
+
+| Package | Description |
+|---|---|
+| `@epam/statgpt-conversation-view` | Main chat UI — all message rendering, streaming, input, and feature context providers |
+| `@epam/statgpt-conversation-list` | Sidebar with conversation history |
+| `@epam/statgpt-dial-toolkit` | DIAL API client (chat, conversations, files, buckets) |
+| `@epam/statgpt-sdmx-toolkit` | SDMX API client and data transformation utilities |
+| `@epam/statgpt-shared-toolkit` | Shared TypeScript interfaces/utilities used across libs and app |
+| `@epam/statgpt-ui-components` | Reusable design-system components (Button, Input, Modal, etc.) |
+| `@statgpt/download-panel` | SDMX data download UI |
+| `@statgpt/share-conversation` | Share conversation via link/QR code |
+| `@statgpt/user-info` | User info display component |
+
+Path aliases for all packages are defined in `/tsconfig.base.json`.
+
+### State Management
+
+No Redux or Zustand. State is managed via **React Context + useState** only. Server state is loaded in Server Components and passed down to client providers.
+
+### Streaming
+
+Chat responses use SSE (Server-Sent Events). `ChatMessagesContext` tracks the `isStreaming` flag. The `/api/chat` route proxies streaming responses from the DIAL API.
+
+### Styling
+
+Tailwind CSS 3.4 with a custom CSS-variable-based color system defined in `tailwind.config.js`. The compiled stylesheet is output to `dist/libs/ui-components/index.css` via `npm run build:styles`.

--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -48,23 +48,7 @@ interface Props {
   datasetInfoOptions?: DatasetInfoOptions;
 }
 
-export const AdvancedView: FC<Props> = ({ attachmentsProps, ...props }) => {
-  const currentUrn = useMemo(
-    () =>
-      attachmentsProps.currentDataQuery?.urn ??
-      attachmentsProps.dataQueries?.[0]?.urn ??
-      'default',
-    [attachmentsProps.currentDataQuery?.urn, attachmentsProps.dataQueries],
-  );
-
-  return (
-    <TableSettingsProvider currentUrn={currentUrn}>
-      <AdvancedViewInternal attachmentsProps={attachmentsProps} {...props} />
-    </TableSettingsProvider>
-  );
-};
-
-const AdvancedViewInternal: FC<Props> = ({
+export const AdvancedView: FC<Props> = ({
   attachmentsProps,
   actions,
   titles,
@@ -78,8 +62,18 @@ const AdvancedViewInternal: FC<Props> = ({
   datasetInfoOptions,
   ...props
 }) => {
+  const currentUrn = useMemo(
+    () =>
+      attachmentsProps.currentDataQuery?.urn ??
+      attachmentsProps.dataQueries?.[0]?.urn ??
+      'default',
+    [attachmentsProps.currentDataQuery?.urn, attachmentsProps.dataQueries],
+  );
+
   const { isOpenedAdvancedView } = useAdvancedView();
-  const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
+  const { isCrossDatasetModeOn, isMetadataInSidePanel } =
+    useConversationViewFeatureToggles();
+  const shouldShowDatasetInfo = !isMetadataInSidePanel;
 
   const lastMessageAttachments =
     props.filtersProps.conversation?.messages?.at(-1)?.custom_content
@@ -178,97 +172,104 @@ const AdvancedViewInternal: FC<Props> = ({
   );
 
   return (
-    <div className="advanced-view flex flex-col flex-1 h-full min-w-0">
-      <Header
-        titles={titles}
-        locale={locale}
-        shareConversationProps={shareConversationProps}
-        isShowShare={advanceViewStyles?.isShowShare}
-      />
-      {!attachmentsProps?.datasets?.length ? (
-        <Loader />
-      ) : (
-        <>
-          {attachmentsProps?.datasets?.length > 1 && !isCrossDatasetModeOn && (
-            <DatasetTabs
-              datasets={attachmentsProps?.datasets}
-              initialSelectedDatasetUrn={
-                attachmentsProps?.currentDataQuery?.urn
-              }
-              locale={locale}
-              isHideAdvancedViewButton={true}
-              selectDataset={onSelectDataset}
-            />
-          )}
-          {isDataLoading && !isFiltering ? (
-            <Loader />
-          ) : (
-            <>
-              {!isCrossDatasetModeOn && (
-                <DatasetInfo
-                  {...datasetInfoOptions}
-                  titles={titles}
-                  locale={locale}
-                  dataset={dataset}
-                  data={dataMessage?.data}
-                  structures={structures}
-                  metadataSettings={metadataSettings}
-                  getDatasetUpdatedTime={getDatasetUpdatedTime}
-                  externalLink={externalLink}
-                />
-              )}
-              <div
-                className={classNames([
-                  'flex flex-1 min-h-0 overflow-auto',
-                  !isCrossDatasetModeOn && 'border-t border-neutrals-500',
-                ])}
-              >
+    <TableSettingsProvider
+      currentUrn={currentUrn}
+      structuresMap={structureDataMaps?.structuresMap}
+      locale={locale}
+      dataQueries={attachmentsProps?.dataQueries}
+    >
+      <div className="advanced-view flex flex-col flex-1 h-full min-w-0">
+        <Header
+          titles={titles}
+          locale={locale}
+          shareConversationProps={shareConversationProps}
+          isShowShare={advanceViewStyles?.isShowShare}
+        />
+        {!attachmentsProps?.datasets?.length ? (
+          <Loader />
+        ) : (
+          <>
+            {attachmentsProps?.datasets?.length > 1 && (
+              <DatasetTabs
+                datasets={attachmentsProps?.datasets}
+                initialSelectedDatasetUrn={
+                  attachmentsProps?.currentDataQuery?.urn
+                }
+                locale={locale}
+                isHideAdvancedViewButton={true}
+                selectDataset={onSelectDataset}
+              />
+            )}
+            {isDataLoading && !isFiltering ? (
+              <Loader />
+            ) : (
+              <>
+                {shouldShowDatasetInfo && (
+                  <DatasetInfo
+                    {...datasetInfoOptions}
+                    titles={titles}
+                    locale={locale}
+                    dataset={dataset}
+                    data={dataMessage?.data}
+                    structures={structures}
+                    metadataSettings={metadataSettings}
+                    getDatasetUpdatedTime={getDatasetUpdatedTime}
+                    externalLink={externalLink}
+                  />
+                )}
                 <div
                   className={classNames(
-                    'flex-1 min-h-0 overflow-auto',
-                    'advanced-view-filters',
+                    'flex flex-1 min-h-0 overflow-auto',
+                    shouldShowDatasetInfo && 'border-t border-neutrals-500',
                   )}
                 >
-                  <DataDetails
-                    {...props}
-                    titles={titles}
-                    actions={actions}
-                    attachments={
-                      isCrossDatasetModeOn
-                        ? [crossDatasetGridAttachment]
-                        : dataSetAttachments
-                    }
-                    attachmentsDataQuery={attachmentsProps.currentDataQuery}
-                    dataQueries={attachmentsProps?.dataQueries}
-                    dimensions={dimensions}
-                    attachmentsStyles={attachmentsProps.styles}
-                    isDataLoading={isDataLoading}
-                    locale={locale}
-                    filtersProps={{
-                      ...props?.filtersProps,
-                      structureDimensions,
-                      structures,
-                      structureDataMaps,
-                      onFiltersChange,
-                      initialConstraints: constraints,
-                      onMultipleDataFiltersChange:
-                        handleMultipleDataFiltersChange,
-                    }}
-                    setIsFiltering={setIsFiltering}
-                    attachmentsConfig={attachmentsConfig}
-                    filters={filters}
-                    filtersMap={filtersMap}
-                    onFiltersChange={handleFiltersChange}
-                  />
+                  <div
+                    className={classNames(
+                      'flex-1 min-h-0 overflow-auto',
+                      'advanced-view-filters',
+                    )}
+                  >
+                    <DataDetails
+                      {...props}
+                      titles={titles}
+                      actions={actions}
+                      attachments={
+                        isCrossDatasetModeOn
+                          ? [crossDatasetGridAttachment]
+                          : dataSetAttachments
+                      }
+                      attachmentsDataQuery={attachmentsProps.currentDataQuery}
+                      dataQueries={attachmentsProps?.dataQueries}
+                      dimensions={dimensions}
+                      attachmentsStyles={attachmentsProps.styles}
+                      isDataLoading={isDataLoading}
+                      locale={locale}
+                      filtersProps={{
+                        ...props?.filtersProps,
+                        structureDimensions,
+                        structures,
+                        structureDataMaps,
+                        onFiltersChange,
+                        onMultipleDataFiltersChange:
+                          handleMultipleDataFiltersChange,
+                        initialConstraints: constraints,
+                      }}
+                      setIsFiltering={setIsFiltering}
+                      attachmentsConfig={attachmentsConfig}
+                      filters={filters}
+                      filtersMap={filtersMap}
+                      onFiltersChange={handleFiltersChange}
+                    />
+                  </div>
+                  {isOpenedAdvancedView && (
+                    <ConversationViewSidePanelOutlet scope="advanced" />
+                  )}
                 </div>
-                {isOpenedAdvancedView && (
-                  <ConversationViewSidePanelOutlet scope="advanced" />
-                )}
-              </div>
-            </>
-          )}
-        </>
-      )}
-    </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </TableSettingsProvider>
   );
 };

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/AgGridColumnsPanel.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/AgGridColumnsPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DraggableList, InputWithIcon } from '@epam/statgpt-ui-components';
+import type { DraggableListItemNode } from '@epam/statgpt-ui-components';
 import { useAgGridColumnsPanel } from './useAgGridColumnsPanel';
 import { ColumnPanelFilter } from './types';
 import { useCallback, useMemo, useState } from 'react';
@@ -10,9 +11,11 @@ import { GridApi } from 'ag-grid-community';
 export function AgGridColumnsPanel({
   api,
   includeColumn,
+  enrichItem,
 }: {
   api: GridApi | null;
   includeColumn?: ColumnPanelFilter;
+  enrichItem?: (item: DraggableListItemNode) => DraggableListItemNode;
 }) {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const changeSearchHandler = useCallback(
@@ -46,6 +49,7 @@ export function AgGridColumnsPanel({
     api,
     includeColumn,
     searchQuery,
+    enrichItem,
   });
 
   return (

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers.ts
@@ -1,9 +1,25 @@
 import type { ColDef, GridApi } from 'ag-grid-community';
 import type {
+  DraggableListGroupNode,
   DraggableListItemNode,
   DraggableListNode,
 } from '@epam/statgpt-ui-components';
+import type {
+  DatasetDimensionsScheme,
+  DimensionConfig,
+  StructuralData,
+} from '@epam/statgpt-sdmx-toolkit';
+import {
+  getDimensionTitle,
+  getDimensions,
+  getLocalizedName,
+} from '@epam/statgpt-sdmx-toolkit';
 import type { AgGridInitialColumnsState, ColumnPanelFilter } from './types';
+import {
+  COUNTRY_COL_ID,
+  FREQUENCY_COL_ID,
+  INDICATOR_COL_ID,
+} from '../../../../constants/cross-dataset-grid';
 
 export const DEFAULT_INCLUDE_COLUMN: ColumnPanelFilter = ({ label, colDef }) =>
   Boolean(label.trim()) && !colDef.suppressColumnsToolPanel;
@@ -86,17 +102,25 @@ export function getItemNodeByPath(
   return current?.type === 'item' ? current : undefined;
 }
 
-export function flattenIncludedLeafIds(nodes: DraggableListNode[]): string[] {
+export function flattenIncludedLeafIds(
+  nodes: DraggableListNode[],
+  isLeaf?: (node: DraggableListItemNode) => boolean,
+): string[] {
   const result: string[] = [];
 
   for (const node of nodes) {
     if (node.type === 'group') {
-      result.push(...flattenIncludedLeafIds(node.items));
+      result.push(...flattenIncludedLeafIds(node.items, isLeaf));
+      continue;
+    }
+
+    if (isLeaf?.(node)) {
+      result.push(node.id);
       continue;
     }
 
     if (node.items?.length) {
-      result.push(...flattenIncludedLeafIds(node.items));
+      result.push(...flattenIncludedLeafIds(node.items, isLeaf));
       continue;
     }
 
@@ -104,6 +128,109 @@ export function flattenIncludedLeafIds(nodes: DraggableListNode[]): string[] {
   }
 
   return result;
+}
+
+export interface CrossDatasetColumnsInfo {
+  dataQueries: Array<{ urn: string }>;
+  structuresMap: Map<string, StructuralData | undefined>;
+  getDimensionsScheme: (urn: string) => DatasetDimensionsScheme | undefined;
+  getDimensionConfig: (
+    urn: string,
+    dimKey: string,
+  ) => DimensionConfig | undefined;
+  locale: string;
+}
+
+const AGGREGATED_COL_IDS = new Set([
+  INDICATOR_COL_ID,
+  COUNTRY_COL_ID,
+  FREQUENCY_COL_ID,
+]);
+
+function getDimKeysForColId(
+  colId: string,
+  urn: string,
+  getDimensionsScheme: (urn: string) => DatasetDimensionsScheme | undefined,
+): string[] {
+  const scheme = getDimensionsScheme(urn);
+
+  if (!scheme) return [];
+  if (colId === INDICATOR_COL_ID) return scheme.indicators;
+  if (colId === COUNTRY_COL_ID) return scheme.region ? [scheme.region] : [];
+  if (colId === FREQUENCY_COL_ID)
+    return scheme.frequency ? [scheme.frequency] : [];
+
+  return [];
+}
+
+function resolveDimLabel(
+  info: CrossDatasetColumnsInfo,
+  urn: string,
+  dimKey: string,
+): string {
+  const config = info.getDimensionConfig(urn, dimKey);
+  if (config?.alias) return config.alias;
+
+  const structures = info.structuresMap.get(urn);
+  const dimensions = structures
+    ? (getDimensions(structures)?.dimensions ?? [])
+    : [];
+  const dimension = dimensions.find((d) => d.id === dimKey);
+
+  return (
+    getDimensionTitle(
+      structures?.conceptSchemes ?? [],
+      dimension,
+      info.locale,
+    ) ?? dimKey
+  );
+}
+
+export function buildCrossDatasetEnrichItem(
+  info: CrossDatasetColumnsInfo,
+): (item: DraggableListItemNode) => DraggableListItemNode {
+  return (item: DraggableListItemNode) => {
+    if (!AGGREGATED_COL_IDS.has(item.id)) {
+      return item;
+    }
+
+    const groups: DraggableListGroupNode[] = [];
+
+    for (const { urn } of info.dataQueries) {
+      const dimKeys = getDimKeysForColId(
+        item.id,
+        urn,
+        info.getDimensionsScheme,
+      );
+      if (!dimKeys.length) continue;
+
+      const leafItems: DraggableListItemNode[] = dimKeys.map((dimKey) => ({
+        id: `${urn}::${dimKey}`,
+        type: 'item' as const,
+        label: resolveDimLabel(info, urn, dimKey),
+        isChecked: true,
+        draggable: false,
+        checkable: false,
+      }));
+
+      const structuralData = info.structuresMap.get(urn);
+      const groupLabel =
+        getLocalizedName(structuralData?.dataflows?.[0], info.locale) ?? urn;
+
+      groups.push({
+        id: urn,
+        type: 'group' as const,
+        label: groupLabel,
+        items: leafItems,
+      });
+    }
+
+    if (!groups.length) {
+      return item;
+    }
+
+    return { ...item, items: groups };
+  };
 }
 
 export function mergeIncludedOrderIntoFullOrder(

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/useAgGridColumnsPanel.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/useAgGridColumnsPanel.ts
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
   filterDraggableListNodes,
+  type DraggableListItemNode,
   type DraggableListNode,
   type ItemClickEvent,
   type ToggleCheckedEvent,
@@ -23,12 +24,15 @@ export function useAgGridColumnsPanel({
   api,
   searchQuery,
   includeColumn = DEFAULT_INCLUDE_COLUMN,
+  enrichItem,
 }: {
   api: GridApi | null;
   searchQuery: string;
   includeColumn?: ColumnPanelFilter;
+  enrichItem?: (item: DraggableListItemNode) => DraggableListItemNode;
 }) {
   const [gridStateVersion, setGridStateVersion] = useState(0);
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
 
   const syncFromGrid = useCallback(() => {
     setGridStateVersion((value) => value + 1);
@@ -36,13 +40,31 @@ export function useAgGridColumnsPanel({
 
   useAgGridColumnGridListeners(api, syncFromGrid);
 
-  const items = useMemo(() => {
-    if (!api) {
+  const rawItems = useMemo(() => {
+    if (!api || !api.getColumnState()) {
       return [];
     }
 
     return mapColumnsToPanelItems(api, includeColumn);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, includeColumn, gridStateVersion]);
+
+  const items = useMemo(() => {
+    const base = enrichItem
+      ? rawItems.map((node) => (node.type === 'item' ? enrichItem(node) : node))
+      : rawItems;
+
+    return base.map((node) =>
+      node.type === 'item' && node.items?.length
+        ? { ...node, isExpanded: !collapsedIds.has(node.id) }
+        : node,
+    );
+  }, [rawItems, enrichItem, collapsedIds]);
+
+  const knownColumnIds = useMemo(
+    () => new Set(rawItems.map((i) => i.id)),
+    [rawItems],
+  );
 
   const visibleItems = useMemo(() => {
     return filterDraggableListNodes(items, searchQuery);
@@ -56,7 +78,7 @@ export function useAgGridColumnsPanel({
 
       const node = getItemNodeByPath(items, e.path);
 
-      if (!node) {
+      if (!node || !knownColumnIds.has(node.id)) {
         return;
       }
 
@@ -66,7 +88,7 @@ export function useAgGridColumnsPanel({
 
       syncFromGrid();
     },
-    [api, items, syncFromGrid],
+    [api, items, knownColumnIds, syncFromGrid],
   );
 
   const handleItemClick = useCallback(
@@ -77,7 +99,7 @@ export function useAgGridColumnsPanel({
 
       const node = getItemNodeByPath(items, e.path);
 
-      if (!node) {
+      if (!node || !knownColumnIds.has(node.id)) {
         return;
       }
 
@@ -93,11 +115,21 @@ export function useAgGridColumnsPanel({
 
       syncFromGrid();
     },
-    [api, items, syncFromGrid],
+    [api, items, knownColumnIds, syncFromGrid],
   );
 
-  const handleToggleExpanded = useCallback((_e: ToggleExpandedEvent) => {
-    // Reserved for future grouped columns support.
+  const handleToggleExpanded = useCallback((e: ToggleExpandedEvent) => {
+    const nodeId = e.path[e.path.length - 1];
+
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (e.nextExpanded) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
   }, []);
 
   const handleItemsChange = useCallback(
@@ -107,8 +139,10 @@ export function useAgGridColumnsPanel({
       }
 
       const fullCurrentOrder = api.getColumnState().map((state) => state.colId);
-      const includedCurrentIds = new Set(items.map((item) => item.id));
-      const nextIncludedOrder = flattenIncludedLeafIds(next);
+      const includedCurrentIds = new Set(rawItems.map((item) => item.id));
+      const nextIncludedOrder = flattenIncludedLeafIds(next, (node) =>
+        knownColumnIds.has(node.id),
+      );
 
       const mergedOrder = mergeIncludedOrderIntoFullOrder(
         fullCurrentOrder,
@@ -123,7 +157,7 @@ export function useAgGridColumnsPanel({
 
       syncFromGrid();
     },
-    [api, items, syncFromGrid],
+    [api, rawItems, knownColumnIds, syncFromGrid],
   );
 
   return {

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsContext.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, ReactNode, useContext, useMemo } from 'react';
 import type { GridApi } from 'ag-grid-community';
+import type { StructuralData } from '@epam/statgpt-sdmx-toolkit';
 import type { AgGridInitialColumnsState } from './AgGridColumnPanel/types';
 import { useAgGridColumnPreferences } from './AgGridColumnPanel/useAgGridColumnPreferences';
 
@@ -9,6 +10,9 @@ type TableSettingsContextValue = {
   gridApi?: GridApi;
   onGridApiReady: (api: GridApi) => void;
   initialColumnsState: AgGridInitialColumnsState | null;
+  structuresMap?: Map<string, StructuralData | undefined>;
+  locale?: string;
+  dataQueries?: Array<{ urn: string }>;
 };
 
 const TableSettingsContext = createContext<TableSettingsContextValue | null>(
@@ -17,17 +21,37 @@ const TableSettingsContext = createContext<TableSettingsContextValue | null>(
 
 export function TableSettingsProvider({
   currentUrn,
+  structuresMap,
+  locale,
+  dataQueries,
   children,
 }: {
   currentUrn: string;
+  structuresMap?: Map<string, StructuralData | undefined>;
+  locale?: string;
+  dataQueries?: Array<{ urn: string }>;
   children: ReactNode;
 }) {
   const { gridApi, onGridApiReady, initialColumnsState } =
     useAgGridColumnPreferences({ currentUrn });
 
   const value = useMemo<TableSettingsContextValue>(
-    () => ({ gridApi, onGridApiReady, initialColumnsState }),
-    [gridApi, initialColumnsState, onGridApiReady],
+    () => ({
+      gridApi,
+      onGridApiReady,
+      initialColumnsState,
+      structuresMap,
+      locale,
+      dataQueries,
+    }),
+    [
+      gridApi,
+      initialColumnsState,
+      onGridApiReady,
+      structuresMap,
+      locale,
+      dataQueries,
+    ],
   );
 
   return (

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsPanel.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsPanel.tsx
@@ -1,8 +1,12 @@
 import { IconRotate } from '@tabler/icons-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { AgGridColumnsPanel } from './AgGridColumnPanel/AgGridColumnsPanel';
-import { restoreInitialColumnsState } from './AgGridColumnPanel/helpers';
+import {
+  buildCrossDatasetEnrichItem,
+  restoreInitialColumnsState,
+} from './AgGridColumnPanel/helpers';
 import { useTableSettingsContext } from './TableSettingsContext';
+import { useDatasetDimensionsMetadataMapOptional } from '../../../context/DatasetDimensionsMetadataMapContext';
 
 export const TABLE_SETTINGS_SIDE_PANEL_ID = 'table-settings-side-panel';
 
@@ -36,7 +40,25 @@ export const TableSettingsPanelHeaderExtension = ({
 };
 
 export const TableSettingsPanel = () => {
-  const { gridApi } = useTableSettingsContext();
+  const { gridApi, structuresMap, locale, dataQueries } =
+    useTableSettingsContext();
+  const dimensionsCtx = useDatasetDimensionsMetadataMapOptional();
 
-  return gridApi ? <AgGridColumnsPanel api={gridApi} /> : null;
+  const enrichItem = useMemo(() => {
+    if (!dimensionsCtx || !structuresMap || !locale || !dataQueries?.length) {
+      return undefined;
+    }
+
+    return buildCrossDatasetEnrichItem({
+      dataQueries,
+      structuresMap,
+      getDimensionsScheme: dimensionsCtx.getDimensionsScheme,
+      getDimensionConfig: (urn, dimKey) => dimensionsCtx.map[urn]?.[dimKey],
+      locale,
+    });
+  }, [dimensionsCtx, structuresMap, locale, dataQueries]);
+
+  return gridApi ? (
+    <AgGridColumnsPanel api={gridApi} enrichItem={enrichItem} />
+  ) : null;
 };

--- a/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
@@ -159,7 +159,8 @@ const AttachmentRenderer: FC<Props> = ({
     if (
       isTableSettingsOpen &&
       selectedAttachment &&
-      !isCustomGridAttachment(selectedAttachment)
+      !isCustomGridAttachment(selectedAttachment) &&
+      !isCrossDatasetGrid(selectedAttachment)
     ) {
       onTableSettingsClose?.();
     }

--- a/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
@@ -84,6 +84,7 @@ const AttachmentsContentRenderer: FC<Props> = ({
           isChartColumnVisible={isOpenedAdvancedView}
           fixHeight={!isOpenedAdvancedView}
           showLimitMessage={showLimitMessage}
+          onApiReady={onGridApiReady}
         />
       )}
       {isCustomChartAttachment(selectedAttachment) && (

--- a/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
@@ -59,7 +59,11 @@ const AttachmentsViewModePanel: FC<Props> = ({
     isTableSettingsFeatureEnabled &&
     !showAdvancedView &&
     !!onTableSettingsOpen &&
-    !!(selectedAttachment && isCustomGridAttachment(selectedAttachment));
+    !!(
+      selectedAttachment &&
+      (isCustomGridAttachment(selectedAttachment) ||
+        isCrossDatasetGrid(selectedAttachment))
+    );
 
   return (
     <div className="flex min-w-0 w-full justify-between itms-center">

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { CrossDatasetGridAttachmentType } from '../../../models/attachments';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Loader, SERIES_LIMIT } from '@epam/statgpt-ui-components';
-import type { ColDef } from 'ag-grid-community';
+import type { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { GridData } from '../../../types/data-grid/grid-data';
 import { getGridHeight } from '../../../utils/attachments/data-grid/grid-height';
@@ -26,6 +26,7 @@ interface Props {
   isChartColumnVisible?: boolean;
   fixHeight?: boolean;
   showLimitMessage?: (p: boolean) => void;
+  onApiReady?: (api: GridApi) => void;
 }
 
 const CrossDatasetGridAttachment: FC<Props> = ({
@@ -34,6 +35,7 @@ const CrossDatasetGridAttachment: FC<Props> = ({
   isChartColumnVisible,
   fixHeight,
   showLimitMessage,
+  onApiReady,
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [rowData, setRowData] = useState<GridData[]>([]);
@@ -65,6 +67,13 @@ const CrossDatasetGridAttachment: FC<Props> = ({
     }
   }, [rowData, showLimitMessage]);
 
+  const handleGridReady = useCallback(
+    (event: GridReadyEvent) => {
+      onApiReady?.(event.api);
+    },
+    [onApiReady],
+  );
+
   //TODO: replace cell renderers
   const memoizedGrid = useMemo(
     () => (
@@ -82,9 +91,10 @@ const CrossDatasetGridAttachment: FC<Props> = ({
           [OBSERVATION_VALUE_CELL_RENDER]: ObservationValueCellRenderer,
           [CHART_CELL_RENDER]: ChartCellRenderer,
         }}
+        onGridReady={handleGridReady}
       />
     ),
-    [rowData, columnDefs],
+    [rowData, columnDefs, handleGridReady],
   );
 
   if (isLoading || isDataLoading) {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #148 

### Description of changes

The branch wires the Table Settings (Columns) panel to work in cross-dataset mode. TableSettingsProvider now receives structuresMap, locale, and dataQueries so the column panel can expand aggregated columns (Indicator, Country, Frequency) into per-dataset labeled groups. The cross-dataset grid's GridApi is now registered in the context via a new onApiReady prop, and the Columns button is shown/hidden correctly for cross-dataset grids.

<img width="1246" height="908" alt="image" src="https://github.com/user-attachments/assets/c8dc9005-8222-4781-81ed-3a81412ebf2f" />

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
