### PR TITLE
fix: hide filter title for a single dataset

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetsList.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetsList.tsx
@@ -104,7 +104,11 @@ const FiltersFacetsList: FC<Props> = ({
             initialConstraintsMap,
           )}
           datasetIcon={datasetIcon}
-          datasetName={getDatasetNameFromFilters(filter, structuresMap)}
+          datasetName={
+            (structuresMap?.size ?? 0) > 1
+              ? getDatasetNameFromFilters(filter, structuresMap)
+              : undefined
+          }
         />
       ))}
     </div>


### PR DESCRIPTION
### Applicable issues

[[AI chat][Cross-dataset query] Items in filter in single dataset is displayed like in Multiply](https://github.com/epam/statgpt-global-trusted-data-commons/issues/157)

### Description of changes

Add a condition to hide dataset title in the FiltersFacetList in case there is a single dataset. 

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
