### PR TITLE
fix: regex fixes

### DIFF
--- a/libs/sdmx-toolkit/src/utils/__tests__/wildcards.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/wildcards.spec.ts
@@ -2,7 +2,7 @@ import type { CommonArtefactProperty } from '../../models/structural-metadata/co
 import {
   getArtifactByUrnWithWildCard,
   getResolvedVersionBySingleWildcard,
-  getWildCardRegexp,
+  getWildCardPrefix,
   isWildCardVersionCorrect,
 } from '../wildcards';
 
@@ -17,29 +17,24 @@ const artifact = (
 ): CommonArtefactProperty => ({ agencyID, id, version, name: id });
 
 // ---------------------------------------------------------------------------
-// getWildCardRegexp
+// getWildCardPrefix
 // ---------------------------------------------------------------------------
 
-describe('getWildCardRegexp', () => {
-  it('creates a regex matching the prefix before the wildcard segment (dot is unescaped)', () => {
-    const reg = getWildCardRegexp('1.2+');
-    expect(reg).toEqual(/^1./);
+describe('getWildCardPrefix', () => {
+  it('extracts the prefix before the wildcard segment', () => {
+    expect(getWildCardPrefix('1.2+')).toBe('1.');
   });
 
-  it('matches versions that share the prefix', () => {
-    const reg = getWildCardRegexp('1.2+');
-    expect(reg.test('1.5')).toBe(true);
-    expect(reg.test('1.2')).toBe(true);
-  });
-
-  it('does not match versions with a different prefix', () => {
-    const reg = getWildCardRegexp('1.2+');
-    expect(reg.test('2.0')).toBe(false);
+  it('returns an empty string when the wildcard starts with digits', () => {
+    expect(getWildCardPrefix('2+')).toBe('');
   });
 
   it('handles a wildcard with leading/trailing whitespace', () => {
-    const reg = getWildCardRegexp('  1.2+  ');
-    expect(reg.test('1.3')).toBe(true);
+    expect(getWildCardPrefix('  1.2+  ')).toBe('1.');
+  });
+
+  it('extracts a multi-segment prefix', () => {
+    expect(getWildCardPrefix('1.2.3+')).toBe('1.2.');
   });
 });
 

--- a/libs/sdmx-toolkit/src/utils/__tests__/wildcards.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/wildcards.spec.ts
@@ -1,0 +1,151 @@
+import type { CommonArtefactProperty } from '../../models/structural-metadata/common-artefact-properties';
+import {
+  getArtifactByUrnWithWildCard,
+  getResolvedVersionBySingleWildcard,
+  getWildCardRegexp,
+  isWildCardVersionCorrect,
+} from '../wildcards';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const artifact = (
+  agencyID: string,
+  id: string,
+  version: string,
+): CommonArtefactProperty => ({ agencyID, id, version, name: id });
+
+// ---------------------------------------------------------------------------
+// getWildCardRegexp
+// ---------------------------------------------------------------------------
+
+describe('getWildCardRegexp', () => {
+  it('creates a regex matching the prefix before the wildcard segment (dot is unescaped)', () => {
+    const reg = getWildCardRegexp('1.2+');
+    expect(reg).toEqual(/^1./);
+  });
+
+  it('matches versions that share the prefix', () => {
+    const reg = getWildCardRegexp('1.2+');
+    expect(reg.test('1.5')).toBe(true);
+    expect(reg.test('1.2')).toBe(true);
+  });
+
+  it('does not match versions with a different prefix', () => {
+    const reg = getWildCardRegexp('1.2+');
+    expect(reg.test('2.0')).toBe(false);
+  });
+
+  it('handles a wildcard with leading/trailing whitespace', () => {
+    const reg = getWildCardRegexp('  1.2+  ');
+    expect(reg.test('1.3')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWildCardVersionCorrect
+// ---------------------------------------------------------------------------
+
+describe('isWildCardVersionCorrect', () => {
+  it('returns true for a version that matches prefix and is >=', () => {
+    expect(isWildCardVersionCorrect('1.2+', '1.3')).toBe(true);
+  });
+
+  it('returns true for the exact base version', () => {
+    expect(isWildCardVersionCorrect('1.2+', '1.2')).toBe(true);
+  });
+
+  it('returns false for a version below the wildcard base', () => {
+    expect(isWildCardVersionCorrect('1.2+', '1.1')).toBe(false);
+  });
+
+  it('returns false for a version with a different prefix', () => {
+    expect(isWildCardVersionCorrect('1.2+', '2.0')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getResolvedVersionBySingleWildcard
+// ---------------------------------------------------------------------------
+
+describe('getResolvedVersionBySingleWildcard', () => {
+  it('returns the first matching version', () => {
+    const result = getResolvedVersionBySingleWildcard('1.0+', [
+      '1.0',
+      '1.1',
+      '1.2',
+    ]);
+    expect(result).toEqual(['1.0']);
+  });
+
+  it('returns an empty array when no versions match', () => {
+    const result = getResolvedVersionBySingleWildcard('2.0+', ['1.0', '1.1']);
+    expect(result).toEqual([]);
+  });
+
+  it('ignores versions below the wildcard base', () => {
+    const result = getResolvedVersionBySingleWildcard('1.5+', [
+      '1.3',
+      '1.4',
+      '1.6',
+    ]);
+    expect(result).toEqual(['1.6']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getArtifactByUrnWithWildCard
+// ---------------------------------------------------------------------------
+
+describe('getArtifactByUrnWithWildCard', () => {
+  const artifacts: CommonArtefactProperty[] = [
+    artifact('SDMX', 'CL_FREQ', '1.0'),
+    artifact('SDMX', 'CL_FREQ', '2.0'),
+    artifact('SDMX', 'CL_UNIT', '1.0'),
+  ];
+
+  it('returns the artifact matching exact version when no wildcard', () => {
+    const result = getArtifactByUrnWithWildCard(
+      'urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_FREQ(2.0)',
+      artifacts,
+    );
+    expect(result).toEqual(artifact('SDMX', 'CL_FREQ', '2.0'));
+  });
+
+  it('returns the single match when only one artifact has the same agency and id', () => {
+    const result = getArtifactByUrnWithWildCard(
+      'urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_UNIT(1.0)',
+      artifacts,
+    );
+    expect(result).toEqual(artifact('SDMX', 'CL_UNIT', '1.0'));
+  });
+
+  it('resolves a wildcard version to the first matching artifact', () => {
+    const result = getArtifactByUrnWithWildCard(
+      'urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_FREQ(1.0+)',
+      artifacts,
+    );
+    expect(result).toEqual(artifact('SDMX', 'CL_FREQ', '1.0'));
+  });
+
+  it('returns undefined when no artifacts match the agency and id', () => {
+    const result = getArtifactByUrnWithWildCard(
+      'urn:sdmx:org.sdmx.infomodel.codelist.Codelist=OTHER:CL_FREQ(1.0)',
+      artifacts,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('excludes artifacts whose version contains a wildcard symbol', () => {
+    const withWildcard: CommonArtefactProperty[] = [
+      artifact('SDMX', 'CL_FREQ', '1.0+'),
+      artifact('SDMX', 'CL_FREQ', '1.0'),
+    ];
+    const result = getArtifactByUrnWithWildCard(
+      'urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_FREQ(1.0)',
+      withWildcard,
+    );
+    expect(result).toEqual(artifact('SDMX', 'CL_FREQ', '1.0'));
+  });
+});

--- a/libs/sdmx-toolkit/src/utils/wildcards.ts
+++ b/libs/sdmx-toolkit/src/utils/wildcards.ts
@@ -61,9 +61,20 @@ const getResolvedVersionByWildcards = (
 
 export const getWildCardPrefix = (wildcard: string): string => {
   const trimmed = wildcard.trim();
-  const idx = trimmed.search(/\d+\+/);
+  const plusIdx = trimmed.indexOf('+');
 
-  return idx > 0 ? trimmed.slice(0, idx) : '';
+  if (plusIdx <= 0) return '';
+
+  let digitStart = plusIdx;
+  while (
+    digitStart > 0 &&
+    trimmed[digitStart - 1] >= '0' &&
+    trimmed[digitStart - 1] <= '9'
+  ) {
+    digitStart--;
+  }
+
+  return digitStart > 0 ? trimmed.slice(0, digitStart) : '';
 };
 
 export const isWildCardVersionCorrect = (

--- a/libs/sdmx-toolkit/src/utils/wildcards.ts
+++ b/libs/sdmx-toolkit/src/utils/wildcards.ts
@@ -59,11 +59,11 @@ const getResolvedVersionByWildcards = (
   return resolved;
 };
 
-export const getWildCardRegexp = (wildcard: string): RegExp => {
-  const regStr = wildcard.trim().replace(/\d+\+/, '*');
-  const [start] = regStr.split('*');
+export const getWildCardPrefix = (wildcard: string): string => {
+  const trimmed = wildcard.trim();
+  const idx = trimmed.search(/\d+\+/);
 
-  return new RegExp(`^${start}`);
+  return idx > 0 ? trimmed.slice(0, idx) : '';
 };
 
 export const isWildCardVersionCorrect = (
@@ -71,7 +71,7 @@ export const isWildCardVersionCorrect = (
   version: string,
 ): boolean => {
   const ver = wildcard.trim().replace(/\+/, '');
-  const reg = getWildCardRegexp(wildcard);
+  const prefix = getWildCardPrefix(wildcard);
 
-  return reg.test(version) && compare(version, ver, '>=');
+  return version.startsWith(prefix) && compare(version, ver, '>=');
 };

--- a/libs/shared-toolkit/src/utils/__tests__/conversation-name.spec.ts
+++ b/libs/shared-toolkit/src/utils/__tests__/conversation-name.spec.ts
@@ -1,0 +1,84 @@
+import {
+  deleteConversationNamePostfix,
+  getClearedConversationName,
+} from '../conversation-name';
+
+// ---------------------------------------------------------------------------
+// deleteConversationNamePostfix
+// ---------------------------------------------------------------------------
+
+describe('deleteConversationNamePostfix', () => {
+  it('removes a numeric postfix preceded by a hyphen', () => {
+    expect(deleteConversationNamePostfix('my-conversation-42')).toBe(
+      'my-conversation',
+    );
+  });
+
+  it('removes only the last numeric postfix', () => {
+    expect(deleteConversationNamePostfix('chat-1-2')).toBe('chat-1');
+  });
+
+  it('returns the full name when there is no numeric postfix', () => {
+    expect(deleteConversationNamePostfix('hello-world')).toBe('hello-world');
+  });
+
+  it('returns an empty string for undefined input', () => {
+    expect(deleteConversationNamePostfix(undefined)).toBe('');
+  });
+
+  it('returns the name unchanged when it ends with non-numeric characters after hyphen', () => {
+    expect(deleteConversationNamePostfix('report-abc')).toBe('report-abc');
+  });
+
+  it('handles a name that is only a numeric postfix pattern', () => {
+    expect(deleteConversationNamePostfix('-123')).toBe('');
+  });
+
+  it('returns an empty string for an empty string input', () => {
+    expect(deleteConversationNamePostfix('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getClearedConversationName
+// ---------------------------------------------------------------------------
+
+describe('getClearedConversationName', () => {
+  it('lowercases and normalises whitespace to single spaces', () => {
+    expect(getClearedConversationName('Hello  World')).toBe('hello world');
+  });
+
+  it('strips leading and trailing non-alphanumeric characters', () => {
+    expect(getClearedConversationName('--Hello--')).toBe('hello');
+  });
+
+  it('replaces punctuation and symbols with spaces', () => {
+    expect(getClearedConversationName('foo@bar!baz')).toBe('foo bar baz');
+  });
+
+  it('preserves unicode letters and digits', () => {
+    expect(getClearedConversationName('Ünïcödé 123')).toBe('ünïcödé 123');
+  });
+
+  it('returns an empty string for undefined input', () => {
+    expect(getClearedConversationName(undefined)).toBe('');
+  });
+
+  it('returns an empty string for an empty string input', () => {
+    expect(getClearedConversationName('')).toBe('');
+  });
+
+  it('returns an empty string when input contains only symbols', () => {
+    expect(getClearedConversationName('!@#$%^&*()')).toBe('');
+  });
+
+  it('collapses multiple consecutive separators into a single space', () => {
+    expect(getClearedConversationName('a---b___c')).toBe('a b c');
+  });
+
+  it('handles a realistic conversation name', () => {
+    expect(
+      getClearedConversationName('  GDP Growth (2024) — Analysis!  '),
+    ).toBe('gdp growth 2024 analysis');
+  });
+});

--- a/libs/shared-toolkit/src/utils/conversation-name.ts
+++ b/libs/shared-toolkit/src/utils/conversation-name.ts
@@ -9,7 +9,8 @@ export const getClearedConversationName = (
     conversationName
       ?.toLowerCase()
       .replace(/[^\p{L}\p{N}]+/gu, '-')
-      .replace(/^-+|-+$/g, '')
+      .replace(/^-+/, '')
+      .replace(/-+$/, '')
       .replace(/-/g, ' ') || ''
   );
 };

--- a/libs/shared-toolkit/src/utils/conversation-name.ts
+++ b/libs/shared-toolkit/src/utils/conversation-name.ts
@@ -2,15 +2,30 @@ export const deleteConversationNamePostfix = (
   conversationName?: string,
 ): string => conversationName?.split(/-\d+$/)[0] ?? '';
 
+const isLetterOrDigit = (char: string): boolean =>
+  /\p{L}/u.test(char) || /\p{N}/u.test(char);
+
 export const getClearedConversationName = (
   conversationName?: string,
 ): string => {
-  return (
-    conversationName
-      ?.toLowerCase()
-      .replace(/[^\p{L}\p{N}]+/gu, '-')
-      .replace(/^-+/, '')
-      .replace(/-+$/, '')
-      .replace(/-/g, ' ') || ''
-  );
+  if (!conversationName) return '';
+
+  const lower = conversationName.toLowerCase();
+  const words: string[] = [];
+  let word = '';
+
+  for (const char of lower) {
+    if (isLetterOrDigit(char)) {
+      word += char;
+    } else if (word) {
+      words.push(word);
+      word = '';
+    }
+  }
+
+  if (word) {
+    words.push(word);
+  }
+
+  return words.join(' ');
 };


### PR DESCRIPTION
…on name util

Replace `/^-+|-+$/g` with two separate replacements to eliminate alternation-based backtracking flagged by static analysis tools. Add unit tests for conversation-name utility functions.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
