### PR TITLE
fix: download dataset

### DIFF
--- a/libs/sdmx-toolkit/src/api/dataset-api.ts
+++ b/libs/sdmx-toolkit/src/api/dataset-api.ts
@@ -65,7 +65,6 @@ export class DatasetApi {
     token?: string,
   ) {
     const queryParams = new URLSearchParams({
-      format: dataFormat,
       compress: 'false',
       attributes: isMetadata ? 'all' : 'none',
       limit: '1000',

--- a/libs/sdmx-toolkit/src/utils/get-file-headers.ts
+++ b/libs/sdmx-toolkit/src/utils/get-file-headers.ts
@@ -13,7 +13,7 @@ export const getRequestAcceptHeader = (
     case SdmxDataFormat.XML:
       return 'application/vnd.sdmx.data+xml;version=3.0.0';
     case SdmxDataFormat.JSON:
-      return `application/${format}`;
+      return 'application/vnd.sdmx.data+json;version=2.1';
     default:
       return getFileAcceptHeader(
         'application/vnd.sdmx.data+csv;version=2.0.0',

--- a/libs/sdmx-toolkit/src/utils/get-file-headers.ts
+++ b/libs/sdmx-toolkit/src/utils/get-file-headers.ts
@@ -11,12 +11,9 @@ export const getRequestAcceptHeader = (
         attribute,
       );
     case SdmxDataFormat.XML:
-      return getFileAcceptHeader(
-        'application/vnd.sdmx.data+xml;version=3.0.0',
-        attribute,
-      );
+      return 'application/vnd.sdmx.data+xml;version=3.0.0';
     case SdmxDataFormat.JSON:
-      return getFileAcceptHeader(`application/${format}`, attribute);
+      return `application/${format}`;
     default:
       return getFileAcceptHeader(
         'application/vnd.sdmx.data+csv;version=2.0.0',


### PR DESCRIPTION
### Applicable issues

[Issue with download dataset](https://github.com/epam/statgpt-global-trusted-data-commons/issues/180)

### Description of changes

Remove format field (not supported in the sdmx api).
Use correct header for the json.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
