### PR TITLE
fix: rewrite getConvertedData for performance improvement

### DIFF
--- a/libs/conversation-view/src/components/ChatMessages/ChatMessages.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/ChatMessages.tsx
@@ -202,6 +202,10 @@ const ChatMessages: FC<Props> = ({
             );
           }
 
+          if (isOpenedAdvancedView && message.role === Role.System) {
+            return null;
+          }
+
           const isLast = index === messages.length - 1;
           const previousMessage = getPreviousMessageWithAttachment(
             messages,

--- a/libs/conversation-view/src/utils/attachments/data-grid/__tests__/get-converted-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/__tests__/get-converted-data.spec.ts
@@ -1,0 +1,120 @@
+import {
+  Dimension,
+  TimeSeries,
+  TimeSeriesObservation,
+  TimeSeriesValue,
+} from '@epam/statgpt-sdmx-toolkit';
+import { getConvertedData } from '../get-converted-data';
+
+const dimensions = [{ id: 'FREQ' }, { id: 'REF_AREA' }] as Dimension[];
+
+const timeDimensions = [{ id: 'TIME_PERIOD' }] as Dimension[];
+
+describe('getConvertedData', () => {
+  it('pivots observations into one grid row per dimension combination', () => {
+    const series = buildSeries({
+      name: 'A.US',
+      values: [
+        buildValue('2020', '10'),
+        buildValue('2021', '12', [
+          { name: 'OBS_STATUS', value: 'E' } as TimeSeriesObservation,
+        ]),
+      ],
+      attributes: [
+        { name: 'UNIT', value: 'USD' } as TimeSeriesObservation,
+        { name: 'EMPTY', value: '' } as TimeSeriesObservation,
+      ],
+    });
+
+    expect(getConvertedData([series], dimensions, timeDimensions)).toEqual([
+      {
+        FREQ: 'A',
+        REF_AREA: 'US',
+        attributes: [{ name: 'UNIT', value: 'USD' }],
+        id: 'A_US',
+        originalData: series,
+        '2020': {
+          value: [{ name: 'OBS_VALUE', value: '10' }],
+          obsAttributes: [],
+        },
+        '2021': {
+          value: [{ name: 'OBS_VALUE', value: '12' }],
+          obsAttributes: [{ name: 'OBS_STATUS', value: 'E' }],
+        },
+      },
+    ]);
+  });
+
+  it('keeps the empty cell produced for a series without observations', () => {
+    const series = buildSeries({
+      name: 'M.FR',
+      values: [],
+      attributes: [{ name: 'UNIT', value: 'EUR' } as TimeSeriesObservation],
+    });
+
+    expect(getConvertedData([series], dimensions, timeDimensions)).toEqual([
+      {
+        FREQ: 'M',
+        REF_AREA: 'FR',
+        attributes: [{ name: 'UNIT', value: 'EUR' }],
+        id: 'M_FR',
+        originalData: series,
+        '': {
+          value: undefined,
+          obsAttributes: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('uses OBS_VALUE attributes before observation values', () => {
+    const seriesAttribute = {
+      name: 'OBS_VALUE',
+      value: 'series-value',
+    } as TimeSeriesObservation;
+    const observationAttribute = {
+      name: 'OBS_VALUE',
+      value: 'observation-attribute-value',
+    } as TimeSeriesObservation;
+    const series = buildSeries({
+      name: 'Q.DE',
+      values: [buildValue('2020-Q1', 'raw-value', [observationAttribute])],
+      attributes: [seriesAttribute],
+    });
+
+    const [row] = getConvertedData([series], dimensions, timeDimensions);
+
+    expect(row['2020-Q1']).toEqual({
+      value: [seriesAttribute],
+      obsAttributes: [observationAttribute],
+    });
+  });
+});
+
+function buildSeries({
+  name,
+  values,
+  attributes = [],
+}: {
+  name: string;
+  values: TimeSeriesValue[];
+  attributes?: TimeSeriesObservation[];
+}): TimeSeries {
+  return {
+    name,
+    values,
+    attributes,
+  } as TimeSeries;
+}
+
+function buildValue(
+  dimensionAtObservation: string,
+  value: string,
+  obsAttributes: TimeSeriesObservation[] = [],
+): TimeSeriesValue {
+  return {
+    dimensionAtObservation,
+    values: [{ name: 'OBS_VALUE', value }],
+    obsAttributes,
+  } as TimeSeriesValue;
+}

--- a/libs/conversation-view/src/utils/attachments/data-grid/get-converted-data.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/get-converted-data.ts
@@ -32,30 +32,43 @@ export const getGridData = (
   columns: string[],
   rows: string[],
 ): GridData[] => {
-  const flatData = getFlatDataForPivot(data, dimensions);
-
   const gridData: Record<string, GridData> = {};
 
-  for (const key of flatData) {
-    const cell = key.rowTime as GridData;
-    const rowKey = getKey(cell, rows);
-    if (gridData[rowKey] == null) {
-      gridData[rowKey] = {};
+  for (const timeSeries of data) {
+    const row = getSeriesRow(timeSeries, dimensions);
+    const rowKey = getKey(row, rows);
+    let gridRow = gridData[rowKey];
 
-      for (const row of rows) {
-        (gridData[rowKey] as GridData)[row] = cell[row];
+    if (gridRow == null) {
+      gridRow = {};
+      gridData[rowKey] = gridRow;
+
+      for (const rowId of rows) {
+        gridRow[rowId] = row[rowId];
       }
     }
 
-    gridData[rowKey] = {
-      attributes: (key.attributes as TimeSeriesObservation[]).filter(
-        ({ value }: TimeSeriesObservation) => value,
-      ),
-      ...gridData[rowKey],
-      id: rowKey,
-      originalData: key.originalData,
-      ...fillCellValue(cell, columns),
-    };
+    const attributes = getFilledAttributes(timeSeries.attributes);
+    fillRowMetadata(gridRow, rowKey, attributes, timeSeries);
+
+    if (!timeSeries.values.length) {
+      fillCellValue(gridRow, row, columns);
+      continue;
+    }
+
+    for (const timeSeriesValue of timeSeries.values) {
+      const obsAttributes = getFilledAttributes(timeSeriesValue.obsAttributes);
+
+      fillRowMetadata(gridRow, rowKey, attributes, timeSeries);
+      fillCellValue(
+        gridRow,
+        row,
+        columns,
+        timeSeriesValue.dimensionAtObservation,
+        getCellValue(timeSeries, timeSeriesValue),
+        obsAttributes,
+      );
+    }
   }
 
   return Object.values(gridData);
@@ -64,75 +77,81 @@ export const getGridData = (
 const getKey = (cell: GridData, dimensions: string[]): string =>
   dimensions.map((dimension) => cell[dimension]).join('_');
 
-const fillCellValue = (cell: GridData, columns: string[]): GridData => {
-  const key = getKey(cell, columns);
-  const { OBS_VALUE, obsAttributes } = cell;
+const getObservationKey = (
+  row: GridData,
+  columns: string[],
+  timePeriod?: string,
+): string =>
+  columns
+    .map((column) => (column === 'TIME_PERIOD' ? timePeriod : row[column]))
+    .join('_');
 
-  const gridData: GridData = {};
-  gridData[key] = {
-    value: OBS_VALUE,
+const fillCellValue = (
+  gridRow: GridData,
+  row: GridData,
+  columns: string[],
+  timePeriod?: string,
+  value?: TimeSeriesObservation[],
+  obsAttributes?: TimeSeriesObservation[],
+): void => {
+  const key = getObservationKey(row, columns, timePeriod);
+
+  gridRow[key] = {
+    value,
     obsAttributes,
   };
-
-  return gridData;
 };
 
-const getFlatDataForPivot = (
-  data: TimeSeries[],
+const getSeriesRow = (
+  timeSeries: TimeSeries,
   dimensions: string[],
-): GridData[] => {
-  const flatData: GridData[] = [];
+): GridData => {
+  const row: GridData = {};
+  const dimValues = timeSeries.name.split('.');
 
-  for (const timeSeries of data) {
-    const row: GridData = {};
-    const dimValues = timeSeries.name.split('.');
-
-    for (let index = 0; index < dimensions.length; index += 1) {
-      row[dimensions[index]] = dimValues[index];
-    }
-
-    if (!timeSeries.values.length) {
-      const rowTime = { ...row };
-      rowTime.TIME_PERIOD = undefined;
-      rowTime.OBS_VALUE = undefined;
-      flatData.push({
-        rowTime,
-        attributes: timeSeries.attributes,
-        id: timeSeries.name,
-        originalData: timeSeries,
-      });
-    }
-
-    timeSeries.values.forEach((timeSeriesValue) => {
-      const rowTime = { ...row };
-      // todo: delete TIME_PERIOD
-      rowTime.TIME_PERIOD = timeSeriesValue.dimensionAtObservation;
-
-      const value = getCellValue(timeSeries, timeSeriesValue);
-      // todo: delete OBS_VALUE
-      rowTime.OBS_VALUE = value;
-      rowTime.obsAttributes =
-        timeSeriesValue?.obsAttributes?.filter(({ value }) => value) || [];
-      flatData.push({
-        rowTime,
-        attributes: timeSeries.attributes,
-        id: timeSeries.name,
-        originalData: timeSeries,
-      });
-    });
+  for (let index = 0; index < dimensions.length; index += 1) {
+    row[dimensions[index]] = dimValues[index];
   }
 
-  return flatData;
+  return row;
 };
 
 const getCellValue = (
   timeSer: TimeSeries,
   timeSeriesValue: TimeSeriesValue,
 ): TimeSeriesObservation[] => {
-  const attributes = [...timeSer.attributes, ...timeSeriesValue.obsAttributes];
-  const attr = attributes.find(
-    ({ name }: TimeSeriesObservation) => name === 'OBS_VALUE',
-  );
+  const seriesAttribute = findObservationValueAttribute(timeSer.attributes);
+  if (seriesAttribute) {
+    return [seriesAttribute];
+  }
 
-  return attr ? [attr] : timeSeriesValue.values;
+  const obsAttribute = findObservationValueAttribute(
+    timeSeriesValue.obsAttributes,
+  );
+  if (obsAttribute) {
+    return [obsAttribute];
+  }
+
+  return timeSeriesValue.values;
+};
+
+const findObservationValueAttribute = (
+  attributes: TimeSeriesObservation[] = [],
+): TimeSeriesObservation | undefined =>
+  attributes.find(({ name }: TimeSeriesObservation) => name === 'OBS_VALUE');
+
+const getFilledAttributes = (
+  attributes: TimeSeriesObservation[] = [],
+): TimeSeriesObservation[] =>
+  attributes.filter(({ value }: TimeSeriesObservation) => value);
+
+const fillRowMetadata = (
+  gridRow: GridData,
+  rowKey: string,
+  attributes: TimeSeriesObservation[],
+  originalData: TimeSeries,
+): void => {
+  gridRow.attributes ??= attributes;
+  gridRow.id = rowKey;
+  gridRow.originalData = originalData;
 };


### PR DESCRIPTION
### Applicable issues

[Page is overloaded in some query with BIS dataset](https://github.com/epam/statgpt-global-trusted-data-commons/issues/179)

### Description of changes

**getConvertedData** (and its internal **getGridData**) converts raw SDMX **TimeSeries[]** into the flat **GridData[]** rows that the grid displays. The old implementation used a two-pass approach: first flatten every time series into an intermediate
array, then pivot that array into the final rows. This PR rewrites it as a single pass.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
