### PR TITLE
fix: select value from the hierarchy tree in the shared filter

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersSettings.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersSettings.tsx
@@ -25,12 +25,17 @@ import classNames from 'classnames';
 import { ConversationViewTitles } from '../../../../models/titles';
 import {
   getFilterIdentity,
+  isSharedFilter,
   getSelectedFilterValues,
   getTotalSelectedValuesLength,
   isSameFilter,
 } from '../../../../utils/filters';
 import { useConversationViewFeatureToggles } from '../../../../context/ConversationViewFeatureTogglesContext';
 import { getInitialConstraints } from '../../../../utils/multiple-filters';
+import {
+  mapHierarchyNodeIdToFilterValueId,
+  mapHierarchyNodesToFilterValueIds,
+} from '../../../../utils/hierarchy-view';
 
 interface Props {
   filtersList: Filter[];
@@ -126,11 +131,19 @@ const FilterSettings: FC<Props> = ({
       return;
     }
 
+    const resolvedId = isSharedFilter(filterToUpdate)
+      ? mapHierarchyNodeIdToFilterValueId(id, filterToUpdate)
+      : id;
+
+    if (!resolvedId) {
+      return;
+    }
+
     const updatedFilter = {
       ...filterToUpdate,
       dimensionValues: filterToUpdate?.dimensionValues?.map(
         (dimensionValue) => {
-          if (dimensionValue?.id === id) {
+          if (dimensionValue?.id === resolvedId) {
             return { ...dimensionValue, isSelectedValue };
           }
           return dimensionValue;
@@ -157,18 +170,25 @@ const FilterSettings: FC<Props> = ({
       return;
     }
 
+    const mappedNodes = isSharedFilter(filterToUpdate)
+      ? mapHierarchyNodesToFilterValueIds(nodes, filterToUpdate)
+      : (nodes ?? []);
+
     // For single-node calls (nodes with all-disabled children that are not yet
     // in dimensionValues), add the node as a new entry so it can be selected.
     const existingIds = new Set(
       filterToUpdate?.dimensionValues?.map((v) => v.id),
     );
     const newEntries: FilterValue[] =
-      nodes?.length === 1 && nodes[0] && !existingIds.has(nodes[0].id)
+      !isSharedFilter(filterToUpdate) &&
+      mappedNodes.length === 1 &&
+      mappedNodes[0] &&
+      !existingIds.has(mappedNodes[0].id)
         ? [
             {
-              id: nodes[0].id,
-              name: nodes[0].name,
-              isSelectedValue: nodes[0].isSelectedValue,
+              id: mappedNodes[0].id,
+              name: mappedNodes[0].name,
+              isSelectedValue: mappedNodes[0].isSelectedValue,
             },
           ]
         : [];
@@ -177,7 +197,7 @@ const FilterSettings: FC<Props> = ({
       ...filterToUpdate,
       dimensionValues: [
         ...(filterToUpdate?.dimensionValues?.map((dimensionValue) => {
-          const nodeValue = nodes?.find(
+          const nodeValue = mappedNodes.find(
             (node) => node?.id === dimensionValue?.id,
           );
           return nodeValue || dimensionValue;

--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/FiltersValuesPanel.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/FiltersValuesPanel.tsx
@@ -31,6 +31,7 @@ import { getFilterIdentity, isSameFilter } from '../../../../../utils/filters';
 import {
   applySelectionToTree,
   filterHierarchyNodes,
+  getSelectedHierarchyNodeIds,
 } from '../../../../../utils/hierarchy-view';
 
 const MIN_CROSS_DATASET_SEARCH_CHARS = 2;
@@ -177,11 +178,7 @@ const FiltersValuesPanel: FC<Props> = ({
   const hierarchyTreeNodes = useMemo(() => {
     const nodes = hierarchyState?.treeNodes;
     if (!nodes?.length) return nodes;
-    const selectedIds = new Set(
-      selectedFilter?.dimensionValues
-        ?.filter((v) => v.isSelectedValue)
-        .map((v) => v.id) ?? [],
-    );
+    const selectedIds = getSelectedHierarchyNodeIds(selectedFilter);
     const withSelection = selectedIds.size
       ? applySelectionToTree(nodes, selectedIds)
       : nodes;
@@ -190,7 +187,7 @@ const FiltersValuesPanel: FC<Props> = ({
       : withSelection;
   }, [
     hierarchyState?.treeNodes,
-    selectedFilter?.dimensionValues,
+    selectedFilter,
     hasSearchQuery,
     normalizedSearchQuery,
   ]);

--- a/libs/conversation-view/src/utils/__tests__/hierarchy-view.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/hierarchy-view.spec.ts
@@ -5,7 +5,7 @@ import type {
   TreeNode,
   HierarchicalCode,
 } from '@epam/statgpt-sdmx-toolkit';
-import type { FilterTreeNodeProps } from '../../models/filters';
+import type { Filter, FilterTreeNodeProps } from '../../models/filters';
 
 const mockGenerateShortUrn = jest.fn(
   (id?: string, version?: string, agency?: string) =>
@@ -122,8 +122,11 @@ import {
   buildHierarchyFilterTreeProps,
   buildHierarchyUrn,
   filterHierarchyNodes,
+  getSelectedHierarchyNodeIds,
   getLatestHierarchies,
   hierarchyNodesToFilterTreeProps,
+  mapHierarchyNodeIdToFilterValueId,
+  mapHierarchyNodesToFilterValueIds,
   toggleTreeNodeExpansion,
 } from '../hierarchy-view';
 
@@ -531,5 +534,80 @@ describe('filterHierarchyNodes', () => {
 
   it('returns an empty array when nothing matches', () => {
     expect(filterHierarchyNodes(tree, 'oceania')).toEqual([]);
+  });
+});
+
+describe('shared hierarchy selection mapping', () => {
+  const sharedCountryFilter: Filter = {
+    id: 'COUNTRY',
+    filterType: 'shared',
+    dimensionValues: [
+      {
+        id: 'name:italy',
+        name: 'Italy',
+        isSelectedValue: true,
+        sourceValues: [
+          {
+            datasetUrn: 'IMF.RES:WEO(9.0.0)',
+            id: 'ITA',
+            name: 'Italy',
+          },
+        ],
+      },
+      {
+        id: 'name:germany',
+        name: 'Germany',
+        isSelectedValue: false,
+        sourceValues: [
+          {
+            datasetUrn: 'IMF.RES:WEO(9.0.0)',
+            id: 'DEU',
+            name: 'Germany',
+          },
+        ],
+      },
+    ],
+  };
+
+  it('builds selected hierarchy ids from native source values for shared filters', () => {
+    expect(
+      Array.from(getSelectedHierarchyNodeIds(sharedCountryFilter)),
+    ).toEqual(['ITA']);
+  });
+
+  it('maps a hierarchy node id to the merged shared value id', () => {
+    expect(mapHierarchyNodeIdToFilterValueId('ITA', sharedCountryFilter)).toBe(
+      'name:italy',
+    );
+  });
+
+  it('maps hierarchy nodes to shared filter value ids', () => {
+    expect(
+      mapHierarchyNodesToFilterValueIds(
+        [
+          { id: 'ITA', name: 'Italy', isSelectedValue: true, children: [] },
+          {
+            id: 'DEU',
+            name: 'Germany',
+            isSelectedValue: false,
+            children: [],
+          },
+        ],
+        sharedCountryFilter,
+      ),
+    ).toEqual([
+      {
+        id: 'name:italy',
+        name: 'Italy',
+        isSelectedValue: true,
+        children: [],
+      },
+      {
+        id: 'name:germany',
+        name: 'Germany',
+        isSelectedValue: false,
+        children: [],
+      },
+    ]);
   });
 });

--- a/libs/conversation-view/src/utils/hierarchy-view.ts
+++ b/libs/conversation-view/src/utils/hierarchy-view.ts
@@ -12,7 +12,7 @@ import {
   TreeNode,
   urnMatchesIgnoreVersion,
 } from '@epam/statgpt-sdmx-toolkit';
-import { FilterTreeNodeProps } from '../models/filters';
+import { Filter, FilterTreeNodeProps } from '../models/filters';
 
 function compareVersions(a: string, b: string): number {
   const aParts = (a ?? '').split('.').map(Number);
@@ -164,6 +164,71 @@ export function hierarchyNodesToFilterTreeProps(
       children: hierarchyNodesToFilterTreeProps(node.children),
     } as FilterTreeNodeProps;
   });
+}
+
+function resolveFilterValueId(
+  filter: Filter | undefined,
+  nodeId: string,
+): string | undefined {
+  if (filter?.filterType !== 'shared') {
+    return nodeId;
+  }
+
+  return filter.dimensionValues?.find(
+    (value) =>
+      value.id === nodeId ||
+      value.sourceValues?.some((sourceValue) => sourceValue.id === nodeId),
+  )?.id;
+}
+
+export function getSelectedHierarchyNodeIds(filter?: Filter): Set<string> {
+  if (filter?.filterType !== 'shared') {
+    return new Set(
+      filter?.dimensionValues
+        ?.filter((value) => value.isSelectedValue)
+        .map((value) => value.id) ?? [],
+    );
+  }
+
+  return new Set(
+    filter.dimensionValues?.flatMap((value) =>
+      value.isSelectedValue
+        ? (value.sourceValues?.map((sourceValue) => sourceValue.id) ?? [])
+        : [],
+    ) ?? [],
+  );
+}
+
+export function mapHierarchyNodesToFilterValueIds(
+  nodes: FilterTreeNodeProps[] | undefined,
+  filter?: Filter,
+): FilterTreeNodeProps[] {
+  if (!nodes?.length || filter?.filterType !== 'shared') {
+    return nodes ?? [];
+  }
+
+  const mappedNodesById = new Map<string, FilterTreeNodeProps>();
+
+  nodes.forEach((node) => {
+    const resolvedId = resolveFilterValueId(filter, node.id);
+    if (!resolvedId) {
+      return;
+    }
+
+    mappedNodesById.set(resolvedId, {
+      ...node,
+      id: resolvedId,
+    });
+  });
+
+  return Array.from(mappedNodesById.values());
+}
+
+export function mapHierarchyNodeIdToFilterValueId(
+  nodeId: string,
+  filter?: Filter,
+): string | undefined {
+  return resolveFilterValueId(filter, nodeId);
 }
 
 export function applySelectionToTree(


### PR DESCRIPTION
### Applicable issues

[Facet items becomes unavailable if select hierarchy mode](https://github.com/epam/statgpt-global-trusted-data-commons/issues/191)

### Description of changes

Fix shared hierarchy selection by mapping hierarchy native codes back to merged shared filter value ids.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
