### PR TITLE
fix: dataset download

### DIFF
--- a/libs/sdmx-toolkit/src/utils/get-file-headers.ts
+++ b/libs/sdmx-toolkit/src/utils/get-file-headers.ts
@@ -11,12 +11,9 @@ export const getRequestAcceptHeader = (
         attribute,
       );
     case SdmxDataFormat.XML:
-      return getFileAcceptHeader(
-        'application/vnd.sdmx.data+xml;version=3.0.0',
-        attribute,
-      );
+      return 'application/vnd.sdmx.data+xml;version=3.0.0';
     case SdmxDataFormat.JSON:
-      return getFileAcceptHeader(`application/${format}`, attribute);
+      return `application/${format}`;
     default:
       return getFileAcceptHeader(
         'application/vnd.sdmx.data+csv;version=2.0.0',


### PR DESCRIPTION
### Applicable issues

[Issue with download dataset](https://github.com/epam/statgpt-global-trusted-data-commons/issues/180)

### Description of changes

Do not send the label parameter for JSON/XML formats, because the API now returns an error if this parameter is present.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
