### PR TITLE
fix: combine TIME_PERIOD filter bounds into a single c[] param

### DIFF
--- a/libs/sdmx-toolkit/src/utils/__tests__/query-filters.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/query-filters.spec.ts
@@ -1,0 +1,63 @@
+import { getQueryTimePeriodFilters } from '../query-filters';
+import type { TimeRange } from '@epam/statgpt-shared-toolkit';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const d = (year: number, month: number, day: number): Date =>
+  new Date(year, month - 1, day);
+
+// ---------------------------------------------------------------------------
+// getQueryTimePeriodFilters
+// ---------------------------------------------------------------------------
+
+describe('getQueryTimePeriodFilters', () => {
+  it('returns null when timeRange is null', () => {
+    expect(getQueryTimePeriodFilters(null, 'TIME_PERIOD')).toBeNull();
+  });
+
+  it('returns null when timeRange is undefined', () => {
+    expect(getQueryTimePeriodFilters(undefined, 'TIME_PERIOD')).toBeNull();
+  });
+
+  it('returns null when both periods are null', () => {
+    expect(
+      getQueryTimePeriodFilters({ startPeriod: null, endPeriod: null }, 'TIME_PERIOD'),
+    ).toBeNull();
+  });
+
+  it('produces a ge: param for start period only', () => {
+    const range: TimeRange = { startPeriod: d(2020, 1, 15), endPeriod: null };
+    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!)).toBe(
+      'c[TIME_PERIOD]=ge:2020-01-15',
+    );
+  });
+
+  it('produces a le: param for end period only', () => {
+    const range: TimeRange = { startPeriod: null, endPeriod: d(2023, 12, 31) };
+    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!)).toBe(
+      'c[TIME_PERIOD]=le:2023-12-31',
+    );
+  });
+
+  it('combines ge: and le: with + into a single param for a full range', () => {
+    const range: TimeRange = { startPeriod: d(2020, 1, 15), endPeriod: d(2023, 12, 31) };
+    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!)).toBe(
+      'c[TIME_PERIOD]=ge:2020-01-15+le:2023-12-31',
+    );
+  });
+
+  it('emits exactly one c[...] param for a full range (spec: once per component)', () => {
+    const range: TimeRange = { startPeriod: d(2020, 1, 15), endPeriod: d(2023, 12, 31) };
+    const result = getQueryTimePeriodFilters(range, 'TIME_PERIOD')!;
+    expect(result.split('c%5B').length - 1).toBe(1);
+  });
+
+  it('uses the provided component id as the param key', () => {
+    const range: TimeRange = { startPeriod: d(2020, 1, 1), endPeriod: null };
+    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'OBS_TIME')!)).toBe(
+      'c[OBS_TIME]=ge:2020-01-01',
+    );
+  });
+});

--- a/libs/sdmx-toolkit/src/utils/__tests__/query-filters.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/query-filters.spec.ts
@@ -23,41 +23,50 @@ describe('getQueryTimePeriodFilters', () => {
 
   it('returns null when both periods are null', () => {
     expect(
-      getQueryTimePeriodFilters({ startPeriod: null, endPeriod: null }, 'TIME_PERIOD'),
+      getQueryTimePeriodFilters(
+        { startPeriod: null, endPeriod: null },
+        'TIME_PERIOD',
+      ),
     ).toBeNull();
   });
 
   it('produces a ge: param for start period only', () => {
     const range: TimeRange = { startPeriod: d(2020, 1, 15), endPeriod: null };
-    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!)).toBe(
-      'c[TIME_PERIOD]=ge:2020-01-15',
-    );
+    expect(
+      decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!),
+    ).toBe('c[TIME_PERIOD]=ge:2020-01-15');
   });
 
   it('produces a le: param for end period only', () => {
     const range: TimeRange = { startPeriod: null, endPeriod: d(2023, 12, 31) };
-    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!)).toBe(
-      'c[TIME_PERIOD]=le:2023-12-31',
-    );
+    expect(
+      decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!),
+    ).toBe('c[TIME_PERIOD]=le:2023-12-31');
   });
 
   it('combines ge: and le: with + into a single param for a full range', () => {
-    const range: TimeRange = { startPeriod: d(2020, 1, 15), endPeriod: d(2023, 12, 31) };
-    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!)).toBe(
-      'c[TIME_PERIOD]=ge:2020-01-15+le:2023-12-31',
-    );
+    const range: TimeRange = {
+      startPeriod: d(2020, 1, 15),
+      endPeriod: d(2023, 12, 31),
+    };
+    expect(
+      decodeURIComponent(getQueryTimePeriodFilters(range, 'TIME_PERIOD')!),
+    ).toBe('c[TIME_PERIOD]=ge:2020-01-15+le:2023-12-31');
   });
 
   it('emits exactly one c[...] param for a full range (spec: once per component)', () => {
-    const range: TimeRange = { startPeriod: d(2020, 1, 15), endPeriod: d(2023, 12, 31) };
+    const range: TimeRange = {
+      startPeriod: d(2020, 1, 15),
+      endPeriod: d(2023, 12, 31),
+    };
     const result = getQueryTimePeriodFilters(range, 'TIME_PERIOD')!;
     expect(result.split('c%5B').length - 1).toBe(1);
   });
 
   it('uses the provided component id as the param key', () => {
     const range: TimeRange = { startPeriod: d(2020, 1, 1), endPeriod: null };
-    expect(decodeURIComponent(getQueryTimePeriodFilters(range, 'OBS_TIME')!)).toBe(
-      'c[OBS_TIME]=ge:2020-01-01',
-    );
+    expect(
+      decodeURIComponent(getQueryTimePeriodFilters(range, 'OBS_TIME')!),
+    ).toBe('c[OBS_TIME]=ge:2020-01-01');
   });
 });

--- a/libs/sdmx-toolkit/src/utils/query-filters.ts
+++ b/libs/sdmx-toolkit/src/utils/query-filters.ts
@@ -12,7 +12,6 @@ import {
 } from '@epam/statgpt-shared-toolkit';
 import { format } from 'date-fns';
 import {
-  AND_QUERY_OPERATOR,
   QUERY_PARAMETER_FILTER_EQUAL,
   QUERY_PARAMETER_FILTER_VALUE_SEPARATOR,
 } from '../constants/query-parameters';
@@ -67,12 +66,8 @@ export const getQueryTimePeriodFilters = (
 
   const id = timePeriodId;
 
-  return filterValues
-    .map(
-      (v) =>
-        `${encodeURIComponent(`c[${id}]`)}${QUERY_PARAMETER_FILTER_EQUAL}${encodeURIComponent(v)}`,
-    )
-    .join(AND_QUERY_OPERATOR);
+  const combinedValue = filterValues.join(GET_v3_FILTER_OR);
+  return `${encodeURIComponent(`c[${id}]`)}${QUERY_PARAMETER_FILTER_EQUAL}${encodeURIComponent(combinedValue)}`;
 };
 
 const formatLocalDate = (date: Date): string => {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #295

### Description of changes

The SDMX REST 2.2 spec requires each component to appear only once in query parameters. The time range filter was emitting two separate c[TIME_PERIOD] params (one for ge:, one for le:), which violates that rule. This changes getQueryTimePeriodFilters to join both bounds with + (AND) into a single param: c[TIME_PERIOD]=ge:2020-01-01+le:2023-12-31. Unit tests for the function are added alongside.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
