### PR TITLE
fix: redirect users to their last conversation after re-login following session expiration

### DIFF
--- a/apps/portals-example/src/app/[locale]/conversations/[...id]/page.tsx
+++ b/apps/portals-example/src/app/[locale]/conversations/[...id]/page.tsx
@@ -1,5 +1,6 @@
 import ConversationViewWrapper from '../../../../components/ConversationView/ConversationViewWrapper';
-import { SIGN_IN_LINK } from '../../../../constants/auth';
+import { getSignInLink } from '../../../../constants/auth';
+import { ApplicationRoute } from '../../../../types/application-routes';
 import { getUserToken } from '../../../../utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '../../../../utils/auth/get-auth-toggle';
 import { getIsInvalidSession } from '../../../../utils/auth/is-valid-session';
@@ -12,9 +13,9 @@ export const dynamic = 'force-dynamic';
 export default async function Page({
   params,
 }: {
-  params: Promise<{ id: string[] }>;
+  params: Promise<{ locale: string; id: string[] }>;
 }) {
-  const { id } = await params;
+  const { locale, id } = await params;
   // Join the array parts to reconstruct the full conversation ID
   const bucketId = id[0];
   const conversationId = id.slice(1).join('/');
@@ -24,7 +25,13 @@ export default async function Page({
   const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
 
   if (isInvalidSession) {
-    return redirect(SIGN_IN_LINK);
+    return redirect(
+      getSignInLink(
+        `/${locale}${ApplicationRoute.Conversations}/${id
+          .map(encodeURIComponent)
+          .join('/')}`,
+      ),
+    );
   }
 
   return (

--- a/apps/portals-example/src/app/[locale]/conversations/page.tsx
+++ b/apps/portals-example/src/app/[locale]/conversations/page.tsx
@@ -1,6 +1,7 @@
 import Footer from '../../../components/Footer/Footer';
 import WelcomeView from '../../../components/WelcomeView/WelcomeView';
-import { SIGN_IN_LINK } from '../../../constants/auth';
+import { getSignInLink } from '../../../constants/auth';
+import { ApplicationRoute } from '../../../types/application-routes';
 import { getUserToken } from '../../../utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '../../../utils/auth/get-auth-toggle';
 import { getIsInvalidSession } from '../../../utils/auth/is-valid-session';
@@ -9,13 +10,20 @@ import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-export default async function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const isEnableAuth = getIsEnableAuthToggle();
   const token = await getUserToken(isEnableAuth, headers(), cookies());
   const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
 
   if (isInvalidSession) {
-    return redirect(SIGN_IN_LINK);
+    return redirect(
+      getSignInLink(`/${locale}${ApplicationRoute.Conversations}`),
+    );
   }
 
   return (

--- a/apps/portals-example/src/app/[locale]/layout.tsx
+++ b/apps/portals-example/src/app/[locale]/layout.tsx
@@ -7,12 +7,10 @@ import {
 import ConversationListWrapper from '../../components/ConversationList/ConversationListWrapper';
 import { ConversationListProvider } from '../../context/ConversationListContext';
 import { I18nProvider } from '../../locales/client';
-import { SIGN_IN_LINK } from '../../constants/auth';
 import { getUserToken } from '../../utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '../../utils/auth/get-auth-toggle';
 import { getIsInvalidSession } from '../../utils/auth/is-valid-session';
 import { cookies, headers } from 'next/headers';
-import { redirect } from 'next/navigation';
 import { ReactNode } from 'react';
 import { getDeploymentConfiguration } from '../actions/configuration';
 import { DeploymentConfigProvider } from '../../context/DeploymentConfigProvider';
@@ -33,15 +31,18 @@ export default async function LocaleLayout({
   children: ReactNode;
   params: Promise<{ locale: string }>;
 }) {
+  const { locale } = await params;
   const isEnableAuth = getIsEnableAuthToggle();
   const token = await getUserToken(isEnableAuth, headers(), cookies());
   const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
 
   if (isInvalidSession) {
-    return redirect(SIGN_IN_LINK);
+    return (
+      <I18nProvider locale={locale}>
+        <div className="main-layout flex size-full flex-row">{children}</div>
+      </I18nProvider>
+    );
   }
-
-  const { locale } = await params;
 
   const configuration = await getDeploymentConfiguration();
   let isAnyConversationAvailable = false;

--- a/apps/portals-example/src/app/[locale]/page.tsx
+++ b/apps/portals-example/src/app/[locale]/page.tsx
@@ -1,18 +1,23 @@
 import { redirect } from 'next/navigation';
 import { ApplicationRoute } from '../../types/application-routes';
 import { getIsEnableAuthToggle } from '../../utils/auth/get-auth-toggle';
-import { SIGN_IN_LINK } from '../../constants/auth';
+import { getSignInLink } from '../../constants/auth';
 import { getUserToken } from '../../utils/auth/auth-request';
 import { cookies, headers } from 'next/headers';
 import { getIsInvalidSession } from '../../utils/auth/is-valid-session';
 
-export default async function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const isEnableAuth = getIsEnableAuthToggle();
   const token = await getUserToken(isEnableAuth, headers(), cookies());
   const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
 
   if (isInvalidSession) {
-    return redirect(SIGN_IN_LINK);
+    return redirect(getSignInLink(`/${locale}`));
   }
 
   redirect(ApplicationRoute.Conversations);

--- a/apps/portals-example/src/app/[locale]/share/[invitationId]/page.tsx
+++ b/apps/portals-example/src/app/[locale]/share/[invitationId]/page.tsx
@@ -5,7 +5,7 @@ import {
   getConversationUrlWithoutLocale,
 } from '@epam/statgpt-shared-toolkit';
 import { getIsInvalidSession } from '../../../../utils/auth/is-valid-session';
-import { SIGN_IN_LINK } from '../../../../constants/auth';
+import { getSignInLink } from '../../../../constants/auth';
 import { getUserToken } from '../../../../utils/auth/auth-request';
 import { getIsEnableAuthToggle } from '../../../../utils/auth/get-auth-toggle';
 import { cookies, headers } from 'next/headers';
@@ -30,7 +30,9 @@ export default async function Page({
   const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
 
   if (isInvalidSession) {
-    return redirect(SIGN_IN_LINK);
+    return redirect(
+      getSignInLink(`/${locale}/share/${encodeURIComponent(invitationId)}`),
+    );
   }
 
   const requestHeaders = getHeaders(void 0, {

--- a/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
@@ -51,7 +51,7 @@ import {
   getConversationId,
   ApiResponse,
 } from '@epam/statgpt-shared-toolkit';
-import { SIGN_IN_LINK } from '../../constants/auth';
+import { getSignInLink } from '../../constants/auth';
 import { wrapWithAuthHandler } from '../../utils/auth/requests-wrapper';
 import { signOut, useSession } from 'next-auth/react';
 import { ConversationInfo } from '@epam/ai-dial-shared';
@@ -86,7 +86,7 @@ const ConversationListWrapper = ({
       action: (...args: Args) => Promise<ApiResponse<T>>,
     ): ((...args: Args) => Promise<T>) => {
       return wrapWithAuthHandler(action, () => {
-        router.push(SIGN_IN_LINK);
+        router.push(getSignInLink(window.location.href));
       });
     },
     [router],

--- a/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
@@ -90,7 +90,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { JWT } from 'next-auth/jwt';
 import { Conversation } from '@epam/ai-dial-shared';
 import { signOut } from 'next-auth/react';
-import { SIGN_IN_LINK } from '../../constants/auth';
+import { getSignInLink } from '../../constants/auth';
 import { wrapWithAuthHandler } from '../../utils/auth/requests-wrapper';
 import { LimitMessages } from '@epam/statgpt-ui-components';
 
@@ -135,7 +135,7 @@ const ConversationViewWrapper: FC<Props> = ({
       action: (...args: Args) => Promise<ApiResponse<T>>,
     ): (...args: Args) => Promise<T> {
       return wrapWithAuthHandler(action, () => {
-        openUrl(SIGN_IN_LINK);
+        openUrl(getSignInLink(window.location.href));
       });
     },
     [openUrl],

--- a/apps/portals-example/src/components/WelcomeView/WelcomeView.tsx
+++ b/apps/portals-example/src/components/WelcomeView/WelcomeView.tsx
@@ -27,7 +27,7 @@ import {
   NavI18nKeys,
   WelcomeI18nKeys,
 } from '../../constants/i18n-keys';
-import { SIGN_IN_LINK } from '../../constants/auth';
+import { getSignInLink } from '../../constants/auth';
 import { wrapWithAuthHandler } from '../../utils/auth/requests-wrapper';
 import { useDeploymentConfig } from '../../context/DeploymentConfigProvider';
 
@@ -43,7 +43,7 @@ const WelcomeView = () => {
       action: (...args: Args) => Promise<ApiResponse<T>>,
     ): (...args: Args) => Promise<T> {
       return wrapWithAuthHandler(action, () => {
-        router.push(SIGN_IN_LINK);
+        router.push(getSignInLink(window.location.href));
       });
     },
     [router],

--- a/apps/portals-example/src/constants/__tests__/auth.spec.ts
+++ b/apps/portals-example/src/constants/__tests__/auth.spec.ts
@@ -1,0 +1,25 @@
+import { getSignInLink, SIGN_IN_LINK } from '../auth';
+
+describe('getSignInLink', () => {
+  it('returns base sign-in link when callbackUrl is not provided', () => {
+    expect(getSignInLink()).toBe(SIGN_IN_LINK);
+    expect(getSignInLink(null)).toBe(SIGN_IN_LINK);
+  });
+
+  it('returns base sign-in link when callbackUrl is empty after trimming', () => {
+    expect(getSignInLink('')).toBe(SIGN_IN_LINK);
+    expect(getSignInLink('   ')).toBe(SIGN_IN_LINK);
+  });
+
+  it('adds trimmed callbackUrl as a query parameter', () => {
+    expect(getSignInLink('  /datasets/42  ')).toBe(
+      `${SIGN_IN_LINK}?callbackUrl=%2Fdatasets%2F42`,
+    );
+  });
+
+  it('encodes callbackUrl query characters', () => {
+    expect(getSignInLink('/chat?conversationId=abc-123&view=table')).toBe(
+      `${SIGN_IN_LINK}?callbackUrl=%2Fchat%3FconversationId%3Dabc-123%26view%3Dtable`,
+    );
+  });
+});

--- a/apps/portals-example/src/constants/auth.ts
+++ b/apps/portals-example/src/constants/auth.ts
@@ -1,1 +1,13 @@
 export const SIGN_IN_LINK = '/api/auth/signin';
+
+export const getSignInLink = (callbackUrl?: string | null) => {
+  const normalizedCallbackUrl = callbackUrl?.trim();
+
+  if (!normalizedCallbackUrl) {
+    return SIGN_IN_LINK;
+  }
+
+  return `${SIGN_IN_LINK}?${new URLSearchParams({
+    callbackUrl: normalizedCallbackUrl,
+  }).toString()}`;
+};


### PR DESCRIPTION
### Applicable issues

[Welcome page is open after authorization if token is expire](https://github.com/epam/statgpt-global-trusted-data-commons/issues/36)

### Description of changes

Add a callback URL when redirect on login

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
