### PR TITLE
fix: reduce AG Grid re-renders

### DIFF
--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
@@ -82,6 +82,21 @@ const CrossDatasetGridAttachment: FC<Props> = ({
     [onApiReady],
   );
 
+  const gridContext = useMemo(
+    () => ({ externalLink, externalLinksMap }),
+    [externalLink, externalLinksMap],
+  );
+  const gridComponents = useMemo(
+    () => ({
+      [METADATA_CELL_RENDER]: MetadataCellRenderer,
+      [OBSERVATION_VALUE_CELL_RENDER]: ObservationValueCellRenderer,
+      [MERGED_DIMENSION_CELL_RENDER]: MergedDimensionCellRenderer,
+      [CHART_CELL_RENDER]: ChartCellRenderer,
+      [DATASET_DETAIL_CELL_RENDER]: DatasetDetailCellRenderer,
+    }),
+    [],
+  );
+
   //TODO: replace cell renderers
   const memoizedGrid = useMemo(
     () => (
@@ -91,21 +106,16 @@ const CrossDatasetGridAttachment: FC<Props> = ({
         rowData={rowData}
         enableCellTextSelection
         columnDefs={columnDefs}
-        context={{ externalLink, externalLinksMap }}
+        context={gridContext}
         domLayout="normal"
         tooltipShowDelay={0}
         tooltipShowMode="whenTruncated"
-        components={{
-          [METADATA_CELL_RENDER]: MetadataCellRenderer,
-          [OBSERVATION_VALUE_CELL_RENDER]: ObservationValueCellRenderer,
-          [MERGED_DIMENSION_CELL_RENDER]: MergedDimensionCellRenderer,
-          [CHART_CELL_RENDER]: ChartCellRenderer,
-          [DATASET_DETAIL_CELL_RENDER]: DatasetDetailCellRenderer,
-        }}
+        components={gridComponents}
+        valueCache
         onGridReady={handleGridReady}
       />
     ),
-    [rowData, columnDefs, handleGridReady, externalLink, externalLinksMap],
+    [rowData, columnDefs, gridContext, gridComponents, handleGridReady],
   );
 
   if (isLoading || isDataLoading) {

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
@@ -139,6 +139,16 @@ const CustomDataGridAttachment: FC<Props> = ({
     [onApiReady],
   );
 
+  const gridContext = useMemo(() => ({ externalLink }), [externalLink]);
+  const gridComponents = useMemo(
+    () => ({
+      [METADATA_CELL_RENDER]: MetadataCellRenderer,
+      [OBSERVATION_VALUE_CELL_RENDER]: ObservationValueCellRenderer,
+      [CHART_CELL_RENDER]: ChartCellRenderer,
+    }),
+    [],
+  );
+
   const memoizedGrid = useMemo(
     () => (
       <AgGridReact
@@ -148,18 +158,15 @@ const CustomDataGridAttachment: FC<Props> = ({
         rowData={rowData}
         enableCellTextSelection
         columnDefs={columnDefs}
-        context={{ externalLink }}
+        context={gridContext}
         domLayout="normal"
         tooltipShowDelay={0}
         tooltipShowMode="whenTruncated"
-        components={{
-          [METADATA_CELL_RENDER]: MetadataCellRenderer,
-          [OBSERVATION_VALUE_CELL_RENDER]: ObservationValueCellRenderer,
-          [CHART_CELL_RENDER]: ChartCellRenderer,
-        }}
+        components={gridComponents}
+        valueCache
       />
     ),
-    [rowData, columnDefs, handleGridReady, externalLink],
+    [rowData, columnDefs, handleGridReady, gridContext, gridComponents],
   );
 
   if (isLoading || isDataLoading) {

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellRenderer.tsx
@@ -1,124 +1,62 @@
 'use client';
 
-import { FC, useCallback, useMemo, useState } from 'react';
-import { ICellRendererParams } from 'ag-grid-community';
+import { FC, useCallback, useState } from 'react';
+
 import Metadata from '../../AdvancedView/Metadata/Metadata';
 import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
 import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
-import {
-  StructuralData,
-  getLastUpdatedTime,
-  getStructureComponentsMap,
-} from '@epam/statgpt-sdmx-toolkit';
-import {
-  getDatasetNameItem,
-  getDatasetInfoData,
-  getDimensionsFromParams,
-  getMetadataDescriptionItems,
-  getObsAttributesFromParams,
-  getObservationItem,
-  getStructureComponentsValues,
-  getTimeDimensionItem,
-} from '../../../utils/attachments/metadata';
-import { MetadataSettings } from '../../../models/metadata';
-import { ConversationViewTitles } from '../../../models/titles';
+import { getObsAttributesFromParams } from '../../../utils/attachments/metadata';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useAdvancedView } from '../../../context/AdvancedViewContext';
-import { getDateFormattedValue } from '../../../utils/date-format';
+import {
+  getObservationMetadataContent,
+  ObservationMetadataContent,
+  ObservationValueCellRendererParams,
+} from './helpers/get-observation-metadata-content';
 
-interface ObservationValueCellRendererParams extends ICellRendererParams {
-  dataSetData: StructuralData;
-  structuresMap?: Map<string, StructuralData | undefined>;
-  locale: string;
-  metadataSettings?: MetadataSettings;
-  titles?: ConversationViewTitles;
-}
+const METADATA_SIDE_PANEL_ID = 'observation-metadata-side-panel';
 
 const ObservationValueCellRenderer: FC<ObservationValueCellRendererParams> = (
   params: ObservationValueCellRendererParams,
 ) => {
-  const METADATA_SIDE_PANEL_ID = 'observation-metadata-side-panel';
+  const obsAttributes = getObsAttributesFromParams(params);
 
-  const [isOpenMetadata, setIsOpenMetadata] = useState<boolean>(false);
+  if (!obsAttributes?.length) {
+    return (
+      <div className="relative size-full p-2 text-end">
+        {params?.valueFormatted || params?.value}
+      </div>
+    );
+  }
+
+  return (
+    <ObservationValueCellWithMetadata
+      params={params}
+      obsAttributes={obsAttributes}
+    />
+  );
+};
+
+interface ObservationValueCellWithMetadataProps {
+  params: ObservationValueCellRendererParams;
+  obsAttributes: NonNullable<ReturnType<typeof getObsAttributesFromParams>>;
+}
+
+const ObservationValueCellWithMetadata: FC<
+  ObservationValueCellWithMetadataProps
+> = ({ params, obsAttributes }) => {
+  const [metadataContent, setMetadataContent] =
+    useState<ObservationMetadataContent | null>(null);
   const { isOpenedAdvancedView } = useAdvancedView();
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
   const rowUrn = params?.data?.dataset?.urn as string | undefined;
   const externalLink = getExternalLinkFromContext(params?.context, rowUrn);
-  const dataSetData = useMemo(() => {
-    if (params.structuresMap) {
-      const urn = params?.data?.dataset?.urn as string | undefined;
-      return urn != null ? params.structuresMap.get(urn) : undefined;
-    }
-    return params.dataSetData;
-  }, [params.structuresMap, params.data, params.dataSetData]);
-  const structureComponentsMap = useMemo(
-    () => getStructureComponentsMap(dataSetData),
-    [dataSetData],
-  );
-  const attributes = useMemo(
-    () =>
-      getStructureComponentsValues(
-        getObsAttributesFromParams(params),
-        structureComponentsMap,
-        params?.locale,
-      ),
-    [params, structureComponentsMap],
-  );
-  const metadata = useMemo(
-    () => [
-      getDatasetNameItem(
-        dataSetData?.dataflows?.[0],
-        params?.locale,
-        params?.titles,
-      ),
-      ...getStructureComponentsValues(
-        getDimensionsFromParams(params, structureComponentsMap),
-        structureComponentsMap,
-        params?.locale,
-      ),
-      ...(!params?.metadataSettings?.isMetadataDescription
-        ? [
-            getTimeDimensionItem(dataSetData, params?.locale, params?.colDef),
-            getObservationItem(
-              params?.valueFormatted || params?.value,
-              params?.titles,
-            ),
-          ]
-        : []),
-      ...attributes,
-    ],
-    [params, dataSetData, structureComponentsMap, attributes],
-  );
-  const metadataDescription = useMemo(
-    () =>
-      getMetadataDescriptionItems(
-        dataSetData,
-        params?.locale,
-        params?.valueFormatted || params?.value,
-        params?.titles,
-        params?.colDef,
-        params?.data,
-      ),
-    [params, dataSetData],
-  );
-  const sidePanelDatasetInfo = useMemo(() => {
-    const dataset = dataSetData?.dataflows?.[0];
-    const lastUpdatedDate = getDateFormattedValue(
-      getLastUpdatedTime(dataset),
-      params?.locale,
-    );
-
-    return getDatasetInfoData(
-      dataset,
-      lastUpdatedDate,
-      params?.locale,
-      params?.titles,
-    );
-  }, [dataSetData, params?.locale, params?.titles]);
 
   const openMetadata = useCallback(() => {
+    const content = getObservationMetadataContent(params, obsAttributes);
+
     if (isMetadataInSidePanel && sidePanel) {
       sidePanel.openPanel({
         id: METADATA_SIDE_PANEL_ID,
@@ -129,14 +67,10 @@ const ObservationValueCellRenderer: FC<ObservationValueCellRendererParams> = (
           <SidePanelMetadataContent
             titles={params.titles}
             locale={params?.locale}
-            metadata={metadata}
-            datasetInfo={sidePanelDatasetInfo}
+            metadata={content.metadata}
+            datasetInfo={content.sidePanelDatasetInfo}
             externalLink={externalLink}
-            metadataDescription={
-              params?.metadataSettings?.isMetadataDescription
-                ? metadataDescription
-                : []
-            }
+            metadataDescription={content.metadataDescription}
           />
         ),
       });
@@ -144,47 +78,37 @@ const ObservationValueCellRenderer: FC<ObservationValueCellRendererParams> = (
       return;
     }
 
-    setIsOpenMetadata(true);
+    setMetadataContent(content);
   }, [
     isMetadataInSidePanel,
     isOpenedAdvancedView,
-    metadata,
-    metadataDescription,
-    sidePanelDatasetInfo,
     externalLink,
-    params?.locale,
-    params?.metadataSettings?.isMetadataDescription,
-    params.titles,
+    obsAttributes,
+    params,
     sidePanel,
   ]);
 
   const closeMetadata = useCallback(() => {
-    setIsOpenMetadata(false);
+    setMetadataContent(null);
   }, []);
 
   return (
     <>
       <div className="relative size-full p-2 text-end">
         {params?.valueFormatted || params?.value}
-        {attributes?.length > 0 && (
-          <div
-            className="metadata-indicator"
-            title={params.titles?.metadata || 'View details'}
-            onClick={openMetadata}
-          ></div>
-        )}
+        <div
+          className="metadata-indicator"
+          title={params.titles?.metadata || 'View details'}
+          onClick={openMetadata}
+        ></div>
       </div>
-      {isOpenMetadata && (
+      {metadataContent && (
         <Metadata
           titles={params.titles}
           locale={params?.locale}
-          metadata={metadata}
-          metadataDescription={
-            params?.metadataSettings?.isMetadataDescription
-              ? metadataDescription
-              : []
-          }
-          isOpenMetadata={isOpenMetadata}
+          metadata={metadataContent.metadata}
+          metadataDescription={metadataContent.metadataDescription}
+          isOpenMetadata
           onCloseMetadata={closeMetadata}
         />
       )}

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellRenderer.tsx
@@ -1,21 +1,10 @@
 'use client';
 
-import { FC, useCallback, useState } from 'react';
+import { FC } from 'react';
 
-import Metadata from '../../AdvancedView/Metadata/Metadata';
-import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
-import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
 import { getObsAttributesFromParams } from '../../../utils/attachments/metadata';
-import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
-import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
-import { useAdvancedView } from '../../../context/AdvancedViewContext';
-import {
-  getObservationMetadataContent,
-  ObservationMetadataContent,
-  ObservationValueCellRendererParams,
-} from './helpers/get-observation-metadata-content';
-
-const METADATA_SIDE_PANEL_ID = 'observation-metadata-side-panel';
+import { ObservationValueCellRendererParams } from './helpers/get-observation-metadata-content';
+import ObservationValueCellWithMetadata from './ObservationValueCellWithMetadata';
 
 const ObservationValueCellRenderer: FC<ObservationValueCellRendererParams> = (
   params: ObservationValueCellRendererParams,
@@ -35,84 +24,6 @@ const ObservationValueCellRenderer: FC<ObservationValueCellRendererParams> = (
       params={params}
       obsAttributes={obsAttributes}
     />
-  );
-};
-
-interface ObservationValueCellWithMetadataProps {
-  params: ObservationValueCellRendererParams;
-  obsAttributes: NonNullable<ReturnType<typeof getObsAttributesFromParams>>;
-}
-
-const ObservationValueCellWithMetadata: FC<
-  ObservationValueCellWithMetadataProps
-> = ({ params, obsAttributes }) => {
-  const [metadataContent, setMetadataContent] =
-    useState<ObservationMetadataContent | null>(null);
-  const { isOpenedAdvancedView } = useAdvancedView();
-  const sidePanel = useConversationViewSidePanelOptional();
-  const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
-  const rowUrn = params?.data?.dataset?.urn as string | undefined;
-  const externalLink = getExternalLinkFromContext(params?.context, rowUrn);
-
-  const openMetadata = useCallback(() => {
-    const content = getObservationMetadataContent(params, obsAttributes);
-
-    if (isMetadataInSidePanel && sidePanel) {
-      sidePanel.openPanel({
-        id: METADATA_SIDE_PANEL_ID,
-        scope: isOpenedAdvancedView ? 'advanced' : 'conversation',
-        title: params.titles?.metadata || 'Metadata',
-        bodyClassName: 'overflow-hidden',
-        content: (
-          <SidePanelMetadataContent
-            titles={params.titles}
-            locale={params?.locale}
-            metadata={content.metadata}
-            datasetInfo={content.sidePanelDatasetInfo}
-            externalLink={externalLink}
-            metadataDescription={content.metadataDescription}
-          />
-        ),
-      });
-
-      return;
-    }
-
-    setMetadataContent(content);
-  }, [
-    isMetadataInSidePanel,
-    isOpenedAdvancedView,
-    externalLink,
-    obsAttributes,
-    params,
-    sidePanel,
-  ]);
-
-  const closeMetadata = useCallback(() => {
-    setMetadataContent(null);
-  }, []);
-
-  return (
-    <>
-      <div className="relative size-full p-2 text-end">
-        {params?.valueFormatted || params?.value}
-        <div
-          className="metadata-indicator"
-          title={params.titles?.metadata || 'View details'}
-          onClick={openMetadata}
-        ></div>
-      </div>
-      {metadataContent && (
-        <Metadata
-          titles={params.titles}
-          locale={params?.locale}
-          metadata={metadataContent.metadata}
-          metadataDescription={metadataContent.metadataDescription}
-          isOpenMetadata
-          onCloseMetadata={closeMetadata}
-        />
-      )}
-    </>
   );
 };
 

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellWithMetadata.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellWithMetadata.tsx
@@ -1,0 +1,96 @@
+import { FC, useCallback, useState } from 'react';
+
+import Metadata from '../../AdvancedView/Metadata/Metadata';
+import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
+import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
+import { getObsAttributesFromParams } from '../../../utils/attachments/metadata';
+import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
+import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
+import { useAdvancedView } from '../../../context/AdvancedViewContext';
+import {
+  getObservationMetadataContent,
+  ObservationMetadataContent,
+  ObservationValueCellRendererParams,
+} from './helpers/get-observation-metadata-content';
+
+const METADATA_SIDE_PANEL_ID = 'observation-metadata-side-panel';
+
+interface ObservationValueCellWithMetadataProps {
+  params: ObservationValueCellRendererParams;
+  obsAttributes: NonNullable<ReturnType<typeof getObsAttributesFromParams>>;
+}
+
+const ObservationValueCellWithMetadata: FC<
+  ObservationValueCellWithMetadataProps
+> = ({ params, obsAttributes }) => {
+  const [metadataContent, setMetadataContent] =
+    useState<ObservationMetadataContent | null>(null);
+  const { isOpenedAdvancedView } = useAdvancedView();
+  const sidePanel = useConversationViewSidePanelOptional();
+  const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
+  const rowUrn = params?.data?.dataset?.urn as string | undefined;
+  const externalLink = getExternalLinkFromContext(params?.context, rowUrn);
+
+  const openMetadata = useCallback(() => {
+    const content = getObservationMetadataContent(params, obsAttributes);
+
+    if (isMetadataInSidePanel && sidePanel) {
+      sidePanel.openPanel({
+        id: METADATA_SIDE_PANEL_ID,
+        scope: isOpenedAdvancedView ? 'advanced' : 'conversation',
+        title: params.titles?.metadata || 'Metadata',
+        bodyClassName: 'overflow-hidden',
+        content: (
+          <SidePanelMetadataContent
+            titles={params.titles}
+            locale={params?.locale}
+            metadata={content.metadata}
+            datasetInfo={content.sidePanelDatasetInfo}
+            externalLink={externalLink}
+            metadataDescription={content.metadataDescription}
+          />
+        ),
+      });
+
+      return;
+    }
+
+    setMetadataContent(content);
+  }, [
+    isMetadataInSidePanel,
+    isOpenedAdvancedView,
+    externalLink,
+    obsAttributes,
+    params,
+    sidePanel,
+  ]);
+
+  const closeMetadata = useCallback(() => {
+    setMetadataContent(null);
+  }, []);
+
+  return (
+    <>
+      <div className="relative size-full p-2 text-end">
+        {params?.valueFormatted || params?.value}
+        <div
+          className="metadata-indicator"
+          title={params.titles?.metadata || 'View details'}
+          onClick={openMetadata}
+        ></div>
+      </div>
+      {metadataContent && (
+        <Metadata
+          titles={params.titles}
+          locale={params?.locale}
+          metadata={metadataContent.metadata}
+          metadataDescription={metadataContent.metadataDescription}
+          isOpenMetadata
+          onCloseMetadata={closeMetadata}
+        />
+      )}
+    </>
+  );
+};
+
+export default ObservationValueCellWithMetadata;

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/helpers/get-observation-metadata-content.ts
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/helpers/get-observation-metadata-content.ts
@@ -1,0 +1,102 @@
+import {
+  getDatasetInfoData,
+  getDatasetNameItem,
+  getDimensionsFromParams,
+  getMetadataDescriptionItems,
+  getObsAttributesFromParams,
+  getObservationItem,
+  getStructureComponentsValues,
+  getTimeDimensionItem,
+} from '../../../../utils/attachments/metadata';
+import { ICellRendererParams } from 'ag-grid-community';
+import {
+  getLastUpdatedTime,
+  getStructureComponentsMap,
+  StructuralData,
+} from '@epam/statgpt-sdmx-toolkit';
+import { getDateFormattedValue } from '../../../../utils/date-format';
+import { MetadataSettings } from '../../../../models/metadata';
+import { ConversationViewTitles } from '@epam/statgpt-conversation-view';
+
+export interface ObservationValueCellRendererParams extends ICellRendererParams {
+  dataSetData: StructuralData;
+  structuresMap?: Map<string, StructuralData | undefined>;
+  locale: string;
+  metadataSettings?: MetadataSettings;
+  titles?: ConversationViewTitles;
+}
+
+export type ObservationMetadataContent = ReturnType<
+  typeof getObservationMetadataContent
+>;
+
+export const getObservationMetadataContent = (
+  params: ObservationValueCellRendererParams,
+  obsAttributes: NonNullable<ReturnType<typeof getObsAttributesFromParams>>,
+) => {
+  const dataSetData = getDataSetData(params);
+  const structureComponentsMap = getStructureComponentsMap(dataSetData);
+  const value = params?.valueFormatted || params?.value;
+  const attributes = getStructureComponentsValues(
+    obsAttributes,
+    structureComponentsMap,
+    params?.locale,
+  );
+  const metadata = [
+    getDatasetNameItem(
+      dataSetData?.dataflows?.[0],
+      params?.locale,
+      params?.titles,
+    ),
+    ...getStructureComponentsValues(
+      getDimensionsFromParams(params, structureComponentsMap),
+      structureComponentsMap,
+      params?.locale,
+    ),
+    ...(!params?.metadataSettings?.isMetadataDescription
+      ? [
+          getTimeDimensionItem(dataSetData, params?.locale, params?.colDef),
+          getObservationItem(value, params?.titles),
+        ]
+      : []),
+    ...attributes,
+  ];
+  const metadataDescription = params?.metadataSettings?.isMetadataDescription
+    ? getMetadataDescriptionItems(
+        dataSetData,
+        params?.locale,
+        value,
+        params?.titles,
+        params?.colDef,
+        params?.data,
+      )
+    : [];
+  const dataset = dataSetData?.dataflows?.[0];
+  const lastUpdatedDate = getDateFormattedValue(
+    getLastUpdatedTime(dataset),
+    params?.locale,
+  );
+  const sidePanelDatasetInfo = getDatasetInfoData(
+    dataset,
+    lastUpdatedDate,
+    params?.locale,
+    params?.titles,
+  );
+
+  return {
+    metadata,
+    metadataDescription,
+    sidePanelDatasetInfo,
+  };
+};
+
+const getDataSetData = (
+  params: ObservationValueCellRendererParams,
+): StructuralData | undefined => {
+  if (params.structuresMap) {
+    const urn = params?.data?.dataset?.urn as string | undefined;
+    return urn != null ? params.structuresMap.get(urn) : undefined;
+  }
+
+  return params.dataSetData;
+};


### PR DESCRIPTION
### Applicable issues

[Page is overloaded in some query with BIS dataset](https://github.com/epam/statgpt-global-trusted-data-commons/issues/179)

### Description of changes

 Three targeted render optimizations with no behavioral changes.

**CustomGridAttachment** / **CrossDatasetGridAttachment** — context and components objects were recreated on every render, causing AG Grid to treat them as changed and re-render all cells. Both are now memoised with useMemo and stable
references.

**ObservationValueCellRenderer** — the component ran six useMemo hooks on every cell render to prepare metadata that the user may never open. Split into a lightweight outer renderer and an **ObservationValueCellWithMetadata** component where all metadata computation is deferred to the click handler. For datasets with many rows this means significantly less work per render cycle.

### Checklist


- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
