### PR TITLE
fix: workaround for specific case for datasets without time period constraints

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/TimePeriodFacet.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/TimePeriodFacet.tsx
@@ -14,6 +14,7 @@ import { Calendar, Radio } from '@epam/statgpt-ui-components';
 import { FC, ReactNode, useEffect, useMemo, useState } from 'react';
 import {
   correctTimeZone,
+  getMergedInitialConstraints,
   getPickerOptions,
   getRangedTimePeriod,
 } from '../../../../../utils/attachments/time-period';
@@ -51,8 +52,10 @@ const TimePeriodFacet: FC<Props> = ({
   titles,
   defaultTimeOption,
 }) => {
-  const initialTimeRange = getAnnotationPeriod(
-    initialConstraints?.[0]?.annotations,
+  // workaround for specific case for datasets without time perion constraints
+  const initialTimeRange = getMergedInitialConstraints(
+    getAnnotationPeriod(initialConstraints?.[0]?.annotations),
+    timeRange,
   );
   const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange | null>(
     timeRange,

--- a/libs/conversation-view/src/utils/attachments/time-period.ts
+++ b/libs/conversation-view/src/utils/attachments/time-period.ts
@@ -186,16 +186,18 @@ export const getMergedInitialConstraints = (
     (selectedTimeRange?.startPeriod &&
       initialTimeRange?.startPeriod &&
       selectedTimeRange.startPeriod < initialTimeRange?.startPeriod)
-  )
+  ) {
     mergedTimeRange.startPeriod = selectedTimeRange?.startPeriod || null;
+  }
 
   if (
     (!initialTimeRange.endPeriod && selectedTimeRange?.endPeriod) ||
     (selectedTimeRange?.endPeriod &&
       initialTimeRange?.endPeriod &&
       selectedTimeRange.endPeriod > initialTimeRange?.endPeriod)
-  )
+  ) {
     mergedTimeRange.endPeriod = selectedTimeRange?.endPeriod || null;
+  }
 
   return mergedTimeRange;
 };

--- a/libs/conversation-view/src/utils/attachments/time-period.ts
+++ b/libs/conversation-view/src/utils/attachments/time-period.ts
@@ -174,3 +174,28 @@ export const localizeTimePeriod = (
 
   return period;
 };
+
+// workaround for specific case for datasets without time perion constraints
+export const getMergedInitialConstraints = (
+  initialTimeRange: TimeRange,
+  selectedTimeRange: TimeRange | null,
+): TimeRange => {
+  const mergedTimeRange = { ...initialTimeRange };
+  if (
+    (!initialTimeRange.startPeriod && selectedTimeRange?.startPeriod) ||
+    (selectedTimeRange?.startPeriod &&
+      initialTimeRange?.startPeriod &&
+      selectedTimeRange.startPeriod < initialTimeRange?.startPeriod)
+  )
+    mergedTimeRange.startPeriod = selectedTimeRange?.startPeriod || null;
+
+  if (
+    (!initialTimeRange.endPeriod && selectedTimeRange?.endPeriod) ||
+    (selectedTimeRange?.endPeriod &&
+      initialTimeRange?.endPeriod &&
+      selectedTimeRange.endPeriod > initialTimeRange?.endPeriod)
+  )
+    mergedTimeRange.endPeriod = selectedTimeRange?.endPeriod || null;
+
+  return mergedTimeRange;
+};


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes [#175 ](https://github.com/epam/statgpt-global-trusted-data-commons/issues/175)

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
