### PR TITLE
fix: show valid filter values even if some requests fail

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -31,7 +31,7 @@ import FilterSettings from '../Filters/FiltersModal/FiltersSettings';
 import ModalFooter from '../Filters/FiltersModal/ModalFooter';
 import {
   buildFiltersMap,
-  getConstraintsMap,
+  getConstraintsMapFromSettledResults,
   getConstraintsRequests,
   getFilledDatasetFiltersMap,
   getFiltersByConstraints,
@@ -39,6 +39,7 @@ import {
   hasUncachedConstraintRequests,
   isStructureDataMapsReady,
   getQueryFiltersMap,
+  mergeConstraintsMaps,
   setDataQueryFiltersMap,
 } from '../../../utils/multiple-filters';
 import { getHierarchyRequestContextForFilter } from '../../../utils/hierarchy-request-context';
@@ -202,9 +203,12 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
 
       const requests = getConstraintsRequests(dataQueries, filtersMap, actions);
 
-      Promise.all(requests)
-        .then((constraintsData) => {
-          const currentConstraintsMap = getConstraintsMap(constraintsData);
+      Promise.allSettled(requests)
+        .then((constraintsResults) => {
+          const currentConstraintsMap = mergeConstraintsMaps(
+            constraintsMapRef.current || structureDataMaps?.constraintsMap,
+            getConstraintsMapFromSettledResults(constraintsResults),
+          );
           const filledFilters = getFiltersByConstraints(
             filtersMap,
             { ...structureDataMaps, constraintsMap: currentConstraintsMap },
@@ -234,7 +238,10 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
           }
         })
         .catch(() => {
-          const currentConstraintsMap = new Map();
+          const currentConstraintsMap =
+            constraintsMapRef.current ||
+            structureDataMaps?.constraintsMap ||
+            new Map();
           const filledFilters = getFiltersByConstraints(
             filtersMap,
             { ...structureDataMaps, constraintsMap: currentConstraintsMap },
@@ -481,15 +488,12 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
 
       const requests = getConstraintsRequests(dataQueries, filtersMap, actions);
 
-      Promise.all(requests)
-        .then((constraintsData) => {
-          const updatedConstraintsMap = getConstraintsMap(constraintsData);
-          const mergedConstraintsMap = new Map(currentConstraintsMap);
-
-          updatedConstraintsMap.forEach((constraints, datasetUrn) => {
-            mergedConstraintsMap.set(datasetUrn, constraints);
-          });
-
+      Promise.allSettled(requests)
+        .then((constraintsResults) => {
+          const mergedConstraintsMap = mergeConstraintsMaps(
+            currentConstraintsMap,
+            getConstraintsMapFromSettledResults(constraintsResults),
+          );
           updateViewAfterDelete(filtersMap, {
             ...structureDataMaps,
             constraintsMap: mergedConstraintsMap,

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -32,7 +32,7 @@ const mockGetFiltersPreselectedByDataQueries = jest.fn(() => [] as Filter[]);
 const mockBuildFiltersMap = jest.fn(() => new Map<string, Filter[]>());
 const mockGetFiltersByConstraints = jest.fn(() => [] as Filter[]);
 const mockGetConstraintsRequests = jest.fn(() => [] as Promise<unknown>[]);
-const mockGetConstraintsMap = jest.fn(() => new Map());
+const mockGetConstraintsMapFromSettledResults = jest.fn(() => new Map());
 const mockIsStructureDataMapsReady = jest.fn(() => false);
 const mockGetFilledDatasetFiltersMap = jest.fn(
   () => new Map<string, Filter[]>(),
@@ -40,6 +40,20 @@ const mockGetFilledDatasetFiltersMap = jest.fn(
 const mockGetQueryFiltersMap = jest.fn(() => new Map());
 const mockSetDataQueryFiltersMap = jest.fn(() => new Map());
 const mockHasUncachedConstraintRequests = jest.fn(() => false);
+const mockMergeConstraintsMaps = jest.fn(
+  (
+    baseConstraintsMap: Map<string, unknown> | undefined,
+    updatedConstraintsMap: Map<string, unknown>,
+  ) => {
+    const mergedConstraintsMap = new Map(baseConstraintsMap);
+
+    updatedConstraintsMap.forEach((constraints, datasetUrn) => {
+      mergedConstraintsMap.set(datasetUrn, constraints);
+    });
+
+    return mergedConstraintsMap;
+  },
+);
 
 jest.mock('@epam/statgpt-ui-components', () => {
   const R = require('react');
@@ -67,10 +81,12 @@ jest.mock('../../../../utils/multiple-filters', () => ({
     (mockGetFiltersByConstraints as any)(...args),
   getConstraintsRequests: (...args: any[]) =>
     (mockGetConstraintsRequests as any)(...args),
-  getConstraintsMap: (...args: any[]) =>
-    (mockGetConstraintsMap as any)(...args),
+  getConstraintsMapFromSettledResults: (...args: any[]) =>
+    (mockGetConstraintsMapFromSettledResults as any)(...args),
   hasUncachedConstraintRequests: (...args: any[]) =>
     (mockHasUncachedConstraintRequests as any)(...args),
+  mergeConstraintsMaps: (...args: any[]) =>
+    (mockMergeConstraintsMaps as any)(...args),
   getQueryFiltersMap: (...args: any[]) =>
     (mockGetQueryFiltersMap as any)(...args),
   setDataQueryFiltersMap: (...args: any[]) =>
@@ -238,7 +254,7 @@ beforeEach(() => {
   mockCallbacks.selectedFiltersCount = null;
   jest.clearAllMocks();
   mockGetConstraintsRequests.mockReturnValue([]);
-  mockGetConstraintsMap.mockReturnValue(new Map());
+  mockGetConstraintsMapFromSettledResults.mockReturnValue(new Map());
   mockGetFiltersPreselectedByDataQueries.mockReturnValue([]);
   mockBuildFiltersMap.mockReturnValue(new Map());
   mockGetFiltersByConstraints.mockReturnValue([]);
@@ -246,6 +262,20 @@ beforeEach(() => {
   mockGetQueryFiltersMap.mockReturnValue(new Map());
   mockSetDataQueryFiltersMap.mockReturnValue(new Map());
   mockHasUncachedConstraintRequests.mockReturnValue(false);
+  mockMergeConstraintsMaps.mockImplementation(
+    (
+      baseConstraintsMap: Map<string, unknown> | undefined,
+      updatedConstraintsMap: Map<string, unknown>,
+    ) => {
+      const mergedConstraintsMap = new Map(baseConstraintsMap);
+
+      updatedConstraintsMap.forEach((constraints, datasetUrn) => {
+        mergedConstraintsMap.set(datasetUrn, constraints);
+      });
+
+      return mergedConstraintsMap;
+    },
+  );
   mockIsStructureDataMapsReady.mockReturnValue(false);
   (defaultProps.updateConversation as jest.Mock).mockResolvedValue(undefined);
 });
@@ -279,6 +309,72 @@ describe('MultiDatasetFilters', () => {
         defaultProps.dataQueries,
         expect.anything(),
         expect.any(Object),
+      );
+    });
+
+    it('keeps existing constraints for datasets whose refresh request fails', async () => {
+      const initialConstraintsA = [{ id: 'initial-a' }] as any[];
+      const initialConstraintsB = [{ id: 'initial-b' }] as any[];
+      const updatedConstraintsA = [{ id: 'updated-a' }] as any[];
+      const fulfilledConstraintData = {
+        urn: DATASET_A_URN,
+        data: { data: { dataConstraints: updatedConstraintsA } },
+      };
+      const initialConstraintsMap = new Map<string, any>([
+        [DATASET_A_URN, initialConstraintsA],
+        [DATASET_B_URN, initialConstraintsB],
+      ]);
+      const updatedConstraintsMap = new Map<string, any>([
+        [DATASET_A_URN, updatedConstraintsA],
+      ]);
+
+      mockIsStructureDataMapsReady.mockReturnValue(true);
+      mockGetFiltersPreselectedByDataQueries.mockReturnValue([
+        makeSharedCountryFilter(),
+      ]);
+      mockGetConstraintsRequests.mockReturnValue([
+        Promise.resolve(fulfilledConstraintData),
+        Promise.reject(new Error('constraints failed')),
+      ]);
+      mockGetConstraintsMapFromSettledResults.mockReturnValue(
+        updatedConstraintsMap,
+      );
+
+      await act(async () => {
+        render(
+          createElement(MultiDatasetFilters, {
+            ...defaultProps,
+            structureDataMaps: {
+              ...defaultProps.structureDataMaps,
+              constraintsMap: initialConstraintsMap,
+            } as StructureDataMaps,
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockGetConstraintsMapFromSettledResults).toHaveBeenCalledWith([
+        expect.objectContaining({
+          status: 'fulfilled',
+          value: fulfilledConstraintData,
+        }),
+        expect.objectContaining({
+          status: 'rejected',
+        }),
+      ]);
+
+      const latestCall =
+        mockGetFiltersByConstraints.mock.calls[
+          mockGetFiltersByConstraints.mock.calls.length - 1
+        ];
+      const latestStructureDataMaps = latestCall[1] as StructureDataMaps;
+
+      expect(latestStructureDataMaps.constraintsMap?.get(DATASET_A_URN)).toBe(
+        updatedConstraintsA,
+      );
+      expect(latestStructureDataMaps.constraintsMap?.get(DATASET_B_URN)).toBe(
+        initialConstraintsB,
       );
     });
   });
@@ -497,7 +593,7 @@ describe('MultiDatasetFilters', () => {
         datasetFilterB,
       ]);
       mockGetConstraintsRequests.mockReturnValue([]);
-      mockGetConstraintsMap
+      mockGetConstraintsMapFromSettledResults
         .mockReturnValueOnce(initialConstraintsMap)
         .mockReturnValueOnce(updatedConstraintsMap);
 

--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -3,34 +3,50 @@ import {
   COMMON_FREQUENCY_FILTER_ID,
   buildFiltersMap,
   getConstraintsMap,
+  getConstraintsMapFromSettledResults,
   getDatasetNameFromFilters,
+  getFilledDatasetFiltersMap,
+  getFiltersByConstraints,
   getFiltersForQueryContext,
   getFiltersPreselectedByDataQueries,
   isStructureDataMapsReady,
+  mergeConstraintsMaps,
 } from '../multiple-filters';
 import type { Filter, SharedFilter } from '../../models/filters';
 
+const mockFindCodelistByDimension = jest.fn();
 const mockGenerateShortUrn = jest.fn(
   (name: string, version: string, agencyId: string) =>
     `${agencyId}:${name}(${version})`,
 );
+const mockGetAvailableCodesFromConstrains = jest.fn(() => [] as any[]);
+const mockGetDatasetFilters = jest.fn(() => [] as Filter[]);
+const mockGetFiltersPreselectedByDataQuery = jest.fn(
+  (filters: Filter[]) => filters,
+);
+const mockGetFilledFilters = jest.fn((filters: Filter[]) => filters);
 
 jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  findCodelistByDimension: (...args: any[]) =>
+    (mockFindCodelistByDimension as any)(...args),
   generateShortUrn: (...args: any[]) => (mockGenerateShortUrn as any)(...args),
   getAnnotationPeriod: jest.fn(() => ({ startPeriod: null, endPeriod: null })),
-  getAvailableCodesFromConstrains: jest.fn(() => []),
+  getAvailableCodesFromConstrains: (...args: any[]) =>
+    (mockGetAvailableCodesFromConstrains as any)(...args),
   TIME_PERIOD: 'TIME_PERIOD',
   TIME_PERIOD_START_ANNOTATION_KEY: 'TIME_PERIOD_START',
   TIME_PERIOD_END_ANNOTATION_KEY: 'TIME_PERIOD_END',
 }));
 
 jest.mock('../filters', () => ({
-  getDatasetFilters: jest.fn(() => []),
-  getFiltersPreselectedByDataQuery: jest.fn((filters: Filter[]) => filters),
+  getDatasetFilters: (...args: any[]) =>
+    (mockGetDatasetFilters as any)(...args),
+  getFiltersPreselectedByDataQuery: (...args: any[]) =>
+    (mockGetFiltersPreselectedByDataQuery as any)(...args),
 }));
 
 jest.mock('../get-filled-filters', () => ({
-  getFilledFilters: jest.fn((filters: Filter[]) => filters),
+  getFilledFilters: (...args: any[]) => (mockGetFilledFilters as any)(...args),
 }));
 
 jest.mock('../get-series-filters', () => ({
@@ -91,6 +107,18 @@ beforeEach(() => {
     (name: string, version: string, agencyId: string) =>
       `${agencyId}:${name}(${version})`,
   );
+  mockFindCodelistByDimension.mockReset();
+  mockFindCodelistByDimension.mockReturnValue(undefined);
+  mockGetAvailableCodesFromConstrains.mockReset();
+  mockGetAvailableCodesFromConstrains.mockReturnValue([]);
+  mockGetDatasetFilters.mockReset();
+  mockGetDatasetFilters.mockReturnValue([]);
+  mockGetFiltersPreselectedByDataQuery.mockReset();
+  mockGetFiltersPreselectedByDataQuery.mockImplementation(
+    (filters: Filter[]) => filters,
+  );
+  mockGetFilledFilters.mockReset();
+  mockGetFilledFilters.mockImplementation((filters: Filter[]) => filters);
 });
 
 const makeDatasetCountryFilter = (
@@ -513,6 +541,196 @@ describe('isStructureDataMapsReady', () => {
   });
 });
 
+describe('datasets with missing constraints entries', () => {
+  it('does not fill initial values from codelist when a dataset constraints request failed', () => {
+    mockGetDatasetFilters.mockImplementation(
+      (
+        _dimensions: unknown,
+        _structures: unknown,
+        _structureDimensions: unknown,
+        _locale: unknown,
+        datasetUrn: string,
+      ) => [
+        {
+          id: 'FREQ',
+          filterType: 'dataset',
+          datasetUrn,
+          dimensionValues: [],
+        } as Filter,
+      ],
+    );
+    mockFindCodelistByDimension.mockReturnValue({
+      codes: [{ id: 'A', name: 'Annual' }],
+    });
+    mockGetAvailableCodesFromConstrains.mockReturnValue([
+      { id: 'A', name: 'Annual' },
+    ]);
+
+    const result = getFilledDatasetFiltersMap({
+      dimensionsMap: new Map([
+        [DATASET_A_URN, [{ id: 'FREQ' }]],
+        [DATASET_B_URN, [{ id: 'FREQ' }]],
+      ]),
+      structuresMap: new Map([
+        [DATASET_A_URN, {}],
+        [DATASET_B_URN, {}],
+      ]),
+      structureDimensionsMap: new Map(),
+      constraintsMap: new Map([[DATASET_A_URN, []]]),
+    } as any);
+
+    expect(result.get(DATASET_A_URN)?.[0].dimensionValues).toEqual([
+      { id: 'A', name: 'Annual' },
+    ]);
+    expect(result.get(DATASET_B_URN)?.[0].dimensionValues).toEqual([]);
+    expect(mockGetAvailableCodesFromConstrains).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fill initial values from constraints when a dataset data request failed', () => {
+    mockGetDatasetFilters.mockImplementation(
+      (
+        _dimensions: unknown,
+        _structures: unknown,
+        _structureDimensions: unknown,
+        _locale: unknown,
+        datasetUrn: string,
+      ) => [
+        {
+          id: 'FREQ',
+          filterType: 'dataset',
+          datasetUrn,
+          dimensionValues: [],
+        } as Filter,
+      ],
+    );
+    mockFindCodelistByDimension.mockReturnValue({
+      codes: [{ id: 'A', name: 'Annual' }],
+    });
+    mockGetAvailableCodesFromConstrains.mockReturnValue([
+      { id: 'A', name: 'Annual' },
+    ]);
+
+    const result = getFilledDatasetFiltersMap({
+      dataMessagesMap: new Map([[DATASET_A_URN, {}]]),
+      dimensionsMap: new Map([
+        [DATASET_A_URN, [{ id: 'FREQ' }]],
+        [DATASET_B_URN, [{ id: 'FREQ' }]],
+      ]),
+      structuresMap: new Map([
+        [DATASET_A_URN, {}],
+        [DATASET_B_URN, {}],
+      ]),
+      structureDimensionsMap: new Map(),
+      constraintsMap: new Map([
+        [DATASET_A_URN, []],
+        [DATASET_B_URN, []],
+      ]),
+    } as any);
+
+    expect(result.get(DATASET_A_URN)?.[0].dimensionValues).toEqual([
+      { id: 'A', name: 'Annual' },
+    ]);
+    expect(result.get(DATASET_B_URN)?.[0].dimensionValues).toEqual([]);
+    expect(mockGetAvailableCodesFromConstrains).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps only selected values when refreshing filters for a dataset without constraints', () => {
+    const datasetAFilter: Filter = {
+      id: 'INDICATOR',
+      filterType: 'dataset',
+      datasetUrn: DATASET_A_URN,
+      dimensionValues: [],
+    };
+    const datasetBFilter: Filter = {
+      id: 'INDICATOR',
+      filterType: 'dataset',
+      datasetUrn: DATASET_B_URN,
+      dimensionValues: [
+        { id: 'GDP', name: 'GDP', isSelectedValue: true },
+        { id: 'CPI', name: 'CPI', isSelectedValue: false },
+      ],
+    };
+
+    mockGetFilledFilters.mockReturnValue([
+      {
+        ...datasetAFilter,
+        dimensionValues: [{ id: 'A', name: 'Available' }],
+      },
+    ]);
+
+    const result = getFiltersByConstraints(
+      new Map([
+        [DATASET_A_URN, [datasetAFilter]],
+        [DATASET_B_URN, [datasetBFilter]],
+      ]),
+      {
+        dimensionsMap: new Map([[DATASET_A_URN, [{ id: 'INDICATOR' }]]]),
+        structuresMap: new Map([[DATASET_A_URN, {}]]),
+        constraintsMap: new Map([[DATASET_A_URN, []]]),
+      } as any,
+    );
+
+    expect(mockGetFilledFilters).toHaveBeenCalledTimes(1);
+    expect(
+      result.find((filter) => filter.datasetUrn === DATASET_B_URN)
+        ?.dimensionValues,
+    ).toEqual([{ id: 'GDP', name: 'GDP', isSelectedValue: true }]);
+  });
+
+  it('keeps only selected values when refreshing filters for a dataset without data response', () => {
+    const datasetAFilter: Filter = {
+      id: 'INDICATOR',
+      filterType: 'dataset',
+      datasetUrn: DATASET_A_URN,
+      dimensionValues: [],
+    };
+    const datasetBFilter: Filter = {
+      id: 'INDICATOR',
+      filterType: 'dataset',
+      datasetUrn: DATASET_B_URN,
+      dimensionValues: [
+        { id: 'GDP', name: 'GDP', isSelectedValue: true },
+        { id: 'CPI', name: 'CPI', isSelectedValue: false },
+      ],
+    };
+
+    mockGetFilledFilters.mockReturnValue([
+      {
+        ...datasetAFilter,
+        dimensionValues: [{ id: 'A', name: 'Available' }],
+      },
+    ]);
+
+    const result = getFiltersByConstraints(
+      new Map([
+        [DATASET_A_URN, [datasetAFilter]],
+        [DATASET_B_URN, [datasetBFilter]],
+      ]),
+      {
+        dataMessagesMap: new Map([[DATASET_A_URN, {}]]),
+        dimensionsMap: new Map([
+          [DATASET_A_URN, [{ id: 'INDICATOR' }]],
+          [DATASET_B_URN, [{ id: 'INDICATOR' }]],
+        ]),
+        structuresMap: new Map([
+          [DATASET_A_URN, {}],
+          [DATASET_B_URN, {}],
+        ]),
+        constraintsMap: new Map([
+          [DATASET_A_URN, []],
+          [DATASET_B_URN, []],
+        ]),
+      } as any,
+    );
+
+    expect(mockGetFilledFilters).toHaveBeenCalledTimes(1);
+    expect(
+      result.find((filter) => filter.datasetUrn === DATASET_B_URN)
+        ?.dimensionValues,
+    ).toEqual([{ id: 'GDP', name: 'GDP', isSelectedValue: true }]);
+  });
+});
+
 // ─── getDatasetNameFromFilters ────────────────────────────────────────────────
 
 describe('getDatasetNameFromFilters', () => {
@@ -580,6 +798,83 @@ describe('getConstraintsMap', () => {
       id: 'DF_A',
       agencyID: 'AGENCY',
     });
+  });
+
+  it('does not create a dataset entry when constraints payload is missing', () => {
+    const map = getConstraintsMap([
+      {
+        urn: DATASET_A_URN,
+        data: {},
+      },
+      {
+        urn: DATASET_B_URN,
+        data: {
+          data: {
+            dataConstraints: [],
+          },
+        },
+      },
+    ] as any[]);
+
+    expect(map.has(DATASET_A_URN)).toBe(false);
+    expect(map.has(DATASET_B_URN)).toBe(true);
+  });
+});
+
+describe('getConstraintsMapFromSettledResults', () => {
+  it('builds constraints map from fulfilled results and ignores rejected results', () => {
+    const constraints = [{ id: 'updated-a' }] as any[];
+
+    const map = getConstraintsMapFromSettledResults([
+      {
+        status: 'fulfilled',
+        value: {
+          urn: DATASET_A_URN,
+          data: {
+            data: {
+              dataConstraints: constraints,
+            },
+          },
+        },
+      },
+      {
+        status: 'rejected',
+        reason: new Error('failed'),
+      },
+    ]);
+
+    expect(map.get(DATASET_A_URN)).toBe(constraints);
+    expect(map.has(DATASET_B_URN)).toBe(false);
+  });
+});
+
+describe('mergeConstraintsMaps', () => {
+  it('overrides only updated dataset entries and preserves the rest', () => {
+    const initialConstraintsA = [{ id: 'initial-a' }] as any[];
+    const initialConstraintsB = [{ id: 'initial-b' }] as any[];
+    const updatedConstraintsA = [{ id: 'updated-a' }] as any[];
+
+    const result = mergeConstraintsMaps(
+      new Map([
+        [DATASET_A_URN, initialConstraintsA],
+        [DATASET_B_URN, initialConstraintsB],
+      ]),
+      new Map([[DATASET_A_URN, updatedConstraintsA]]),
+    );
+
+    expect(result.get(DATASET_A_URN)).toBe(updatedConstraintsA);
+    expect(result.get(DATASET_B_URN)).toBe(initialConstraintsB);
+  });
+
+  it('creates a new map when there are no base constraints', () => {
+    const updatedConstraintsA = [{ id: 'updated-a' }] as any[];
+
+    const result = mergeConstraintsMaps(
+      undefined,
+      new Map([[DATASET_A_URN, updatedConstraintsA]]),
+    );
+
+    expect(result).toEqual(new Map([[DATASET_A_URN, updatedConstraintsA]]));
   });
 });
 

--- a/libs/conversation-view/src/utils/attachments/attachments-data.ts
+++ b/libs/conversation-view/src/utils/attachments/attachments-data.ts
@@ -47,10 +47,11 @@ export const getDataConstraintsMap = async (
 
   settledConstraints.forEach((result) => {
     if (result.status === 'fulfilled') {
-      constraintsMap.set(
-        result.value.urn,
-        result.value.response?.data?.dataConstraints || [],
-      );
+      const constraints = result.value.response?.data?.dataConstraints;
+
+      if (Array.isArray(constraints)) {
+        constraintsMap.set(result.value.urn, constraints);
+      }
     }
   });
 

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -45,7 +45,7 @@ type SharedFilterConfig = {
   getMergedValueKey: (value: FilterValue, datasetUrn?: string) => string;
 };
 
-type ExtendedStructuralMetadata = {
+export type ExtendedStructuralMetadata = {
   urn: string;
   data?: StructuralMetaData;
 };
@@ -205,6 +205,18 @@ const isSharedFilterId = (filterId?: string) =>
 
 const isSharedFilter = (filter?: Filter): filter is SharedFilter =>
   filter?.filterType === 'shared' && isSharedFilterId(filter?.id);
+
+const hasConstraintsForDataset = (
+  constraintsMap: Map<string, DataConstraints[] | undefined> | undefined,
+  datasetUrn: string,
+) => !constraintsMap || Array.isArray(constraintsMap.get(datasetUrn));
+
+const hasDataMessageForDataset = (
+  structureDataMaps: StructureDataMaps | undefined,
+  datasetUrn: string,
+) =>
+  !structureDataMaps?.dataMessagesMap ||
+  structureDataMaps.dataMessagesMap.has(datasetUrn);
 
 const mergeSharedFilterValues = (
   filters: Filter[],
@@ -605,8 +617,23 @@ const getFiltersWithValuesMap = (
   return new Map(
     Array.from(structureDataMaps?.dimensionsMap?.entries() || []).map(
       ([datasetUrn, dimensions]) => {
+        const hasDatasetConstraints = hasConstraintsForDataset(
+          structureDataMaps?.constraintsMap,
+          datasetUrn,
+        );
+        const hasDatasetDataMessage = hasDataMessageForDataset(
+          structureDataMaps,
+          datasetUrn,
+        );
         const filters =
           dimensions?.map((dimension) => {
+            if (!hasDatasetConstraints || !hasDatasetDataMessage) {
+              return {
+                ...dimension,
+                dimensionValues: [],
+              };
+            }
+
             const codeList = findCodelistByDimension(
               structureDataMaps?.structuresMap?.get(datasetUrn)?.codelists,
               structureDataMaps?.structuresMap?.get(datasetUrn)?.conceptSchemes,
@@ -628,6 +655,14 @@ const getFiltersWithValuesMap = (
     ),
   );
 };
+
+const getFiltersWithSelectedValuesOnly = (filters: Filter[]): Filter[] =>
+  filters.map((filter) => ({
+    ...filter,
+    isDisabled: false,
+    dimensionValues:
+      filter.dimensionValues?.filter((value) => value.isSelectedValue) || [],
+  }));
 
 export const getFilledDatasetFiltersMap = (
   structureDataMaps?: StructureDataMaps,
@@ -716,6 +751,20 @@ export const getFiltersByConstraints = (
   Array.from(filtersMap?.entries())?.forEach(([datasetUrn, filters]) => {
     const dimensions = structureDataMaps?.dimensionsMap?.get(datasetUrn);
     const structures = structureDataMaps?.structuresMap?.get(datasetUrn);
+    const hasDatasetConstraints = hasConstraintsForDataset(
+      structureDataMaps?.constraintsMap,
+      datasetUrn,
+    );
+    const hasDatasetDataMessage = hasDataMessageForDataset(
+      structureDataMaps,
+      datasetUrn,
+    );
+
+    if (!hasDatasetConstraints || !hasDatasetDataMessage) {
+      updatedFilters.push(...getFiltersWithSelectedValuesOnly(filters));
+      return;
+    }
+
     const constraints = structureDataMaps?.constraintsMap?.get(datasetUrn);
 
     updatedFilters.push(
@@ -839,11 +888,33 @@ export const getConstraintsMap = (
   constraintsData: ExtendedStructuralMetadata[],
 ): Map<string, DataConstraints[] | undefined> => {
   return new Map(
-    constraintsData?.map(({ urn, data }) => {
-      const constraint = data?.data?.dataConstraints;
-      return [urn, constraint];
+    constraintsData?.flatMap(({ urn, data }) => {
+      const constraints = data?.data?.dataConstraints;
+      return Array.isArray(constraints) ? [[urn, constraints]] : [];
     }),
   );
+};
+
+export const getConstraintsMapFromSettledResults = (
+  constraintsResults: PromiseSettledResult<ExtendedStructuralMetadata>[],
+): Map<string, DataConstraints[] | undefined> =>
+  getConstraintsMap(
+    constraintsResults.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : [],
+    ),
+  );
+
+export const mergeConstraintsMaps = (
+  baseConstraintsMap: Map<string, DataConstraints[] | undefined> | undefined,
+  updatedConstraintsMap: Map<string, DataConstraints[] | undefined>,
+): Map<string, DataConstraints[] | undefined> => {
+  const mergedConstraintsMap = new Map(baseConstraintsMap);
+
+  updatedConstraintsMap.forEach((constraints, datasetUrn) => {
+    mergedConstraintsMap.set(datasetUrn, constraints);
+  });
+
+  return mergedConstraintsMap;
 };
 
 export const getInitialConstraints = (


### PR DESCRIPTION
### Applicable issues

[Not valid Frequency list after reselect with BIS + other dataset](https://github.com/epam/statgpt-global-trusted-data-commons/issues/206)

### Description of changes

- Handle partial constraints request failures with `Promise.allSettled` instead of failing the whole batch.
- Preserve existing constraints for datasets whose refresh request fails.
- Avoid using datasets in shared filter value aggregation when their dataset data or constraints were not successfully loaded.
- Distinguish between valid empty constraints and missing/invalid constraints payloads.
- Keep already selected values for failed datasets without expanding them from the codelist.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
