### PR TITLE
fix: defer grid building and compute chart data lazily

### DIFF
--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -2,8 +2,9 @@
 
 import { CustomChartAttachmentType } from '../../../models/attachments';
 import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { scheduleDeferredWork } from '../../../utils/deferred-work';
 import { Loader } from '@epam/statgpt-ui-components';
-import { ChartUnit } from '../../../models/charting';
+import { ChartingData, ChartUnit } from '../../../models/charting';
 import { ChartingIcon } from '../../../types/charting-icon';
 import ChartSidebar from './ChartSidebar';
 import Slider from './Slider';
@@ -43,6 +44,7 @@ const CustomChartAttachment: FC<Props> = ({
   titles,
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [chartingData, setChartingData] = useState<ChartingData>();
   const [flatUnits, setFlatUnits] = useState<FlatChartUnit[]>([]);
   const [chartIndex, setChartIndex] = useState<number>(0);
   const [selectedUnit, setSelectedUnit] = useState<ChartUnit | undefined>(
@@ -52,11 +54,39 @@ const CustomChartAttachment: FC<Props> = ({
   const { onboardingFileSchema, isShowOnboarding, setOnboardingFileSchema } =
     useOnboarding();
   const chartAttachmentRef = useRef<HTMLDivElement | null>(null);
+  const { charting_data: providedChartingData, getChartingData } = attachment;
 
   useEffect(() => {
-    setIsLoading(attachment.charting_data == null);
-    const groups = attachment.charting_data?.groups ?? [];
-    const units = attachment.charting_data?.units ?? [];
+    setChartIndex(0);
+
+    if (providedChartingData) {
+      setChartingData(providedChartingData);
+      setIsLoading(false);
+      return;
+    }
+
+    if (!getChartingData) {
+      setChartingData(undefined);
+      setIsLoading(true);
+      return;
+    }
+
+    setIsLoading(true);
+    return scheduleDeferredWork(() => {
+      try {
+        setChartingData(getChartingData());
+      } catch (err) {
+        console.error('Error building chart data', err as object);
+        setChartingData({ units: [] });
+      } finally {
+        setIsLoading(false);
+      }
+    });
+  }, [providedChartingData, getChartingData]);
+
+  useEffect(() => {
+    const groups = chartingData?.groups ?? [];
+    const units = chartingData?.units ?? [];
     setFlatUnits(
       groups.length > 0
         ? groups.flatMap((group) =>
@@ -64,7 +94,7 @@ const CustomChartAttachment: FC<Props> = ({
           )
         : units.map((unit) => ({ unit })),
     );
-  }, [attachment.charting_data]);
+  }, [chartingData]);
 
   useEffect(() => {
     const isChartIndexInRange = flatUnits.length > chartIndex;
@@ -125,7 +155,7 @@ const CustomChartAttachment: FC<Props> = ({
 
   return (
     <div className="chart-attachment size-full" ref={chartAttachmentRef}>
-      {attachment.charting_data && (
+      {chartingData && (
         <div className="flex size-full flex-col gap-4">
           {flatUnits.length == 0 || selectedUnit == null ? (
             <h4 className="ml-1">{titles?.chartInfo || 'No data'}</h4>

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ChartCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ChartCellRenderer.tsx
@@ -7,6 +7,7 @@ import ChartIcon from '../../../assets/icons/chart.svg';
 import { ICellRendererParams } from 'ag-grid-community';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ConversationViewTitles } from '../../../models/titles';
+import { ChartUnit, ChartUnitValue } from '../../../models/charting';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { getTooltipDataByElement } from '../../../utils/get-tooltip-data.by-element';
 import { OnboardingElements } from '../../../constants/onboarding-elements';
@@ -23,6 +24,7 @@ interface ChartCellRendererParams extends ICellRendererParams {
 
 const ChartCellRenderer = (params: ChartCellRendererParams) => {
   const [isOpenChart, setIsOpenChart] = useState<boolean>(false);
+  const [chart, setChart] = useState<ChartUnit>();
   const iconRef = useRef<HTMLDivElement | null>(null);
   const [tooltipTitle, setTooltipTitle] = useState<string>('');
   const [tooltipDescription, setTooltipDescription] = useState<string>('');
@@ -32,8 +34,9 @@ const ChartCellRenderer = (params: ChartCellRendererParams) => {
   const [isChartClosed, setIsChartClosed] = useState(false);
 
   const openChart = useCallback(() => {
+    setChart((currentChart) => currentChart ?? getChartUnit(params.value));
     setIsOpenChart(true);
-  }, []);
+  }, [params.value]);
 
   const closeChart = useCallback(() => {
     setIsOpenChart(false);
@@ -64,6 +67,10 @@ const ChartCellRenderer = (params: ChartCellRendererParams) => {
     isShowOnboarding,
   ]);
 
+  useEffect(() => {
+    setChart(undefined);
+  }, [params.value]);
+
   return (
     <>
       <div ref={iconRef}>
@@ -83,9 +90,9 @@ const ChartCellRenderer = (params: ChartCellRendererParams) => {
           shouldCloseTooltip={isChartClosed}
         />
       )}
-      {isOpenChart && (
+      {isOpenChart && chart && (
         <SingleLineChart
-          chart={params.value}
+          chart={chart}
           isOpen={isOpenChart}
           onClose={closeChart}
           titles={params.titles}
@@ -99,5 +106,11 @@ const ChartCellRenderer = (params: ChartCellRendererParams) => {
     </>
   );
 };
+
+function getChartUnit(
+  chartValue: ChartUnitValue | undefined,
+): ChartUnit | undefined {
+  return typeof chartValue === 'function' ? chartValue() : chartValue;
+}
 
 export default ChartCellRenderer;

--- a/libs/conversation-view/src/context/AttachmentsData.tsx
+++ b/libs/conversation-view/src/context/AttachmentsData.tsx
@@ -31,7 +31,7 @@ import {
 } from '../types/actions';
 import { buildCustomGridAttachment } from '../utils/attachments/data-grid/build-custom-grid-attachment';
 import { getTimeQueryFilterFromAttachment } from '../utils/query-filters';
-import { buildChartData } from '../utils/attachments/charting/chart-data';
+import { createChartDataResolver } from '../utils/attachments/charting/chart-data';
 import { ChartingStyles } from '../models/attachments-styles';
 import { MetadataSettings } from '../models/metadata';
 import { ConversationViewTitles } from '../models/titles';
@@ -47,6 +47,7 @@ import {
   createInitialGridAttachment,
   createInitialChartAttachment,
 } from '../constants/attachments';
+import { scheduleDeferredWork } from '../utils/deferred-work';
 
 export function useAttachmentsData(
   actions: {
@@ -85,6 +86,8 @@ export function useAttachmentsData(
     StructureItemBase[]
   >([]);
   const [isLoadingGridData, setIsLoadingGridData] = useState(false);
+  const [isBuildingGridAttachment, setIsBuildingGridAttachment] =
+    useState(false);
   const [selectedTimePeriod, setSelectedTimePeriod] = useState<TimeRange>({
     startPeriod: null,
     endPeriod: null,
@@ -160,6 +163,7 @@ export function useAttachmentsData(
           () => getDataSetData(dataQuery.urn, { filterKey, timeFilter }),
         )
           .then((data) => {
+            setIsBuildingGridAttachment(true);
             setDataMessage(data || void 0);
             setStructureDimensions(getStructureDimensions(data));
           })
@@ -214,6 +218,7 @@ export function useAttachmentsData(
         const timePeriodFilter = filters?.find(
           (filter) => filter.id === TIME_PERIOD,
         )?.timeRange;
+
         if (timePeriodFilter) {
           setSelectedTimePeriod(timePeriodFilter);
         }
@@ -223,6 +228,7 @@ export function useAttachmentsData(
           () => getDataSetData(dataQuery?.urn || '', filterParams),
         )
           .then((data) => {
+            setIsBuildingGridAttachment(true);
             setDataMessage(data || void 0);
             setStructureDimensions(getStructureDimensions(data));
           })
@@ -236,23 +242,38 @@ export function useAttachmentsData(
 
   useEffect(() => {
     if (structures != null && dataMessage != null && constraints?.length) {
-      setCustomGridAttachment((prev) => ({
-        ...prev,
-        ...buildCustomGridAttachment(
-          structures,
-          dataMessage,
-          dataQuery,
-          locale,
-          formattingSettings,
-          metadataSettings,
-          chartStyles,
-          titles,
-          putOnboardingFile,
-          constraints,
-          selectedTimePeriod,
-        ),
-      }));
+      setIsBuildingGridAttachment(true);
+
+      const cancel = scheduleDeferredWork(() => {
+        setCustomGridAttachment((prev) => ({
+          ...prev,
+          ...buildCustomGridAttachment(
+            structures,
+            dataMessage,
+            dataQuery,
+            locale,
+            formattingSettings,
+            metadataSettings,
+            chartStyles,
+            titles,
+            putOnboardingFile,
+            constraints,
+            selectedTimePeriod,
+          ),
+        }));
+        setIsBuildingGridAttachment(false);
+      });
+
+      return () => {
+        cancel();
+        setIsBuildingGridAttachment(false);
+      };
     }
+
+    if (dataMessage == null || constraints !== undefined) {
+      setIsBuildingGridAttachment(false);
+    }
+    return undefined;
   }, [
     structures,
     dataMessage,
@@ -271,7 +292,8 @@ export function useAttachmentsData(
     if (structures != null && dataMessage != null) {
       setCustomChartAttachment((prev) => ({
         ...prev,
-        charting_data: buildChartData(
+        charting_data: undefined,
+        getChartingData: createChartDataResolver(
           structures,
           dataMessage,
           dataQuery,
@@ -307,7 +329,7 @@ export function useAttachmentsData(
     structureDimensions,
     onFiltersChange,
     constraints,
-    isLoadingGridData,
+    isLoadingGridData: isLoadingGridData || isBuildingGridAttachment,
     dataSetAttachments: attachments,
   };
 }

--- a/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
+++ b/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
@@ -3,7 +3,6 @@ import {
   DataConstraints,
   DatasetDimensionsScheme,
   DatasetQueryFilters,
-  getLocalizedName,
 } from '@epam/statgpt-sdmx-toolkit';
 import { DataQuery, FormatNumbersType } from '@epam/statgpt-shared-toolkit';
 import {
@@ -34,7 +33,8 @@ import {
 import { buildCrossDatasetGridAttachment } from '../utils/attachments/cross-dataset-grid/build-cross-dataset-grid-attachment';
 import { MetadataSettings } from '../models/metadata';
 import { StructureDataMaps } from '../models/structure-data';
-import { buildChartData } from '../utils/attachments/charting/chart-data';
+import { createCrossDatasetChartingDataResolver } from '../utils/attachments/charting/cross-dataset-chart-data';
+import { scheduleDeferredWork } from '../utils/deferred-work';
 
 export function useAttachmentsDataMultipleQueries(
   actions: {
@@ -55,6 +55,10 @@ export function useAttachmentsDataMultipleQueries(
   const [datasetDimensionsSchemesMap, setDatasetDimensionsSchemesMap] =
     useState<Map<string, DatasetDimensionsScheme | undefined>>();
   const [isLoadingGridData, setIsLoadingGridData] = useState(false);
+  const [
+    isBuildingCrossDatasetGridAttachment,
+    setIsBuildingCrossDatasetGridAttachment,
+  ] = useState(false);
 
   const [crossDatasetGridAttachment, setCrossDatasetGridAttachment] =
     useState<CustomGridAttachment>(
@@ -178,26 +182,39 @@ export function useAttachmentsDataMultipleQueries(
       datasetDimensionsSchemesMap != null &&
       !isLoadingGridData
     ) {
-      setCrossDatasetGridAttachment((prev) => ({
-        ...prev,
-        ...buildCrossDatasetGridAttachment(
-          structuresMap,
-          dataMessagesMap,
-          datasetDimensionsSchemesMap,
-          dataQueries || [],
-          locale,
-          formattingSettings,
-          metadataSettings,
-          chartStyles,
-          titles,
-          constraintsMap,
-          {
-            startPeriod: null,
-            endPeriod: null,
-          },
-        ),
-      }));
+      setIsBuildingCrossDatasetGridAttachment(true);
+
+      const cancel = scheduleDeferredWork(() => {
+        setCrossDatasetGridAttachment((prev) => ({
+          ...prev,
+          ...buildCrossDatasetGridAttachment(
+            structuresMap,
+            dataMessagesMap,
+            datasetDimensionsSchemesMap,
+            dataQueries || [],
+            locale,
+            formattingSettings,
+            metadataSettings,
+            chartStyles,
+            titles,
+            constraintsMap,
+            {
+              startPeriod: null,
+              endPeriod: null,
+            },
+          ),
+        }));
+        setIsBuildingCrossDatasetGridAttachment(false);
+      });
+
+      return () => {
+        cancel();
+        setIsBuildingCrossDatasetGridAttachment(false);
+      };
     }
+
+    setIsBuildingCrossDatasetGridAttachment(false);
+    return undefined;
   }, [
     structureDataMaps,
     dataQueries,
@@ -219,36 +236,16 @@ export function useAttachmentsDataMultipleQueries(
       dataMessagesMap != null &&
       !isLoadingGridData
     ) {
-      const chartGroups = (dataQueries || []).flatMap((dataQuery) => {
-        const structures = structuresMap.get(dataQuery.urn);
-        const dataMessage = dataMessagesMap.get(dataQuery.urn);
-
-        if (!structures || !dataMessage) {
-          return [];
-        }
-
-        const datasetName = getLocalizedName(structures.dataflows?.[0], locale);
-
-        return [
-          {
-            title: datasetName,
-            units: buildChartData(
-              structures,
-              dataMessage,
-              dataQuery,
-              locale,
-              chartStyles,
-            ).units,
-          },
-        ];
-      });
-
       setCrossDatasetChartAttachment((prev) => ({
         ...prev,
-        charting_data: {
-          units: chartGroups.flatMap((group) => group.units),
-          groups: chartGroups,
-        },
+        charting_data: undefined,
+        getChartingData: createCrossDatasetChartingDataResolver(
+          structuresMap,
+          dataMessagesMap,
+          dataQueries || [],
+          locale,
+          chartStyles,
+        ),
       }));
     }
   }, [structureDataMaps, dataQueries, locale, chartStyles, isLoadingGridData]);
@@ -281,6 +278,7 @@ export function useAttachmentsDataMultipleQueries(
             getDataSetDataAction,
           )
             .then(({ dataMessage, structureDimensions }) => {
+              setIsBuildingCrossDatasetGridAttachment(true);
               setStructureDataMaps((prevStructureDataMaps) => {
                 const dataMessagesMap = new Map(
                   prevStructureDataMaps?.dataMessagesMap,
@@ -314,7 +312,8 @@ export function useAttachmentsDataMultipleQueries(
   return {
     structureDataMaps,
     datasetDimensionsSchemesMap,
-    isLoadingGridData,
+    isLoadingGridData:
+      isLoadingGridData || isBuildingCrossDatasetGridAttachment,
     crossDatasetAttachments,
     onMultipleDataFiltersChange,
   };

--- a/libs/conversation-view/src/models/attachments.ts
+++ b/libs/conversation-view/src/models/attachments.ts
@@ -16,6 +16,7 @@ export interface CrossDatasetGridAttachmentType extends Attachment {
 
 export interface CustomChartAttachmentType extends Attachment {
   charting_data?: ChartingData;
+  getChartingData?: () => ChartingData;
 }
 
 export interface CustomCodeAttachment extends Attachment {

--- a/libs/conversation-view/src/models/charting.ts
+++ b/libs/conversation-view/src/models/charting.ts
@@ -12,6 +12,8 @@ export interface ChartUnit extends ChartUnitRows {
   limitedByRowsAmountTo: number | undefined;
 }
 
+export type ChartUnitValue = ChartUnit | (() => ChartUnit);
+
 export interface ChartUnitGroup {
   title?: string;
   units: ChartUnit[];

--- a/libs/conversation-view/src/utils/attachments/charting/__tests__/cross-dataset-chart-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/__tests__/cross-dataset-chart-data.spec.ts
@@ -1,0 +1,71 @@
+import { getLocalizedName } from '@epam/statgpt-sdmx-toolkit';
+import { buildChartData } from '../chart-data';
+import {
+  buildCrossDatasetChartingData,
+  createCrossDatasetChartingDataResolver,
+} from '../cross-dataset-chart-data';
+
+jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  getLocalizedName: jest.fn(),
+}));
+
+jest.mock('../chart-data', () => ({
+  buildChartData: jest.fn(),
+}));
+
+describe('cross-dataset chart data', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds chart groups for datasets with structures and data messages', () => {
+    const structures = { dataflows: [{ id: 'flow-1' }] };
+    const dataMessage = {};
+    const dataQuery = { urn: 'urn:1' };
+    const structuresMap = new Map([['urn:1', structures]]);
+    const dataMessagesMap = new Map([['urn:1', dataMessage]]);
+    const chartUnit = { config: {}, dimensions: [], rows: [] };
+
+    jest.mocked(getLocalizedName).mockReturnValue('Dataset 1');
+    jest.mocked(buildChartData).mockReturnValue({ units: [chartUnit] });
+
+    expect(
+      buildCrossDatasetChartingData(
+        structuresMap,
+        dataMessagesMap,
+        [dataQuery],
+        'en',
+      ),
+    ).toEqual({
+      units: [chartUnit],
+      groups: [{ title: 'Dataset 1', units: [chartUnit] }],
+    });
+  });
+
+  it('does not build charts until the resolver is called and caches the result', () => {
+    const structures = { dataflows: [{ id: 'flow-1' }] };
+    const dataMessage = {};
+    const dataQuery = { urn: 'urn:1' };
+    const structuresMap = new Map([['urn:1', structures]]);
+    const dataMessagesMap = new Map([['urn:1', dataMessage]]);
+    const chartUnit = { config: {}, dimensions: [], rows: [] };
+
+    jest.mocked(getLocalizedName).mockReturnValue('Dataset 1');
+    jest.mocked(buildChartData).mockReturnValue({ units: [chartUnit] });
+
+    const getChartingData = createCrossDatasetChartingDataResolver(
+      structuresMap,
+      dataMessagesMap,
+      [dataQuery],
+      'en',
+    );
+
+    expect(buildChartData).not.toHaveBeenCalled();
+
+    const firstResult = getChartingData();
+    const secondResult = getChartingData();
+
+    expect(firstResult).toBe(secondResult);
+    expect(buildChartData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/conversation-view/src/utils/attachments/charting/chart-data.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/chart-data.ts
@@ -40,7 +40,9 @@ export function buildChartData(
   locale: string,
   styles?: ChartingStyles,
 ): ChartingData {
-  const rows = getRowsData(data, structures, dataQuery, locale, styles);
+  const rows = getRowsData(data, structures, dataQuery, locale, styles, {
+    includeChartData: false,
+  });
   const timePeriods = getTimePeriods(data);
   const sortedTimePeriods = timePeriods.sort((a, b) => sortPeriods(a, b));
   const sortedDimensionsList = buildSortedNonRegionDimensionsList(
@@ -59,6 +61,28 @@ export function buildChartData(
     units: units.map((unit) =>
       buildUnit(unit, structures, dataQuery, sortedTimePeriods, locale, styles),
     ),
+  };
+}
+
+export function createChartDataResolver(
+  structures: StructuralData,
+  data: DataMessage,
+  dataQuery: DataQuery | undefined,
+  locale: string,
+  styles?: ChartingStyles,
+): () => ChartingData {
+  let cachedChartingData: ChartingData | undefined;
+
+  return () => {
+    cachedChartingData ??= buildChartData(
+      structures,
+      data,
+      dataQuery,
+      locale,
+      styles,
+    );
+
+    return cachedChartingData;
   };
 }
 

--- a/libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts
@@ -1,0 +1,68 @@
+import {
+  DataMessage,
+  getLocalizedName,
+  StructuralData,
+} from '@epam/statgpt-sdmx-toolkit';
+import { DataQuery } from '@epam/statgpt-shared-toolkit';
+import { ChartingData } from '../../../models/charting';
+import { ChartingStyles } from '../../../models/attachments-styles';
+import { buildChartData } from './chart-data';
+
+export function createCrossDatasetChartingDataResolver(
+  structuresMap: Map<string, StructuralData | undefined>,
+  dataMessagesMap: Map<string, DataMessage | null>,
+  dataQueries: DataQuery[],
+  locale: string,
+  chartStyles?: ChartingStyles,
+): () => ChartingData {
+  let cachedChartingData: ChartingData | undefined;
+
+  return () => {
+    cachedChartingData ??= buildCrossDatasetChartingData(
+      structuresMap,
+      dataMessagesMap,
+      dataQueries,
+      locale,
+      chartStyles,
+    );
+
+    return cachedChartingData;
+  };
+}
+
+export function buildCrossDatasetChartingData(
+  structuresMap: Map<string, StructuralData | undefined>,
+  dataMessagesMap: Map<string, DataMessage | null>,
+  dataQueries: DataQuery[],
+  locale: string,
+  chartStyles?: ChartingStyles,
+): ChartingData {
+  const groups = dataQueries.flatMap((dataQuery) => {
+    const structures = structuresMap.get(dataQuery.urn);
+    const dataMessage = dataMessagesMap.get(dataQuery.urn);
+
+    if (!structures || !dataMessage) {
+      return [];
+    }
+
+    const datasetName = getLocalizedName(structures.dataflows?.[0], locale);
+
+    return [
+      {
+        title: datasetName,
+        units: buildChartData(
+          structures,
+          dataMessage,
+          dataQuery,
+          locale,
+          chartStyles,
+        ).units,
+      },
+    ];
+  });
+
+  return {
+    units: groups.flatMap((group) => group.units),
+    groups,
+  };
+}

--- a/libs/conversation-view/src/utils/attachments/data-grid/__tests__/rows-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/__tests__/rows-data.spec.ts
@@ -1,0 +1,67 @@
+import {
+  getDimensions,
+  getParsedResponse,
+  getTimePeriods,
+  sortPeriods,
+} from '@epam/statgpt-sdmx-toolkit';
+import { CHART_COLUMN_ID } from '../../../../constants/grid';
+import { buildSingleLineUnit } from '../../charting/chart-data';
+import { getConvertedData } from '../get-converted-data';
+import { getRowsData } from '../rows-data';
+
+jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  getDimensions: jest.fn(),
+  getParsedResponse: jest.fn(),
+  getTimePeriods: jest.fn(),
+  sortPeriods: jest.fn(),
+}));
+
+jest.mock('../get-converted-data', () => ({
+  getConvertedData: jest.fn(),
+}));
+
+jest.mock('../../charting/chart-data', () => ({
+  buildSingleLineUnit: jest.fn(),
+}));
+
+describe('getRowsData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds single-line chart data only when the chart cell value is resolved', () => {
+    const data = {};
+    const structures = {};
+    const dataQuery = { urn: 'test-urn' };
+    const chartStyles = {};
+    const timeSeries = [{ name: 'A.US' }];
+    const rows = [{ FREQ: 'A', REF_AREA: 'US' }];
+    const chartUnit = { config: {}, dimensions: [], rows };
+
+    jest.mocked(getParsedResponse).mockReturnValue(timeSeries);
+    jest.mocked(getDimensions).mockReturnValue({
+      dimensions: [{ id: 'FREQ' }, { id: 'REF_AREA' }],
+      timeDimensions: [{ id: 'TIME_PERIOD' }],
+    });
+    jest.mocked(getConvertedData).mockReturnValue(rows);
+    jest.mocked(getTimePeriods).mockReturnValue(['2021', '2020']);
+    jest.mocked(sortPeriods).mockImplementation((a, b) => a.localeCompare(b));
+    jest.mocked(buildSingleLineUnit).mockReturnValue(chartUnit);
+
+    const result = getRowsData(data, structures, dataQuery, 'en', chartStyles);
+
+    expect(buildSingleLineUnit).not.toHaveBeenCalled();
+
+    const chartCellValue = result[0][CHART_COLUMN_ID];
+    expect(typeof chartCellValue).toBe('function');
+    expect((chartCellValue as () => unknown)()).toBe(chartUnit);
+    expect(buildSingleLineUnit).toHaveBeenCalledWith(
+      rows[0],
+      ['2020', '2021'],
+      structures,
+      dataQuery,
+      'en',
+      chartStyles,
+    );
+  });
+});

--- a/libs/conversation-view/src/utils/attachments/data-grid/rows-data.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/rows-data.ts
@@ -15,17 +15,27 @@ import { buildSingleLineUnit } from '../charting/chart-data';
 import { ChartingStyles } from '../../../models/attachments-styles';
 import { CHART_COLUMN_ID } from '../../../constants/grid';
 
+interface GetRowsDataOptions {
+  includeChartData?: boolean;
+}
+
 export function getRowsData(
   data: DataMessage,
   structures: StructuralData,
   dataQuery: DataQuery | undefined,
   locale: string,
   chartStyles?: ChartingStyles,
+  options: GetRowsDataOptions = {},
 ): GridData[] {
   const timeSeries: TimeSeries[] = data == null ? [] : getParsedResponse(data);
   const dimensions = getDimensions(structures)?.dimensions || [];
   const timeDimensions = getDimensions(structures)?.timeDimensions || [];
   const rows = getConvertedData(timeSeries, dimensions, timeDimensions);
+
+  if (options.includeChartData === false) {
+    return rows;
+  }
+
   return extendDataWithChart(
     rows,
     data,
@@ -49,14 +59,15 @@ function extendDataWithChart(
   return rows.map((row) => {
     return {
       ...row,
-      [CHART_COLUMN_ID]: buildSingleLineUnit(
-        row,
-        sortedTimePeriods,
-        structures,
-        dataQuery,
-        locale,
-        chartStyles,
-      ),
+      [CHART_COLUMN_ID]: () =>
+        buildSingleLineUnit(
+          row,
+          sortedTimePeriods,
+          structures,
+          dataQuery,
+          locale,
+          chartStyles,
+        ),
     };
   });
 }

--- a/libs/conversation-view/src/utils/deferred-work.ts
+++ b/libs/conversation-view/src/utils/deferred-work.ts
@@ -1,0 +1,20 @@
+type CancelDeferredWork = () => void;
+
+export function scheduleDeferredWork(callback: () => void): CancelDeferredWork {
+  if (typeof window === 'undefined') {
+    callback();
+    return () => undefined;
+  }
+
+  let timeoutId: number | undefined;
+  const frameId = window.requestAnimationFrame(() => {
+    timeoutId = window.setTimeout(callback, 0);
+  });
+
+  return () => {
+    window.cancelAnimationFrame(frameId);
+    if (timeoutId != null) {
+      window.clearTimeout(timeoutId);
+    }
+  };
+}


### PR DESCRIPTION
### Applicable issues

[Page is overloaded in some query with BIS dataset](https://github.com/epam/statgpt-global-trusted-data-commons/issues/179)

### Description of changes

**Problem 1 — UI freezes on view switch**

Grid assembly (pivot, column building) ran synchronously on the main thread, blocking the browser from rendering the view transition. On large datasets this made switching between the conversation and advanced view feel frozen.

A **scheduleDeferredWork** utility now wraps grid building, so the view renders first and the grid assembles after paint.

**Problem 2 — Unnecessary upfront chart computation**

Chart data was computed eagerly on every data load even when the user never opens the chart tab or clicks a row chart.

 - Chart tab is now wrapped in a **createChartDataResolver** / **createCrossDatasetChartingDataResolver** - runs only when the chart tab is first opened.
 - Per-row chart is stored as a **() => ChartUnit** on each grid row instead of a pre-built object.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
