### PR TITLE
fix: show shared filters first in the AttachmentDetails

### DIFF
--- a/libs/conversation-view/src/components/Attachments/AttachmentDetails/AttachmentDetails.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentDetails/AttachmentDetails.tsx
@@ -1,7 +1,10 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 import classNames from 'classnames';
 import AttachmentDetailsItem from './AttachmentDetailsItem';
 import { AttachmentInfo } from '../../../models/attachments';
+import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
+import { SHARED_FILTER_IDS } from '../../../utils/multiple-filters';
+import { QueryFilterDetails } from '@epam/statgpt-shared-toolkit';
 
 interface Props {
   titles: {
@@ -17,29 +20,103 @@ const AttachmentDetails: FC<Props> = ({
   attachmentInfoList,
   datasetIcon,
 }) => {
+  const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
+
+  const { sharedFilterDetails, perDatasetInfoList } = useMemo(() => {
+    if (!isCrossDatasetModeOn) {
+      return {
+        sharedFilterDetails: [] as QueryFilterDetails[],
+        perDatasetInfoList: [] as AttachmentInfo[],
+      };
+    }
+
+    const sharedFiltersMap = new Map<string, QueryFilterDetails>();
+    const perDatasetInfoList: AttachmentInfo[] = [];
+
+    attachmentInfoList?.forEach((info) => {
+      const datasetOnlyFilters: QueryFilterDetails[] = [];
+
+      info.queryFiltersDetails?.forEach((detail) => {
+        if (SHARED_FILTER_IDS.has(detail.id)) {
+          const existing = sharedFiltersMap.get(detail.id);
+          if (existing) {
+            sharedFiltersMap.set(detail.id, {
+              ...existing,
+              valuesTitles: Array.from(
+                new Set([
+                  ...(existing.valuesTitles || []),
+                  ...(detail.valuesTitles || []),
+                ]),
+              ),
+            });
+          } else {
+            sharedFiltersMap.set(detail.id, { ...detail });
+          }
+        } else {
+          datasetOnlyFilters.push(detail);
+        }
+      });
+
+      if (datasetOnlyFilters.length) {
+        perDatasetInfoList.push({
+          ...info,
+          queryFiltersDetails: datasetOnlyFilters,
+        });
+      }
+    });
+
+    return {
+      sharedFilterDetails: Array.from(sharedFiltersMap.values()),
+      perDatasetInfoList,
+    };
+  }, [isCrossDatasetModeOn, attachmentInfoList]);
+
   return (
     <div className="attachment-details flex flex-col">
       <p
         className={classNames(
           'body-1',
-          attachmentInfoList && attachmentInfoList.length <= 1 && 'mb-2',
+          ((attachmentInfoList && attachmentInfoList.length <= 1) ||
+            (isCrossDatasetModeOn && sharedFilterDetails.length > 0)) &&
+            'mb-2',
         )}
       >
         {titles?.queryUpdatedManuallyTitle ??
           'Query has been updated manually.'}
       </p>
-      {attachmentInfoList?.map(
-        (attachmentInfo) =>
-          !!attachmentInfo?.queryFiltersDetails?.length && (
+      {isCrossDatasetModeOn ? (
+        <>
+          {sharedFilterDetails.length > 0 && (
             <AttachmentDetailsItem
-              key={attachmentInfo?.datasetName}
               setToTitle={titles?.setToTitle}
-              datasetName={attachmentInfo?.datasetName}
-              datasetIcon={datasetIcon}
-              isShowDatasetDetails={attachmentInfoList?.length > 1}
-              queryFilterDetails={attachmentInfo?.queryFiltersDetails}
+              queryFilterDetails={sharedFilterDetails}
             />
-          ),
+          )}
+          {perDatasetInfoList.map((info) => (
+            <AttachmentDetailsItem
+              key={info.datasetName}
+              setToTitle={titles?.setToTitle}
+              datasetName={info.datasetName}
+              datasetIcon={datasetIcon}
+              isShowDatasetDetails
+              queryFilterDetails={info.queryFiltersDetails}
+            />
+          ))}
+        </>
+      ) : (
+        attachmentInfoList?.map(
+          (attachmentInfo) =>
+            !!attachmentInfo?.queryFiltersDetails?.length && (
+              <AttachmentDetailsItem
+                key={attachmentInfo?.datasetName}
+                setToTitle={titles?.setToTitle}
+                datasetName={attachmentInfo?.datasetName}
+                datasetIcon={datasetIcon}
+                isShowDatasetDetails={attachmentInfoList?.length > 1}
+                queryFilterDetails={attachmentInfo?.queryFiltersDetails}
+              />
+            ),
+        )
       )}
     </div>
   );

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -43,6 +43,12 @@ export const COMMON_COUNTRY_FILTER_ID = 'COUNTRY';
 export const COMMON_FREQUENCY_FILTER_ID = 'FREQUENCY';
 export const COMMON_TIME_PERIOD_FILTER_ID = 'TIME_PERIOD';
 
+export const SHARED_FILTER_IDS = new Set([
+  COMMON_COUNTRY_FILTER_ID,
+  COMMON_FREQUENCY_FILTER_ID,
+  COMMON_TIME_PERIOD_FILTER_ID,
+]);
+
 const buildSharedFilterNameMatcher =
   (): SharedFilterConfig['getMergedValueKey'] => (value, datasetUrn) => {
     const normalizedName = value?.name?.trim()?.toLocaleLowerCase();


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

- Show applied shared filters first in AttachmentDetails, then display the remaining applied filters grouped by dataset.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
