### PR TITLE
fix: select the correct dataset tab after applying a filter (single dataset mode).

### DIFF
--- a/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
@@ -141,6 +141,7 @@ const Message: FC<Props> = ({
     actions.updateDataQueries,
     actions.updateCurrentDataQuery,
     attachmentsDataQueries,
+    dataQuery,
   );
   const [isEditing, setIsEditing] = useState(false);
   const [choiceButtons, setChoiceButtons] = useState<FormSchemaButtonOption[]>(

--- a/libs/conversation-view/src/context/Datasets.tsx
+++ b/libs/conversation-view/src/context/Datasets.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { GetDatasetDetails } from '../types/actions';
-import {
-  Dataflow,
-  generateShortUrn,
-  StructuralData,
-} from '@epam/statgpt-sdmx-toolkit';
-import { DataQuery } from '@epam/statgpt-shared-toolkit';
+import { generateShortUrn } from '@epam/statgpt-sdmx-toolkit';
+import type { Dataflow, StructuralData } from '@epam/statgpt-sdmx-toolkit';
+import type { DataQuery } from '@epam/statgpt-shared-toolkit';
 import {
   buildRequestCacheKey,
   getCachedRequestResult,
@@ -17,11 +14,17 @@ export function useDatasets(
   updateDataQueries: (dataQueries?: DataQuery[]) => void,
   updateCurrentDataQuery: (dataQuery?: DataQuery) => void,
   dataQueries?: DataQuery[],
+  currentDataQuery?: DataQuery,
 ) {
   const [datasets, setDatasets] = useState<Dataflow[]>([]);
   const [datasetStructuresMap, setDatasetStructuresMap] =
     useState<Map<string, StructuralData | undefined>>();
   const [isLoading, setIsLoading] = useState(false);
+  const currentDataQueryRef = useRef<DataQuery | undefined>(undefined);
+
+  useEffect(() => {
+    currentDataQueryRef.current = currentDataQuery;
+  }, [currentDataQuery]);
 
   useEffect(() => {
     let isActive = true;
@@ -51,7 +54,11 @@ export function useDatasets(
         setDatasets(updatedDatasets);
         updateDatasets(updatedDatasets);
         updateDataQueries(nextDataQueries);
-        updateCurrentDataQuery(nextDataQueries[0]);
+        updateCurrentDataQuery(
+          nextDataQueries.find(
+            (query) => query.urn === currentDataQueryRef.current?.urn,
+          ) ?? nextDataQueries[0],
+        );
 
         setDatasetStructuresMap(
           new Map(


### PR DESCRIPTION
### Applicable issues

[First dataset is displayed after filter some data in the last one](https://github.com/epam/statgpt-global-trusted-data-commons/issues/105)

### Description of changes

Select the correct dataset tab after applying a filter in single dataset mode, instead of always switching to the first dataset tab.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
