### PR TITLE
fix: set correct Content-Type header for SDMX data downloads

### DIFF
--- a/libs/sdmx-toolkit/src/api/dataset-api.ts
+++ b/libs/sdmx-toolkit/src/api/dataset-api.ts
@@ -2,7 +2,10 @@ import { SdmxApiClient } from './sdmx-api-client';
 import { StructuralMetaData } from '../models/structural-metadata/structural-metadata';
 import { splitUrn } from '../utils/urn';
 import { DataMessage } from '../models/data/data-message';
-import { getRequestAcceptHeader } from '../utils/get-file-headers';
+import {
+  getRequestAcceptHeader,
+  getResponseContentType,
+} from '../utils/get-file-headers';
 import { SdmxReferences } from '../types/references';
 import { SdmxDetails } from '../types/details';
 import { ALL_ATTRIBUTES } from '../constants/attributes';
@@ -83,6 +86,7 @@ export class DatasetApi {
       },
       filename,
       token,
+      getResponseContentType(dataFormat),
     );
   }
 }

--- a/libs/sdmx-toolkit/src/api/sdmx-api-client.ts
+++ b/libs/sdmx-toolkit/src/api/sdmx-api-client.ts
@@ -53,6 +53,7 @@ export class SdmxApiClient {
     options: RequestOptions,
     filename: string,
     token?: string,
+    contentType?: string,
   ): Promise<Response> {
     const url = `${this.config.apiUrl}/${endpoint}`;
 
@@ -94,6 +95,7 @@ export class SdmxApiClient {
 
     const responseHeaders = new Headers({
       'Content-Disposition': `attachment; filename=${encodeURIComponent(filename)}`,
+      ...(contentType ? { 'Content-Type': contentType } : {}),
     });
 
     return new Response(stream, { headers: responseHeaders });

--- a/libs/sdmx-toolkit/src/utils/get-file-headers.ts
+++ b/libs/sdmx-toolkit/src/utils/get-file-headers.ts
@@ -22,5 +22,18 @@ export const getRequestAcceptHeader = (
   }
 };
 
+export const getResponseContentType = (format: string): string => {
+  switch (format) {
+    case SdmxDataFormat.CSV:
+      return 'text/csv; charset=utf-8';
+    case SdmxDataFormat.XML:
+      return 'application/xml; charset=utf-8';
+    case SdmxDataFormat.JSON:
+      return 'application/json; charset=utf-8';
+    default:
+      return 'text/csv; charset=utf-8';
+  }
+};
+
 const getFileAcceptHeader = (acceptHeader: string, attribute: string): string =>
   `${acceptHeader}; labels=${attribute}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13677,14 +13677,11 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "vitest": "4.0.0"
   },
   "overrides": {
-    "dompurify": "3.3.2",
+    "dompurify": "3.4.0",
     "koa": "3.1.2",
     "lodash": "$lodash",
     "minimatch": "10.2.3",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
https://github.com/epam/statgpt-portal-frontend/issues/289

### Description of changes

Downloads from the SDMX API were missing a Content-Type response header, so the browser had no reliable way to identify the file format. This fix adds a getResponseContentType utility that maps each SdmxDataFormat (CSV, XML, JSON) to its correct MIME type, and passes it through SdmxApiClient.streamData so the header is included in the download response.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
