### PR TITLE
fix: Combine filters from different agencies into a shared filter

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -43,6 +43,7 @@ import {
 import { getHierarchyRequestContextForFilter } from '../../../utils/hierarchy-request-context';
 import { StructureDataMaps } from '../../../models/structure-data';
 import { useHierarchyState } from '../../../utils/use-hierarchy-state';
+import { useDatasetDimensionsMetadataMapOptional } from '../../../context/DatasetDimensionsMetadataMapContext';
 
 const MultiDatasetFilters: FC<FiltersProps> = ({
   actions,
@@ -63,6 +64,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
   limitMessages,
   filterIconClassName,
 }) => {
+  const datasetDimensionsMetadata = useDatasetDimensionsMetadataMapOptional();
   const [modalState, setModalState] = useState(PopUpState.Closed);
   const [modalFilters, setModalFilters] = useState<Filter[]>([]);
   const [appliedFilters, setAppliedFilters] = useState<Filter[]>([]);
@@ -166,6 +168,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
         filters,
         constraintsMapRef.current,
         true,
+        datasetDimensionsMetadata.map,
       );
 
       Promise.all(getConstraintsRequests(dataQueries, filtersMap, actions))
@@ -178,6 +181,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
               filtersMap,
               { ...structureDataMaps, constraintsMap: currentConstraintsMap },
               locale as Locale,
+              datasetDimensionsMetadata.map,
             ),
           );
           if (changedFilter) {
@@ -196,6 +200,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
               filtersMap,
               { ...structureDataMaps, constraintsMap: currentConstraintsMap },
               locale as Locale,
+              datasetDimensionsMetadata.map,
             ),
           );
         })
@@ -206,6 +211,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     [
       actions,
       dataQueries,
+      datasetDimensionsMetadata.map,
       getConstraintsForFilter,
       locale,
       rebuildHierarchyTree,
@@ -227,6 +233,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       filledDatasetFiltersMap,
       dataQueries,
       structureDataMaps?.constraintsMap,
+      datasetDimensionsMetadata.map,
     );
     setIsConstraintsLoading?.(true);
     handleFiltersWithConstraints(
@@ -236,6 +243,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     );
   }, [
     dataQueries,
+    datasetDimensionsMetadata.map,
     handleFiltersWithConstraints,
     isStructureDataReady,
     locale,
@@ -371,6 +379,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
         filtersToUpdateMap,
         structureDataMaps,
         locale as Locale,
+        datasetDimensionsMetadata.map,
       );
       constraintsMapRef.current = structureDataMaps?.constraintsMap;
 
@@ -383,7 +392,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       setModalFilters(filledFilters);
       setIsDisableFilterValues(false);
     },
-    [locale],
+    [datasetDimensionsMetadata.map, locale],
   );
 
   const handleFiltersDelete = useCallback(
@@ -394,6 +403,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
         filtersToUpdate,
         constraintsMapRef.current,
         true,
+        datasetDimensionsMetadata.map,
       );
 
       Promise.all(getConstraintsRequests(dataQueries, filtersMap, actions))
@@ -410,7 +420,12 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
           });
         });
     },
-    [actions, structureDataMaps, updateViewAfterDelete],
+    [
+      actions,
+      datasetDimensionsMetadata.map,
+      structureDataMaps,
+      updateViewAfterDelete,
+    ],
   );
 
   const onDeleteFilter = useCallback(
@@ -445,6 +460,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       modalFilters,
       constraintsMapRef.current,
       true,
+      datasetDimensionsMetadata.map,
     );
     const appliedFilters = getFiltersByConstraints(
       appliedFiltersMap,
@@ -453,6 +469,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
         constraintsMap: constraintsMapRef.current,
       },
       locale as Locale,
+      datasetDimensionsMetadata.map,
     );
     const filtersParamsMap = getFiltersChangeParamsMap(appliedFiltersMap);
     onMultipleDataFiltersChange?.(
@@ -467,7 +484,12 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
 
     startTransition(() => {
       addSystemMessage(
-        buildFiltersMap(modalFilters, constraintsMapRef.current, true),
+        buildFiltersMap(
+          modalFilters,
+          constraintsMapRef.current,
+          true,
+          datasetDimensionsMetadata.map,
+        ),
       );
     });
   }, [
@@ -475,6 +497,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     modalFilters,
     structureDataMaps,
     locale,
+    datasetDimensionsMetadata.map,
     onMultipleDataFiltersChange,
     dataQueries,
     addSystemMessage,

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -264,6 +264,7 @@ describe('MultiDatasetFilters', () => {
         expect.any(Map),
         defaultProps.dataQueries,
         expect.anything(),
+        expect.any(Object),
       );
     });
   });
@@ -286,6 +287,7 @@ describe('MultiDatasetFilters', () => {
         expect.any(Map),
         defaultProps.dataQueries,
         defaultProps.structureDataMaps.constraintsMap,
+        expect.any(Object),
       );
 
       expect(mockBuildFiltersMap).toHaveBeenCalledWith(
@@ -297,6 +299,7 @@ describe('MultiDatasetFilters', () => {
         ]),
         defaultProps.structureDataMaps.constraintsMap,
         true,
+        expect.any(Object),
       );
     });
 
@@ -369,6 +372,7 @@ describe('MultiDatasetFilters', () => {
         ]),
         defaultProps.structureDataMaps.constraintsMap,
         true,
+        expect.any(Object),
       );
 
       expect(onMultipleDataFiltersChange).toHaveBeenCalledWith(

--- a/libs/conversation-view/src/models/filters.ts
+++ b/libs/conversation-view/src/models/filters.ts
@@ -42,6 +42,7 @@ export interface SharedFilter extends FilterBase {
   filterType: 'shared';
   datasetUrn?: undefined;
   sourceDatasetUrns?: string[];
+  sourceFilterIdsByDataset?: Record<string, string>;
 }
 
 export type Filter = DatasetFilter | SharedFilter;

--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -55,6 +55,34 @@ jest.mock('../query-filters', () => ({
 
 const DATASET_A_URN = 'AGENCY:DF_A(1.0)';
 const DATASET_B_URN = 'AGENCY:DF_B(1.0)';
+const DATASET_DIMENSIONS_METADATA_MAP = {
+  [DATASET_A_URN]: {
+    FREQ: {
+      subtype: 'FREQUENCY',
+      dimensionType: 'NON_INDICATOR',
+    },
+    REF_AREA: {
+      subtype: 'REGION',
+      dimensionType: 'NON_INDICATOR',
+    },
+    TIME_PERIOD: {
+      dimensionType: 'TIME_PERIOD',
+    },
+  },
+  [DATASET_B_URN]: {
+    FREQUENCY: {
+      subtype: 'FREQUENCY',
+      dimensionType: 'NON_INDICATOR',
+    },
+    COUNTRY: {
+      subtype: 'REGION',
+      dimensionType: 'NON_INDICATOR',
+    },
+    TIME_PERIOD: {
+      dimensionType: 'TIME_PERIOD',
+    },
+  },
+} as any;
 
 // ─── Default mock reset ───────────────────────────────────────────────────────
 
@@ -68,8 +96,9 @@ beforeEach(() => {
 const makeDatasetCountryFilter = (
   datasetUrn: string,
   values: Array<{ id: string; name?: string; isSelectedValue?: boolean }>,
+  filterId = COMMON_COUNTRY_FILTER_ID,
 ): Filter => ({
-  id: COMMON_COUNTRY_FILTER_ID,
+  id: filterId,
   filterType: 'dataset',
   datasetUrn,
   dimensionValues: values.map((v) => ({
@@ -209,6 +238,45 @@ describe('merging country filters from multiple datasets', () => {
     expect(merged).toHaveLength(2);
     const indicator = merged.find((f) => f.id === 'INDICATOR');
     expect(indicator?.filterType).toBe('dataset');
+  });
+});
+
+describe('merging shared filters by subtype', () => {
+  it('merges region filters even when dataset ids differ', () => {
+    const merged = getFiltersPreselectedByDataQueries(
+      new Map([
+        [
+          DATASET_A_URN,
+          [
+            makeDatasetCountryFilter(
+              DATASET_A_URN,
+              [{ id: 'FR', name: 'France', isSelectedValue: true }],
+              'REF_AREA',
+            ),
+          ],
+        ],
+        [
+          DATASET_B_URN,
+          [
+            makeDatasetCountryFilter(
+              DATASET_B_URN,
+              [{ id: 'FRA', name: 'France', isSelectedValue: false }],
+              'COUNTRY',
+            ),
+          ],
+        ],
+      ]),
+      [{ urn: DATASET_A_URN }, { urn: DATASET_B_URN }] as any[],
+      undefined,
+      DATASET_DIMENSIONS_METADATA_MAP,
+    );
+
+    const sharedCountry = merged.find((f) => f.id === COMMON_COUNTRY_FILTER_ID);
+    expect(sharedCountry?.filterType).toBe('shared');
+    expect((sharedCountry as SharedFilter).sourceFilterIdsByDataset).toEqual({
+      [DATASET_A_URN]: 'REF_AREA',
+      [DATASET_B_URN]: 'COUNTRY',
+    });
   });
 });
 
@@ -518,9 +586,9 @@ describe('getConstraintsMap', () => {
 // ─── FREQUENCY filter follows the same name-based merge strategy ─────────────
 
 describe('merging frequency filters', () => {
-  it('merges aliased frequency filters from multiple datasets by name', () => {
+  it('merges frequency filters from subtype metadata when dataset ids differ', () => {
     const freqFilterA: Filter = {
-      id: COMMON_FREQUENCY_FILTER_ID,
+      id: 'FREQ',
       filterType: 'dataset',
       datasetUrn: DATASET_A_URN,
       dimensionValues: [
@@ -529,7 +597,7 @@ describe('merging frequency filters', () => {
       ],
     };
     const freqFilterB: Filter = {
-      id: 'FREQ',
+      id: COMMON_FREQUENCY_FILTER_ID,
       filterType: 'dataset',
       datasetUrn: DATASET_B_URN,
       dimensionValues: [
@@ -544,6 +612,8 @@ describe('merging frequency filters', () => {
         [DATASET_B_URN, [freqFilterB]],
       ]),
       [{ urn: DATASET_A_URN }, { urn: DATASET_B_URN }] as any[],
+      undefined,
+      DATASET_DIMENSIONS_METADATA_MAP,
     );
 
     const sharedFreq = merged.find((f) => f.id === COMMON_FREQUENCY_FILTER_ID)!;
@@ -558,22 +628,18 @@ describe('merging frequency filters', () => {
     expect(annual?.isSelectedValue).toBe(true);
     expect(annual?.sourceValues).toHaveLength(2);
     expect((sharedFreq as SharedFilter).sourceFilterIdsByDataset).toEqual({
-      [DATASET_A_URN]: COMMON_FREQUENCY_FILTER_ID,
-      [DATASET_B_URN]: 'FREQ',
+      [DATASET_A_URN]: 'FREQ',
+      [DATASET_B_URN]: COMMON_FREQUENCY_FILTER_ID,
     });
   });
 });
 
-describe('expanding shared filters with aliased dataset ids', () => {
-  it('restores the native filter id for each dataset', () => {
+describe('expanding shared filters with subtype metadata', () => {
+  it('restores the native filter id for each dataset from metadata', () => {
     const sharedFreqFilter: Filter = {
       id: COMMON_FREQUENCY_FILTER_ID,
       filterType: 'shared',
       sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
-      sourceFilterIdsByDataset: {
-        [DATASET_A_URN]: COMMON_FREQUENCY_FILTER_ID,
-        [DATASET_B_URN]: 'FREQ',
-      },
       dimensionValues: [
         {
           id: 'name:annual',
@@ -587,12 +653,17 @@ describe('expanding shared filters with aliased dataset ids', () => {
       ],
     };
 
-    const filtersMap = buildFiltersMap([sharedFreqFilter]);
+    const filtersMap = buildFiltersMap(
+      [sharedFreqFilter],
+      undefined,
+      false,
+      DATASET_DIMENSIONS_METADATA_MAP,
+    );
 
-    expect(filtersMap.get(DATASET_A_URN)?.[0]?.id).toBe(
+    expect(filtersMap.get(DATASET_A_URN)?.[0]?.id).toBe('FREQ');
+    expect(filtersMap.get(DATASET_B_URN)?.[0]?.id).toBe(
       COMMON_FREQUENCY_FILTER_ID,
     );
-    expect(filtersMap.get(DATASET_B_URN)?.[0]?.id).toBe('FREQ');
   });
 });
 

--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -518,7 +518,7 @@ describe('getConstraintsMap', () => {
 // ─── FREQUENCY filter follows the same name-based merge strategy ─────────────
 
 describe('merging frequency filters', () => {
-  it('merges FREQUENCY filters from multiple datasets by name', () => {
+  it('merges aliased frequency filters from multiple datasets by name', () => {
     const freqFilterA: Filter = {
       id: COMMON_FREQUENCY_FILTER_ID,
       filterType: 'dataset',
@@ -529,7 +529,7 @@ describe('merging frequency filters', () => {
       ],
     };
     const freqFilterB: Filter = {
-      id: COMMON_FREQUENCY_FILTER_ID,
+      id: 'FREQ',
       filterType: 'dataset',
       datasetUrn: DATASET_B_URN,
       dimensionValues: [
@@ -557,6 +557,42 @@ describe('merging frequency filters', () => {
     );
     expect(annual?.isSelectedValue).toBe(true);
     expect(annual?.sourceValues).toHaveLength(2);
+    expect((sharedFreq as SharedFilter).sourceFilterIdsByDataset).toEqual({
+      [DATASET_A_URN]: COMMON_FREQUENCY_FILTER_ID,
+      [DATASET_B_URN]: 'FREQ',
+    });
+  });
+});
+
+describe('expanding shared filters with aliased dataset ids', () => {
+  it('restores the native filter id for each dataset', () => {
+    const sharedFreqFilter: Filter = {
+      id: COMMON_FREQUENCY_FILTER_ID,
+      filterType: 'shared',
+      sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
+      sourceFilterIdsByDataset: {
+        [DATASET_A_URN]: COMMON_FREQUENCY_FILTER_ID,
+        [DATASET_B_URN]: 'FREQ',
+      },
+      dimensionValues: [
+        {
+          id: 'name:annual',
+          name: 'Annual',
+          isSelectedValue: true,
+          sourceValues: [
+            { datasetUrn: DATASET_A_URN, id: 'A', name: 'Annual' },
+            { datasetUrn: DATASET_B_URN, id: 'ANNUAL', name: 'Annual' },
+          ],
+        },
+      ],
+    };
+
+    const filtersMap = buildFiltersMap([sharedFreqFilter]);
+
+    expect(filtersMap.get(DATASET_A_URN)?.[0]?.id).toBe(
+      COMMON_FREQUENCY_FILTER_ID,
+    );
+    expect(filtersMap.get(DATASET_B_URN)?.[0]?.id).toBe('FREQ');
   });
 });
 

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -1,6 +1,7 @@
 import {
   DataConstraints,
   DatasetQueryFilters,
+  DatasetDimensionsMetadataMap,
   Dimension,
   findCodelistByDimension,
   getAnnotationPeriod,
@@ -36,7 +37,7 @@ import { getQueryFilters, setDataQueryFilters } from './query-filters';
 
 type SharedFilterConfig = {
   id: string;
-  aliases: string[];
+  subtype?: string;
   getMergedValueKey: (value: FilterValue, datasetUrn?: string) => string;
 };
 
@@ -72,34 +73,128 @@ const buildMergedValueNameKey = (name: string) => `name:${name}`;
 const buildMergedValueDatasetKey = (datasetUrn: string, valueId: string) =>
   `dataset:${datasetUrn}:id:${valueId}`;
 
+const getDatasetDimensionsMetadata = (
+  datasetUrn?: string,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+) => (datasetUrn ? datasetDimensionsMetadataMap?.[datasetUrn] : undefined);
+
+const getDatasetDimensionMetadata = (
+  filter?: Filter,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+) => {
+  if (filter?.filterType !== 'dataset' || !filter.id) {
+    return undefined;
+  }
+
+  return getDatasetDimensionsMetadata(
+    filter.datasetUrn,
+    datasetDimensionsMetadataMap,
+  )?.[filter.id];
+};
+
+const findDatasetDimensionKey = (
+  datasetUrn: string,
+  matcher: (dimensionMetadata: {
+    subtype?: string | null;
+    dimensionType?: string | null;
+  }) => boolean,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+): string | undefined =>
+  Object.entries(
+    getDatasetDimensionsMetadata(datasetUrn, datasetDimensionsMetadataMap) ||
+      {},
+  ).find(([, dimensionMetadata]) => matcher(dimensionMetadata))?.[0];
+
+const getDatasetDimensionKeyBySubtype = (
+  datasetUrn: string,
+  subtype: string,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+) =>
+  findDatasetDimensionKey(
+    datasetUrn,
+    (dimensionMetadata) => dimensionMetadata.subtype === subtype,
+    datasetDimensionsMetadataMap,
+  );
+
+const getTimeDimensionKey = (
+  datasetUrn: string,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+) =>
+  findDatasetDimensionKey(
+    datasetUrn,
+    (dimensionMetadata) => dimensionMetadata.dimensionType === 'TIME_PERIOD',
+    datasetDimensionsMetadataMap,
+  );
+
 const SHARED_FILTERS_CONFIG: SharedFilterConfig[] = [
   {
     id: COMMON_COUNTRY_FILTER_ID,
-    aliases: [COMMON_COUNTRY_FILTER_ID],
+    subtype: 'REGION',
     getMergedValueKey: buildSharedFilterNameMatcher(),
   },
   {
     id: COMMON_FREQUENCY_FILTER_ID,
-    aliases: [COMMON_FREQUENCY_FILTER_ID, 'FREQ'],
+    subtype: 'FREQUENCY',
     getMergedValueKey: buildSharedFilterNameMatcher(),
   },
   {
     id: COMMON_TIME_PERIOD_FILTER_ID,
-    aliases: [COMMON_TIME_PERIOD_FILTER_ID],
     getMergedValueKey: (value) => value.id,
   },
 ];
 
 const SHARED_FILTERS_CONFIG_MAP = new Map<string, SharedFilterConfig>(
-  SHARED_FILTERS_CONFIG.flatMap((config) =>
-    config.aliases.map((alias) => [normalizeFilterId(alias) || alias, config]),
-  ),
+  SHARED_FILTERS_CONFIG.map((config) => [config.id, config]),
 );
 
 const getSharedFilterConfig = (filterId?: string) =>
   filterId
     ? SHARED_FILTERS_CONFIG_MAP.get(normalizeFilterId(filterId) || '')
     : void 0;
+
+const isMatchingSharedFilterConfig = (
+  filter: Filter,
+  config: SharedFilterConfig,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+) => {
+  if (filter.filterType === 'shared') {
+    return config.id === normalizeFilterId(filter.id);
+  }
+
+  if (config.id === COMMON_TIME_PERIOD_FILTER_ID) {
+    return (
+      filter.isTimeDimension ||
+      getDatasetDimensionMetadata(filter, datasetDimensionsMetadataMap)
+        ?.dimensionType === 'TIME_PERIOD' ||
+      config.id === normalizeFilterId(filter.id)
+    );
+  }
+
+  const dimensionMetadata = getDatasetDimensionMetadata(
+    filter,
+    datasetDimensionsMetadataMap,
+  );
+
+  if (config.subtype && dimensionMetadata?.subtype === config.subtype) {
+    return true;
+  }
+
+  return config.id === normalizeFilterId(filter.id);
+};
+
+const getSharedFilterConfigForFilter = (
+  filter?: Filter,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+) =>
+  filter
+    ? SHARED_FILTERS_CONFIG.find((config) =>
+        isMatchingSharedFilterConfig(
+          filter,
+          config,
+          datasetDimensionsMetadataMap,
+        ),
+      )
+    : undefined;
 
 const isSharedFilterId = (filterId?: string) =>
   !!getSharedFilterConfig(filterId);
@@ -147,12 +242,18 @@ const mergeSharedFilterValues = (
   return Array.from(valueMap.values());
 };
 
-const mergeSharedFilters = (filters: Filter[]): Filter[] => {
+const mergeSharedFilters = (
+  filters: Filter[],
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+): Filter[] => {
   const groupedFilters = new Map<string, Filter[]>();
   const otherFilters: Filter[] = [];
 
   filters.forEach((filter) => {
-    const config = getSharedFilterConfig(filter?.id);
+    const config = getSharedFilterConfigForFilter(
+      filter,
+      datasetDimensionsMetadataMap,
+    );
 
     if (config && filter?.datasetUrn) {
       const group = groupedFilters.get(config.id) || [];
@@ -202,21 +303,60 @@ const mergeSharedFilters = (filters: Filter[]): Filter[] => {
   return [...sharedFilters, ...otherFilters];
 };
 
+const getNativeFilterIdForSharedFilter = (
+  filter: SharedFilter,
+  datasetUrn: string,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+): string | undefined => {
+  const sourceFilterId = filter.sourceFilterIdsByDataset?.[datasetUrn];
+
+  if (sourceFilterId) {
+    return sourceFilterId;
+  }
+
+  if (filter.id === COMMON_TIME_PERIOD_FILTER_ID) {
+    return getTimeDimensionKey(datasetUrn, datasetDimensionsMetadataMap);
+  }
+
+  const config = getSharedFilterConfig(filter.id);
+  return config?.subtype
+    ? getDatasetDimensionKeyBySubtype(
+        datasetUrn,
+        config.subtype,
+        datasetDimensionsMetadataMap,
+      )
+    : undefined;
+};
+
 const toDatasetFilter = (
   filter: SharedFilter,
   datasetUrn: string,
   dimensionValues?: FilterValue[],
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Filter => ({
   ...filter,
-  id: filter.sourceFilterIdsByDataset?.[datasetUrn] || filter.id,
+  id:
+    getNativeFilterIdForSharedFilter(
+      filter,
+      datasetUrn,
+      datasetDimensionsMetadataMap,
+    ) || filter.id,
   datasetUrn,
   filterType: 'dataset',
   ...(dimensionValues ? { dimensionValues } : {}),
 });
 
-const expandSharedTimeFilter = (filter: SharedFilter): Filter[] =>
+const expandSharedTimeFilter = (
+  filter: SharedFilter,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+): Filter[] =>
   (filter.sourceDatasetUrns || []).map((datasetUrn) =>
-    toDatasetFilter(filter, datasetUrn),
+    toDatasetFilter(
+      filter,
+      datasetUrn,
+      undefined,
+      datasetDimensionsMetadataMap,
+    ),
   );
 
 const mapSharedValueToDatasetValue = (
@@ -231,6 +371,7 @@ const mapSharedValueToDatasetValue = (
 
 const mapSharedDimensionValuesByDataset = (
   filter: SharedFilter,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Map<string, Filter> => {
   const datasetFiltersMap = new Map<string, Filter>();
 
@@ -250,7 +391,12 @@ const mapSharedDimensionValuesByDataset = (
 
       datasetFiltersMap.set(
         datasetUrn,
-        toDatasetFilter(filter, datasetUrn, [mappedValue]),
+        toDatasetFilter(
+          filter,
+          datasetUrn,
+          [mappedValue],
+          datasetDimensionsMetadataMap,
+        ),
       );
     });
   });
@@ -280,6 +426,7 @@ const getNativeSharedFallbackValues = (
 const applySharedFallbackToDatasets = (
   filter: SharedFilter,
   datasetFiltersMap: Map<string, Filter>,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): void => {
   const selectedValues =
     filter.dimensionValues?.filter((value) => value.isSelectedValue) || [];
@@ -303,7 +450,12 @@ const applySharedFallbackToDatasets = (
     if (!existingFilter || !hasSelectedValue) {
       datasetFiltersMap.set(
         datasetUrn,
-        toDatasetFilter(filter, datasetUrn, nativeFallbackValues),
+        toDatasetFilter(
+          filter,
+          datasetUrn,
+          nativeFallbackValues,
+          datasetDimensionsMetadataMap,
+        ),
       );
     }
   });
@@ -312,19 +464,27 @@ const applySharedFallbackToDatasets = (
 const expandSharedFilter = (
   filter: Filter,
   propagateSharedFiltersToAllDatasets = false,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Filter[] => {
   if (!isSharedFilter(filter)) {
     return [filter];
   }
 
   if (filter.isTimeDimension) {
-    return expandSharedTimeFilter(filter);
+    return expandSharedTimeFilter(filter, datasetDimensionsMetadataMap);
   }
 
-  const datasetFiltersMap = mapSharedDimensionValuesByDataset(filter);
+  const datasetFiltersMap = mapSharedDimensionValuesByDataset(
+    filter,
+    datasetDimensionsMetadataMap,
+  );
 
   if (propagateSharedFiltersToAllDatasets) {
-    applySharedFallbackToDatasets(filter, datasetFiltersMap);
+    applySharedFallbackToDatasets(
+      filter,
+      datasetFiltersMap,
+      datasetDimensionsMetadataMap,
+    );
   }
 
   return Array.from(datasetFiltersMap.values());
@@ -500,6 +660,7 @@ export const getFiltersPreselectedByDataQueries = (
   filtersMap: Map<string, Filter[]>,
   dataQueries?: DataQuery[],
   constraintsMap?: Map<string, DataConstraints[] | undefined>,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Filter[] => {
   return mergeSharedFilters(
     dataQueries?.flatMap((dataQuery) => {
@@ -508,6 +669,7 @@ export const getFiltersPreselectedByDataQueries = (
       const constraints = constraintsMap?.get(urn) || [];
       return getFiltersPreselectedByDataQuery(filters, dataQuery, constraints);
     }) || [],
+    datasetDimensionsMetadataMap,
   );
 };
 
@@ -515,9 +677,16 @@ export const buildFiltersMap = (
   filters: Filter[],
   constraintsMap?: Map<string, DataConstraints[] | undefined>,
   applySharedFallback = false,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Map<string, Filter[]> => {
   return filters
-    ?.flatMap((filter) => expandSharedFilter(filter, applySharedFallback))
+    ?.flatMap((filter) =>
+      expandSharedFilter(
+        filter,
+        applySharedFallback,
+        datasetDimensionsMetadataMap,
+      ),
+    )
     ?.reduce((filterMap, filter) => {
       const urn = filter?.datasetUrn || '';
       const filterWithLimitedTimeRange = limitTimeRangeByConstraints(
@@ -537,6 +706,7 @@ export const getFiltersByConstraints = (
   filtersMap: Map<string, Filter[]>,
   structureDataMaps?: StructureDataMaps,
   locale = Locale.EN,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Filter[] => {
   const updatedFilters: Filter[] = [];
   Array.from(filtersMap?.entries())?.forEach(([datasetUrn, filters]) => {
@@ -549,18 +719,26 @@ export const getFiltersByConstraints = (
     );
   });
 
-  return mergeSharedFilters(updatedFilters);
+  return mergeSharedFilters(updatedFilters, datasetDimensionsMetadataMap);
 };
 
 export const getFiltersForQueryContext = (
   filters: Filter[],
   datasetUrn?: string,
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): Filter[] => {
   if (!datasetUrn) {
     return filters.filter((filter) => filter.filterType !== 'shared');
   }
 
-  return buildFiltersMap(filters).get(datasetUrn) || [];
+  return (
+    buildFiltersMap(
+      filters,
+      undefined,
+      false,
+      datasetDimensionsMetadataMap,
+    ).get(datasetUrn) || []
+  );
 };
 
 export const getDatasetNameFromFilters = (

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -36,6 +36,7 @@ import { getQueryFilters, setDataQueryFilters } from './query-filters';
 
 type SharedFilterConfig = {
   id: string;
+  aliases: string[];
   getMergedValueKey: (value: FilterValue, datasetUrn?: string) => string;
 };
 
@@ -54,6 +55,9 @@ export const SHARED_FILTER_IDS = new Set([
   COMMON_TIME_PERIOD_FILTER_ID,
 ]);
 
+const normalizeFilterId = (filterId?: string) =>
+  filterId?.trim()?.toLocaleUpperCase();
+
 const buildSharedFilterNameMatcher =
   (): SharedFilterConfig['getMergedValueKey'] => (value, datasetUrn) => {
     const normalizedName = value?.name?.trim()?.toLocaleLowerCase();
@@ -71,24 +75,31 @@ const buildMergedValueDatasetKey = (datasetUrn: string, valueId: string) =>
 const SHARED_FILTERS_CONFIG: SharedFilterConfig[] = [
   {
     id: COMMON_COUNTRY_FILTER_ID,
+    aliases: [COMMON_COUNTRY_FILTER_ID],
     getMergedValueKey: buildSharedFilterNameMatcher(),
   },
   {
     id: COMMON_FREQUENCY_FILTER_ID,
+    aliases: [COMMON_FREQUENCY_FILTER_ID, 'FREQ'],
     getMergedValueKey: buildSharedFilterNameMatcher(),
   },
   {
     id: COMMON_TIME_PERIOD_FILTER_ID,
+    aliases: [COMMON_TIME_PERIOD_FILTER_ID],
     getMergedValueKey: (value) => value.id,
   },
 ];
 
-const SHARED_FILTERS_CONFIG_MAP = new Map(
-  SHARED_FILTERS_CONFIG.map((config) => [config.id, config]),
+const SHARED_FILTERS_CONFIG_MAP = new Map<string, SharedFilterConfig>(
+  SHARED_FILTERS_CONFIG.flatMap((config) =>
+    config.aliases.map((alias) => [normalizeFilterId(alias) || alias, config]),
+  ),
 );
 
 const getSharedFilterConfig = (filterId?: string) =>
-  filterId ? SHARED_FILTERS_CONFIG_MAP.get(filterId) : void 0;
+  filterId
+    ? SHARED_FILTERS_CONFIG_MAP.get(normalizeFilterId(filterId) || '')
+    : void 0;
 
 const isSharedFilterId = (filterId?: string) =>
   !!getSharedFilterConfig(filterId);
@@ -141,9 +152,11 @@ const mergeSharedFilters = (filters: Filter[]): Filter[] => {
   const otherFilters: Filter[] = [];
 
   filters.forEach((filter) => {
-    if (isSharedFilterId(filter?.id) && filter?.datasetUrn) {
-      const group = groupedFilters.get(filter.id as string) || [];
-      groupedFilters.set(filter.id as string, [...group, filter]);
+    const config = getSharedFilterConfig(filter?.id);
+
+    if (config && filter?.datasetUrn) {
+      const group = groupedFilters.get(config.id) || [];
+      groupedFilters.set(config.id, [...group, filter]);
       return;
     }
 
@@ -159,11 +172,23 @@ const mergeSharedFilters = (filters: Filter[]): Filter[] => {
 
     const sharedFilter: Filter = {
       ...grouped[0],
+      id: config.id,
       datasetUrn: void 0,
       filterType: 'shared',
-      sourceDatasetUrns: grouped
-        .map((filter) => filter.datasetUrn)
-        .filter((datasetUrn): datasetUrn is string => !!datasetUrn),
+      sourceDatasetUrns: Array.from(
+        new Set(
+          grouped
+            .map((filter) => filter.datasetUrn)
+            .filter((datasetUrn): datasetUrn is string => !!datasetUrn),
+        ),
+      ),
+      sourceFilterIdsByDataset: Object.fromEntries(
+        grouped.flatMap((filter) =>
+          filter.datasetUrn && filter.id
+            ? [[filter.datasetUrn, filter.id]]
+            : [],
+        ),
+      ),
       dimensionValues: mergeSharedFilterValues(grouped, config),
     };
 
@@ -183,6 +208,7 @@ const toDatasetFilter = (
   dimensionValues?: FilterValue[],
 ): Filter => ({
   ...filter,
+  id: filter.sourceFilterIdsByDataset?.[datasetUrn] || filter.id,
   datasetUrn,
   filterType: 'dataset',
   ...(dimensionValues ? { dimensionValues } : {}),


### PR DESCRIPTION
### Applicable issues

[The same facet items from BIS is not combined from other datasets](https://github.com/epam/statgpt-global-trusted-data-commons/issues/189)

### Description of changes

Use alias names to create shared filters

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
