### PR TITLE
fix: lock drag for all leaves when only one visible remains in a group

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/__tests__/draggableListUtils.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/__tests__/draggableListUtils.spec.ts
@@ -208,6 +208,20 @@ describe('protectLastVisibleLeafInGroups', () => {
       expect(result.items![0]).toBe(node.items![0]);
     });
 
+    it('does not force draggable: false when a group has two or more visible leaves', () => {
+      const node = item('col', [
+        group('g1', [
+          checkedItem('a', true, { draggable: true }),
+          checkedItem('b', true, { draggable: true }),
+        ]),
+      ]);
+      const result = protectLastVisibleLeafInGroups(node);
+      const leaves = (result.items![0] as ReturnType<typeof group>)
+        .items as DraggableListItemNode[];
+      expect(leaves.find((l) => l.id === 'a')?.draggable).toBe(true);
+      expect(leaves.find((l) => l.id === 'b')?.draggable).toBe(true);
+    });
+
     it('returns unchanged when a group has zero visible leaves', () => {
       const node = item('col', [
         group('g1', [checkedItem('a', false), checkedItem('b', false)]),
@@ -260,17 +274,20 @@ describe('protectLastVisibleLeafInGroups', () => {
       expect(leaves.find((l) => l.id === 'b')?.checkable).toBe(false);
     });
 
-    it('does not change draggable on the last visible leaf', () => {
+    it('sets draggable: false on all leaves in a group when only one leaf is visible', () => {
       const node = item('col', [
         group('g1', [
-          checkedItem('a', false),
+          checkedItem('a', false, { draggable: true }),
           checkedItem('b', true, { draggable: true }),
+          checkedItem('c', false, { draggable: true }),
         ]),
       ]);
       const result = protectLastVisibleLeafInGroups(node);
       const leaves = (result.items![0] as ReturnType<typeof group>)
         .items as DraggableListItemNode[];
-      expect(leaves.find((l) => l.id === 'b')?.draggable).toBe(true);
+      expect(leaves.find((l) => l.id === 'a')?.draggable).toBe(false);
+      expect(leaves.find((l) => l.id === 'b')?.draggable).toBe(false);
+      expect(leaves.find((l) => l.id === 'c')?.draggable).toBe(false);
     });
 
     it('preserves all other fields on the protected leaf', () => {
@@ -288,7 +305,7 @@ describe('protectLastVisibleLeafInGroups', () => {
         id: 'b',
         label: 'Leaf B',
         isChecked: true,
-        draggable: true,
+        draggable: false,
         checkable: false,
       });
     });
@@ -305,8 +322,14 @@ describe('protectLastVisibleLeafInGroups', () => {
   describe('multiple groups', () => {
     it('protects only the group that has exactly one visible leaf', () => {
       const node = item('col', [
-        group('g1', [checkedItem('a', true), checkedItem('b', true)]),
-        group('g2', [checkedItem('c', false), checkedItem('d', true)]),
+        group('g1', [
+          checkedItem('a', true, { draggable: true }),
+          checkedItem('b', true, { draggable: true }),
+        ]),
+        group('g2', [
+          checkedItem('c', false, { draggable: true }),
+          checkedItem('d', true, { draggable: true }),
+        ]),
       ]);
       const result = protectLastVisibleLeafInGroups(node);
       const g1Leaves = (result.items![0] as ReturnType<typeof group>)
@@ -318,6 +341,10 @@ describe('protectLastVisibleLeafInGroups', () => {
       expect(result.items![0]).toBe(node.items![0]);
       // g2 has 1 visible → protected
       expect(g2Leaves.find((l) => l.id === 'd')?.checkable).toBe(false);
+      expect(g1Leaves.find((l) => l.id === 'a')?.draggable).toBe(true);
+      expect(g1Leaves.find((l) => l.id === 'b')?.draggable).toBe(true);
+      expect(g2Leaves.find((l) => l.id === 'c')?.draggable).toBe(false);
+      expect(g2Leaves.find((l) => l.id === 'd')?.draggable).toBe(false);
     });
 
     it('protects the last visible leaf in each group independently', () => {
@@ -333,6 +360,8 @@ describe('protectLastVisibleLeafInGroups', () => {
 
       expect(g1Leaves.find((l) => l.id === 'b')?.checkable).toBe(false);
       expect(g2Leaves.find((l) => l.id === 'c')?.checkable).toBe(false);
+      expect(g1Leaves.find((l) => l.id === 'b')?.draggable).toBe(false);
+      expect(g2Leaves.find((l) => l.id === 'c')?.draggable).toBe(false);
     });
   });
 

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/draggableListUtils.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/draggableListUtils.ts
@@ -37,9 +37,10 @@ export function getItemNodeByPath(
  * becoming completely empty.
  *
  * A leaf is considered visible when `isChecked` is not explicitly `false`.
- * When exactly one visible leaf remains in a group, that leaf is returned
- * with `checkable: false`. Groups with zero or two or more visible leaves
- * are left unchanged.
+ * When exactly one visible leaf remains in a group, the visible leaf is
+ * returned with `checkable: false`, and all item leaves in that group are
+ * returned with `draggable: false`. Groups with zero or two or more visible
+ * leaves are left unchanged.
  *
  * @param item - A top-level draggable list item node, potentially containing
  *   named group sub-nodes with leaf items.
@@ -65,7 +66,11 @@ export function protectLastVisibleLeafInGroups(
     return {
       ...node,
       items: node.items.map((leaf) =>
-        leaf === soleVisibleLeaf ? { ...leaf, checkable: false } : leaf,
+        leaf.type !== 'item'
+          ? leaf
+          : leaf === soleVisibleLeaf
+            ? { ...leaf, checkable: false, draggable: false }
+            : { ...leaf, draggable: false },
       ),
     };
   });


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/195

### Description of changes

When a column group has exactly one visible leaf, drag-and-drop is now disabled for all leaves in that group (not just the visible one), so no reordering is possible until at least two leaves are visible again. The sole visible leaf remains non-checkable as before.

Tests updated to verify: single-visible group locks all leaves; groups with 2+ visible leaves are unaffected; in multi-group layouts, lock applies only to the affected group.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
