### PR TITLE
fix: hide the dataset name in the filter values section for a single dataset.

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/FilterValues.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/FilterValues.tsx
@@ -66,11 +66,12 @@ const FilterValues: FC<Props> = ({
   const datasetName = selectedFilter
     ? getDatasetNameFromFilters(selectedFilter, structuresMap)
     : void 0;
+  const isSingleDatasetInModal = structuresMap?.size === 1;
   const shouldShowHeader =
     isCrossDatasetModeOn &&
     selectedFilter?.filterType !== 'shared' &&
-    !!datasetName &&
-    !!selectedFilter?.title;
+    !!selectedFilter?.title &&
+    (isSingleDatasetInModal || !!datasetName);
   const filtersHeight = filterValues.length * ROW_HEIGHT;
   const containerHeight =
     filtersHeight > MAX_MOBILE_HEIGHT ? MAX_MOBILE_HEIGHT : filtersHeight;
@@ -83,9 +84,13 @@ const FilterValues: FC<Props> = ({
     >
       {shouldShowHeader && (
         <div className="mb-2 flex items-center gap-x-1">
-          <DatasetIcon className="size-4 shrink-0 text-neutrals-700" />
-          <span className="h4 text-neutrals-800">{datasetName}</span>
-          <ChevronRightIcon className="size-4 shrink-0 text-neutrals-1000" />
+          {!isSingleDatasetInModal && (
+            <>
+              <DatasetIcon className="size-4 shrink-0 text-neutrals-700" />
+              <span className="h4 text-neutrals-800">{datasetName}</span>
+              <ChevronRightIcon className="size-4 shrink-0 text-neutrals-1000" />
+            </>
+          )}
           <span className="h4 text-neutrals-1000">{selectedFilter?.title}</span>
         </div>
       )}


### PR DESCRIPTION
### Applicable issues

[Items in filter in single dataset is displayed like in Multiply](https://github.com/epam/statgpt-global-trusted-data-commons/issues/157)

### Description of changes

Hide the dataset name in the filter values section for a single dataset

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
