### PR TITLE
fix: group filters by dataset

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetItem.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, ReactNode, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import ChevronSolidDownIcon from '../../../../../assets/icons/chevron-solid-down.svg';
 import { DataConstraints } from '@epam/statgpt-sdmx-toolkit';
@@ -34,8 +34,6 @@ interface Props {
   timeRangeOptions?: TimeRangeOptions[];
   titles?: ConversationViewTitles;
   initialConstraints?: DataConstraints[];
-  datasetIcon?: ReactNode;
-  datasetName?: string;
   onTimePeriodChange: (
     timeRange: TimeRange | null,
     selectedOption: string | number,
@@ -64,8 +62,6 @@ const FiltersFacetItem: FC<Props> = ({
   locale,
   titles,
   initialConstraints,
-  datasetIcon,
-  datasetName,
   hideFacetCounterByDefault,
   filterValuesProps,
   isDisableValues,
@@ -116,12 +112,6 @@ const FiltersFacetItem: FC<Props> = ({
 
   return (
     <div className="flex flex-col">
-      {datasetName && (
-        <h4 className="filters-facet-dataset-name">
-          <span className="filters-facet-dataset-icon">{datasetIcon}</span>
-          {datasetName}
-        </h4>
-      )}
       <div
         className={classNames(
           'flex justify-between items-center p-2 hover:bg-hues-100 py-2 sm:py-4 sm:hover:bg-white',

--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetsList.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetsList.tsx
@@ -73,44 +73,65 @@ const FiltersFacetsList: FC<Props> = ({
   expandHierarchicalValue,
 }) => {
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
+  const datasetCount = new Set(
+    filtersList
+      .filter((filter) => filter.filterType === 'dataset')
+      .map((filter) => filter.datasetUrn || ''),
+  ).size;
+
   return (
     <div
       className={classNames(
         'overflow-y-auto advanced-view-filters-list min-w-[320px] pr-3 h-full sm:w-full',
       )}
     >
-      {filtersList?.map((filter) => (
-        <FiltersFacetItem
-          filtersList={filtersList}
-          titles={titles}
-          locale={locale}
-          filter={filter}
-          key={getFilterIdentity(filter)}
-          onSelectFilter={onSelectFilter}
-          onSelectDisplayMode={onSelectDisplayMode}
-          onDeleteFilter={onDeleteFilter}
-          hideFacetCounterByDefault={hideFacetCounterByDefault}
-          isDisableValues={isDisableValues}
-          timeRangeOptions={timeRangeOptions}
-          selectFilterValue={selectFilterValue}
-          selectHierarchicalNodes={selectHierarchicalNodes}
-          expandHierarchicalValue={expandHierarchicalValue}
-          onTimePeriodChange={onTimePeriodChange}
-          filterValuesProps={filterValuesProps}
-          initialConstraints={getInitialConstraints(
-            isCrossDatasetModeOn,
-            filter,
-            initialConstraints,
-            initialConstraintsMap,
-          )}
-          datasetIcon={datasetIcon}
-          datasetName={
-            (structuresMap?.size ?? 0) > 1
-              ? getDatasetNameFromFilters(filter, structuresMap)
-              : undefined
-          }
-        />
-      ))}
+      {filtersList.map((filter, index) => {
+        const previousFilter = filtersList[index - 1];
+        const shouldRenderDatasetTitle =
+          filter.filterType === 'dataset' &&
+          datasetCount > 1 &&
+          filter.datasetUrn !== previousFilter?.datasetUrn;
+        const datasetName = shouldRenderDatasetTitle
+          ? getDatasetNameFromFilters(filter, structuresMap)
+          : undefined;
+
+        return (
+          <div key={getFilterIdentity(filter)}>
+            {datasetName && (
+              <h4 className="filters-facet-dataset-name">
+                <span className="filters-facet-dataset-icon">
+                  {datasetIcon}
+                </span>
+                {datasetName}
+              </h4>
+            )}
+
+            <FiltersFacetItem
+              filtersList={filtersList}
+              titles={titles}
+              locale={locale}
+              filter={filter}
+              onSelectFilter={onSelectFilter}
+              onSelectDisplayMode={onSelectDisplayMode}
+              onDeleteFilter={onDeleteFilter}
+              hideFacetCounterByDefault={hideFacetCounterByDefault}
+              isDisableValues={isDisableValues}
+              timeRangeOptions={timeRangeOptions}
+              selectFilterValue={selectFilterValue}
+              selectHierarchicalNodes={selectHierarchicalNodes}
+              expandHierarchicalValue={expandHierarchicalValue}
+              onTimePeriodChange={onTimePeriodChange}
+              filterValuesProps={filterValuesProps}
+              initialConstraints={getInitialConstraints(
+                isCrossDatasetModeOn,
+                filter,
+                initialConstraints,
+                initialConstraintsMap,
+              )}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
### Applicable issues

[[AI chat][Cross-dataset query] Items in filter in single dataset is displayed like in Multiply](https://github.com/epam/statgpt-global-trusted-data-commons/issues/157)

### Description of changes

- Grouping filters by dataset.
- Do not show dataset name in case there is only one dataset.

Multiple datasets vs single dataset:

<img width="347" height="435" alt="multiple_datasets" src="https://github.com/user-attachments/assets/23cb0154-8ba0-423d-a2ce-2c63fb4e6599" />
<img width="346" height="330" alt="one_dataset" src="https://github.com/user-attachments/assets/032281a8-722c-4add-95e6-f6693c2e877f" />

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
