### PR TITLE
fix: share cross-dataset attachment state between advanced view and messages

### DIFF
--- a/apps/portals-example/src/app/[locale]/layout.tsx
+++ b/apps/portals-example/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import {
   OnboardingProvider,
   ChatMessagesProvider,
   ConversationViewFeatureTogglesProvider,
+  CrossDatasetAttachmentsProvider,
 } from '@epam/statgpt-conversation-view';
 import ConversationListWrapper from '../../components/ConversationList/ConversationListWrapper';
 import { ConversationListProvider } from '../../context/ConversationListContext';
@@ -94,14 +95,16 @@ export default async function LocaleLayout({
           >
             <OnboardingProvider>
               <AdvancedViewProvider>
-                <ConversationListProvider>
-                  <ChatMessagesProvider>
-                    <ConversationListWrapper
-                      clientContactSupportUrl={clientContactSupportUrl}
-                    />
-                    <main className="h-full min-w-0 flex-1">{children}</main>
-                  </ChatMessagesProvider>
-                </ConversationListProvider>
+                <CrossDatasetAttachmentsProvider>
+                  <ConversationListProvider>
+                    <ChatMessagesProvider>
+                      <ConversationListWrapper
+                        clientContactSupportUrl={clientContactSupportUrl}
+                      />
+                      <main className="h-full min-w-0 flex-1">{children}</main>
+                    </ChatMessagesProvider>
+                  </ConversationListProvider>
+                </CrossDatasetAttachmentsProvider>
               </AdvancedViewProvider>
             </OnboardingProvider>
           </ClientProvidersWrapper>

--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -8,7 +8,7 @@ import { AttachmentsConfig, AttachmentsProps } from '../../models/attachments';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
 import { MetadataSettings } from '../../models/metadata';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { AttachmentsActions } from '../../models/actions';
 import { DataQuery, FormatNumbersType } from '@epam/statgpt-shared-toolkit';
 import { Loader, LimitMessages } from '@epam/statgpt-ui-components';
@@ -29,6 +29,12 @@ import { useAdvancedView } from '../../context/AdvancedViewContext';
 import { ConversationViewSidePanelOutlet } from '../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useConversationViewFeatureToggles } from '../../context/ConversationViewFeatureTogglesContext';
 import { ConversationViewTitlesProvider } from '../../context/ConversationViewTitlesContext';
+import { useCrossDatasetAttachments } from '../../context/CrossDatasetAttachmentsContext';
+import { useDatasetDimensionsMetadataMap } from '../../context/DatasetDimensionsMetadataMapContext';
+import {
+  getCrossDatasetSnapshotKey,
+  getRestoredActiveDatasetUrns,
+} from '../../utils/multiple-filters';
 
 interface Props {
   filtersProps: FiltersProps;
@@ -71,8 +77,14 @@ export const AdvancedView: FC<Props> = ({
   );
 
   const { isOpenedAdvancedView } = useAdvancedView();
+  const {
+    activeDatasetUrns: sharedActiveDatasetUrns,
+    dataQueriesKey: sharedCrossDatasetDataQueriesKey,
+    setCrossDatasetAttachmentsState,
+  } = useCrossDatasetAttachments();
   const { isCrossDatasetModeOn, isMetadataInSidePanel } =
     useConversationViewFeatureToggles();
+  const datasetDimensionsMetadata = useDatasetDimensionsMetadataMap();
   const shouldShowDatasetInfo = !isMetadataInSidePanel;
   const datasets = attachmentsProps.datasets ?? [];
   const showDatasetTabs = datasets.length > 1 && !isCrossDatasetModeOn;
@@ -80,6 +92,17 @@ export const AdvancedView: FC<Props> = ({
   const lastMessageAttachments =
     props.filtersProps.conversation?.messages?.at(-1)?.custom_content
       ?.attachments;
+  const crossDatasetDataQueriesKey = useMemo(
+    () => getCrossDatasetSnapshotKey(attachmentsProps.dataQueries),
+    [attachmentsProps.dataQueries],
+  );
+  const initialActiveDatasetUrns =
+    sharedCrossDatasetDataQueriesKey === crossDatasetDataQueriesKey
+      ? sharedActiveDatasetUrns
+      : getRestoredActiveDatasetUrns(
+          attachmentsProps.dataQueries,
+          datasetDimensionsMetadata.map,
+        );
 
   const {
     dataMessage,
@@ -104,6 +127,7 @@ export const AdvancedView: FC<Props> = ({
   const {
     structureDataMaps,
     crossDatasetAttachments,
+    activeDatasetUrns,
     isLoadingGridData: isLoadingCrossDsGridData,
     onMultipleDataFiltersChange,
   } = useAttachmentsDataMultipleQueries(
@@ -114,7 +138,37 @@ export const AdvancedView: FC<Props> = ({
     formattingSettings,
     metadataSettings,
     lastMessageAttachments,
+    initialActiveDatasetUrns,
   );
+
+  useEffect(() => {
+    if (!isCrossDatasetModeOn || !attachmentsProps.dataQueries?.length) {
+      setCrossDatasetAttachmentsState();
+      return;
+    }
+
+    if (!structureDataMaps) {
+      return;
+    }
+
+    setCrossDatasetAttachmentsState({
+      attachments: crossDatasetAttachments,
+      dataQueriesKey: crossDatasetDataQueriesKey,
+      activeDatasetUrns: activeDatasetUrns
+        ? Array.from(activeDatasetUrns)
+        : undefined,
+      isLoading: isLoadingCrossDsGridData,
+    });
+  }, [
+    activeDatasetUrns,
+    attachmentsProps.dataQueries?.length,
+    crossDatasetAttachments,
+    crossDatasetDataQueriesKey,
+    isCrossDatasetModeOn,
+    isLoadingCrossDsGridData,
+    setCrossDatasetAttachmentsState,
+    structureDataMaps,
+  ]);
   const [isFiltering, setIsFiltering] = useState<boolean>();
   const [filters, setFilters] = useState<DatasetQueryFilters>({
     filterKey: null,

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -31,6 +31,7 @@ import FilterSettings from '../Filters/FiltersModal/FiltersSettings';
 import ModalFooter from '../Filters/FiltersModal/ModalFooter';
 import {
   buildFiltersMap,
+  getCompatibleDatasetUrns,
   getConstraintsMapFromSettledResults,
   getConstraintsRequests,
   getFilledDatasetFiltersMap,
@@ -188,7 +189,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       const filtersMap = buildFiltersMap(
         filters,
         constraintsMapRef.current,
-        true,
+        false,
         datasetDimensionsMetadata.map,
       );
       const shouldTrackFilterValuesLoading = hasUncachedConstraintRequests(
@@ -469,7 +470,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       const filtersMap = buildFiltersMap(
         filtersToUpdate,
         constraintsMapRef.current,
-        true,
+        false,
         datasetDimensionsMetadata.map,
       );
       const currentConstraintsMap =
@@ -552,7 +553,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     const appliedFiltersMap = buildFiltersMap(
       modalFilters,
       constraintsMapRef.current,
-      true,
+      false,
       datasetDimensionsMetadata.map,
     );
     const appliedFilters = getFiltersByConstraints(
@@ -565,10 +566,14 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       datasetDimensionsMetadata.map,
     );
     const filtersParamsMap = getFiltersChangeParamsMap(appliedFiltersMap);
+    const compatibleUrns = getCompatibleDatasetUrns(
+      modalFilters,
+      dataQueries?.map((q) => q.urn) ?? [],
+    );
     onMultipleDataFiltersChange?.(
       filtersParamsMap,
       constraintsMapRef.current,
-      dataQueries,
+      dataQueries?.filter((q) => compatibleUrns.has(q.urn)),
     );
 
     setAppliedFilters(appliedFilters);
@@ -576,14 +581,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     setIsModalClosed(true);
 
     startTransition(() => {
-      addSystemMessage(
-        buildFiltersMap(
-          modalFilters,
-          constraintsMapRef.current,
-          true,
-          datasetDimensionsMetadata.map,
-        ),
-      );
+      addSystemMessage(appliedFiltersMap);
     });
   }, [
     getFiltersChangeParamsMap,

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -91,6 +91,8 @@ jest.mock('../../../../utils/multiple-filters', () => ({
     (mockGetQueryFiltersMap as any)(...args),
   setDataQueryFiltersMap: (...args: any[]) =>
     (mockSetDataQueryFiltersMap as any)(...args),
+  getCompatibleDatasetUrns: (_filters: any[], dataQueryUrns: string[]) =>
+    new Set(dataQueryUrns),
 }));
 
 jest.mock('../../../../utils/filters', () => ({
@@ -408,12 +410,12 @@ describe('MultiDatasetFilters', () => {
           }),
         ]),
         defaultProps.structureDataMaps.constraintsMap,
-        true,
+        false,
         expect.any(Object),
       );
     });
 
-    it('applies shared filter fallback when applying cross-dataset filters', async () => {
+    it('applies filters only with constraint-supported values when applying cross-dataset filters', async () => {
       const onMultipleDataFiltersChange = jest.fn();
       const sharedCountryFilter = makeSharedCountryFilter();
       const expandedFiltersMap = new Map([
@@ -481,7 +483,7 @@ describe('MultiDatasetFilters', () => {
           }),
         ]),
         defaultProps.structureDataMaps.constraintsMap,
-        true,
+        false,
         expect.any(Object),
       );
 

--- a/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
@@ -56,6 +56,12 @@ import MessageEdit from '../MessageEdit/MessageEdit';
 import { ChoiceButtons } from '../../ConversationOnboarding/ChoiceButtons/ChoiceButtons';
 import { useAttachmentsDataMultipleQueries } from '../../../context/AttachmentsDataMultipleQueries';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
+import { useCrossDatasetAttachments } from '../../../context/CrossDatasetAttachmentsContext';
+import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
+import {
+  getCrossDatasetSnapshotKey,
+  getRestoredActiveDatasetUrns,
+} from '../../../utils/multiple-filters';
 
 interface Props {
   message: MessageType;
@@ -129,6 +135,7 @@ const Message: FC<Props> = ({
   const [isDataSetAttachments, setIsDataSetAttachments] =
     useState<boolean>(false);
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
+  const datasetDimensionsMetadata = useDatasetDimensionsMetadataMap();
   const isUser = message.role === Role.User;
   const isSystem = message.role === Role.System;
   const {
@@ -167,6 +174,14 @@ const Message: FC<Props> = ({
         : void 0,
       isLoadingDatasets,
     );
+  const restoredActiveDatasetUrns = useMemo(
+    () =>
+      getRestoredActiveDatasetUrns(
+        attachmentsDataQueries,
+        datasetDimensionsMetadata.map,
+      ),
+    [attachmentsDataQueries, datasetDimensionsMetadata.map],
+  );
 
   const {
     crossDatasetAttachments,
@@ -179,12 +194,41 @@ const Message: FC<Props> = ({
     formattingSettings,
     metadataSettings,
     message.custom_content?.attachments,
+    restoredActiveDatasetUrns,
   );
   const { isOpenedAdvancedView } = useAdvancedView();
+  const {
+    attachments: sharedCrossDatasetAttachments,
+    dataQueriesKey: crossDatasetDataQueriesKey,
+    isLoading: isCrossDatasetLoading,
+  } = useCrossDatasetAttachments();
+  const messageCrossDatasetDataQueriesKey = useMemo(
+    () => getCrossDatasetSnapshotKey(attachmentsDataQueries),
+    [attachmentsDataQueries],
+  );
+  const shouldUseSharedCrossDatasetAttachments =
+    isCrossDatasetModeOn &&
+    !!showAdvancedView &&
+    sharedCrossDatasetAttachments != null &&
+    crossDatasetDataQueriesKey === messageCrossDatasetDataQueriesKey;
+  const visibleCrossDatasetAttachments = shouldUseSharedCrossDatasetAttachments
+    ? sharedCrossDatasetAttachments
+    : crossDatasetAttachments;
 
   const isDataLoading = useMemo(
-    () => (isCrossDatasetModeOn ? isLoadingCrossDsGridData : isLoadingGridData),
-    [isCrossDatasetModeOn, isLoadingCrossDsGridData, isLoadingGridData],
+    () =>
+      isCrossDatasetModeOn
+        ? shouldUseSharedCrossDatasetAttachments
+          ? isCrossDatasetLoading
+          : isLoadingCrossDsGridData
+        : isLoadingGridData,
+    [
+      isCrossDatasetModeOn,
+      isLoadingCrossDsGridData,
+      isLoadingGridData,
+      isCrossDatasetLoading,
+      shouldUseSharedCrossDatasetAttachments,
+    ],
   );
 
   const onEditClick = () => {
@@ -312,7 +356,7 @@ const Message: FC<Props> = ({
         attachments={
           isDataSetAttachments
             ? isCrossDatasetModeOn
-              ? crossDatasetAttachments
+              ? visibleCrossDatasetAttachments
               : dataSetAttachments
             : baseGridAttachments
         }
@@ -341,7 +385,7 @@ const Message: FC<Props> = ({
       isDataSetAttachments,
       dataSetAttachments,
       baseGridAttachments,
-      crossDatasetAttachments,
+      visibleCrossDatasetAttachments,
       datasets,
       initialSelectedDatasetUrn,
       messageStyles,

--- a/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
+++ b/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
@@ -106,6 +106,7 @@ import {
 import { updateConversationErrorContext } from '../../utils/conversation';
 import { clearRequestCache } from '../../utils/request-cache';
 import { ConversationViewSidePanelOutlet } from './SidePanel/ConversationViewSidePanelContext';
+import { useCrossDatasetAttachments } from '../../context/CrossDatasetAttachmentsContext';
 
 interface Props {
   conversationKey: string;
@@ -174,6 +175,7 @@ export const ConversationView: FC<Props> = ({
   const [isLoading, setIsLoading] = useState(true);
   const { isStreaming, setIsStreaming } = useChatMessages();
   const { isOpenedAdvancedView } = useAdvancedView();
+  const { setCrossDatasetAttachmentsState } = useCrossDatasetAttachments();
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
 
   const { isAgentAvailable } = useAgentAvailability();
@@ -748,6 +750,7 @@ export const ConversationView: FC<Props> = ({
 
   useEffect(() => {
     clearRequestCache();
+    setCrossDatasetAttachmentsState();
 
     async function fetchConversationById() {
       try {

--- a/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
+++ b/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   DataConstraints,
   DatasetDimensionsScheme,
@@ -48,6 +48,7 @@ export function useAttachmentsDataMultipleQueries(
   formattingSettings?: FormatNumbersType,
   metadataSettings?: MetadataSettings,
   rawAttachments?: Attachment[],
+  initialActiveDatasetUrns?: string[],
 ) {
   const [structureDataMaps, setStructureDataMaps] =
     useState<StructureDataMaps>();
@@ -55,6 +56,10 @@ export function useAttachmentsDataMultipleQueries(
   const [datasetDimensionsSchemesMap, setDatasetDimensionsSchemesMap] =
     useState<Map<string, DatasetDimensionsScheme | undefined>>();
   const [isLoadingGridData, setIsLoadingGridData] = useState(false);
+  const [activeDatasetUrns, setActiveDatasetUrns] =
+    useState<Set<string> | null>(
+      initialActiveDatasetUrns ? new Set(initialActiveDatasetUrns) : null,
+    );
 
   const [crossDatasetGridAttachment, setCrossDatasetGridAttachment] =
     useState<CustomGridAttachment>(
@@ -72,11 +77,21 @@ export function useAttachmentsDataMultipleQueries(
     getDataSetData: getDataSetDataAction,
   } = actions;
 
+  const dataQueriesRef = useRef(dataQueries);
+  dataQueriesRef.current = dataQueries;
+  const initialActiveDatasetUrnsRef = useRef(initialActiveDatasetUrns);
+  initialActiveDatasetUrnsRef.current = initialActiveDatasetUrns;
+
+  const dataQueriesUrnsKey = useMemo(
+    () => dataQueries?.map((q) => q.urn).join(',') ?? '',
+    [dataQueries],
+  );
+
   const loadConstraintsMap = useCallback(
     async (dataQueries: DataQuery[]) => {
       try {
         const constraintsMap = await getDataConstraintsMap(
-          dataQueries,
+          dataQueries.map((q) => ({ ...q, filters: [] })),
           getConstraints,
         );
         setStructureDataMaps((prevStructureDataMaps) => ({
@@ -129,15 +144,16 @@ export function useAttachmentsDataMultipleQueries(
   );
 
   useEffect(() => {
-    async function loadDataSets(dataQueries: DataQuery[]) {
+    async function loadDataSets(dq: DataQuery[]) {
+      const initialActiveDatasetUrns = initialActiveDatasetUrnsRef.current;
+      setActiveDatasetUrns(
+        initialActiveDatasetUrns ? new Set(initialActiveDatasetUrns) : null,
+      );
       setIsLoadingGridData(true);
 
       try {
-        loadDimensionsSchemes(dataQueries);
-        await Promise.all([
-          loadConstraintsMap(dataQueries),
-          loadStructureData(dataQueries),
-        ]);
+        loadDimensionsSchemes(dq);
+        await Promise.all([loadConstraintsMap(dq), loadStructureData(dq)]);
       } catch (err) {
         console.error('Error loading dataset details', err as object);
       } finally {
@@ -145,11 +161,12 @@ export function useAttachmentsDataMultipleQueries(
       }
     }
 
-    if (dataQueries?.length) {
-      loadDataSets(dataQueries);
+    const currentDataQueries = dataQueriesRef.current;
+    if (currentDataQueries?.length) {
+      loadDataSets(currentDataQueries);
     }
   }, [
-    dataQueries,
+    dataQueriesUrnsKey,
     loadConstraintsMap,
     loadDimensionsSchemes,
     loadStructureData,
@@ -178,13 +195,31 @@ export function useAttachmentsDataMultipleQueries(
       datasetDimensionsSchemesMap != null &&
       !isLoadingGridData
     ) {
+      const visibleDataQueries = activeDatasetUrns
+        ? (dataQueries || []).filter((q) => activeDatasetUrns.has(q.urn))
+        : dataQueries || [];
+      const visibleStructuresMap = activeDatasetUrns
+        ? new Map([...structuresMap].filter(([k]) => activeDatasetUrns.has(k)))
+        : structuresMap;
+      const visibleDataMessagesMap = activeDatasetUrns
+        ? new Map(
+            [...dataMessagesMap].filter(([k]) => activeDatasetUrns.has(k)),
+          )
+        : dataMessagesMap;
+      const visibleDimensionsSchemesMap = activeDatasetUrns
+        ? new Map(
+            [...datasetDimensionsSchemesMap].filter(([k]) =>
+              activeDatasetUrns.has(k),
+            ),
+          )
+        : datasetDimensionsSchemesMap;
       setCrossDatasetGridAttachment((prev) => ({
         ...prev,
         ...buildCrossDatasetGridAttachment(
-          structuresMap,
-          dataMessagesMap,
-          datasetDimensionsSchemesMap,
-          dataQueries || [],
+          visibleStructuresMap,
+          visibleDataMessagesMap,
+          visibleDimensionsSchemesMap,
+          visibleDataQueries,
           locale,
           formattingSettings,
           metadataSettings,
@@ -208,6 +243,7 @@ export function useAttachmentsDataMultipleQueries(
     titles,
     datasetDimensionsSchemesMap,
     isLoadingGridData,
+    activeDatasetUrns,
   ]);
 
   useEffect(() => {
@@ -219,7 +255,10 @@ export function useAttachmentsDataMultipleQueries(
       dataMessagesMap != null &&
       !isLoadingGridData
     ) {
-      const chartGroups = (dataQueries || []).flatMap((dataQuery) => {
+      const visibleDataQueries = activeDatasetUrns
+        ? (dataQueries || []).filter((q) => activeDatasetUrns.has(q.urn))
+        : dataQueries || [];
+      const chartGroups = visibleDataQueries.flatMap((dataQuery) => {
         const structures = structuresMap.get(dataQuery.urn);
         const dataMessage = dataMessagesMap.get(dataQuery.urn);
 
@@ -251,7 +290,14 @@ export function useAttachmentsDataMultipleQueries(
         },
       }));
     }
-  }, [structureDataMaps, dataQueries, locale, chartStyles, isLoadingGridData]);
+  }, [
+    structureDataMaps,
+    dataQueries,
+    locale,
+    chartStyles,
+    isLoadingGridData,
+    activeDatasetUrns,
+  ]);
 
   const crossDatasetAttachments = useMemo(
     () => [
@@ -266,15 +312,25 @@ export function useAttachmentsDataMultipleQueries(
     (
       filterParamsMap: Map<string, DatasetQueryFilters>,
       constraintsMap?: Map<string, DataConstraints[] | undefined>,
-      dataQueries?: DataQuery[],
+      compatibleDataQueries?: DataQuery[],
     ): void => {
       try {
         setIsLoadingGridData(true);
+        const compatibleUrns = new Set(
+          compatibleDataQueries?.map((q) => q.urn),
+        );
+        setActiveDatasetUrns(compatibleUrns);
         setStructureDataMaps((prevStructureDataMaps) => ({
           ...prevStructureDataMaps,
           constraintsMap,
         }));
-        dataQueries?.forEach((dataQuery) => {
+
+        if (!compatibleDataQueries?.length) {
+          setIsLoadingGridData(false);
+          return;
+        }
+
+        compatibleDataQueries.forEach((dataQuery) => {
           getDataSetData(
             dataQuery,
             filterParamsMap?.get(dataQuery?.urn) as DatasetQueryFilters,
@@ -316,6 +372,7 @@ export function useAttachmentsDataMultipleQueries(
     datasetDimensionsSchemesMap,
     isLoadingGridData,
     crossDatasetAttachments,
+    activeDatasetUrns,
     onMultipleDataFiltersChange,
   };
 }

--- a/libs/conversation-view/src/context/CrossDatasetAttachmentsContext.tsx
+++ b/libs/conversation-view/src/context/CrossDatasetAttachmentsContext.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { Attachment } from '@epam/ai-dial-shared';
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+interface CrossDatasetAttachmentsState {
+  attachments?: Attachment[];
+  dataQueriesKey?: string;
+  activeDatasetUrns?: string[];
+  isLoading?: boolean;
+  signature?: string;
+}
+
+interface CrossDatasetAttachmentsContextType extends CrossDatasetAttachmentsState {
+  setCrossDatasetAttachmentsState: (
+    state?: Omit<CrossDatasetAttachmentsState, 'signature'>,
+  ) => void;
+}
+
+const CrossDatasetAttachmentsContext = createContext<
+  CrossDatasetAttachmentsContextType | undefined
+>(undefined);
+const DEFAULT_CONTEXT: CrossDatasetAttachmentsContextType = {
+  setCrossDatasetAttachmentsState: () => undefined,
+};
+
+const getStateSignature = (
+  state?: Omit<CrossDatasetAttachmentsState, 'signature'>,
+) => {
+  if (!state) {
+    return '';
+  }
+
+  try {
+    return JSON.stringify({
+      dataQueriesKey: state.dataQueriesKey,
+      activeDatasetUrns: state.activeDatasetUrns,
+      isLoading: !!state.isLoading,
+      attachments: state.attachments,
+    });
+  } catch {
+    return JSON.stringify({
+      dataQueriesKey: state.dataQueriesKey,
+      activeDatasetUrns: state.activeDatasetUrns,
+      isLoading: !!state.isLoading,
+      attachmentsLength: state.attachments?.length ?? 0,
+    });
+  }
+};
+
+export const CrossDatasetAttachmentsProvider: FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [state, setState] = useState<CrossDatasetAttachmentsState>({});
+  const setCrossDatasetAttachmentsState = useCallback(
+    (nextState?: Omit<CrossDatasetAttachmentsState, 'signature'>) => {
+      const signature = getStateSignature(nextState);
+
+      setState((prevState) => {
+        if (prevState.signature === signature) {
+          return prevState;
+        }
+
+        return {
+          ...nextState,
+          isLoading: !!nextState?.isLoading,
+          signature,
+        };
+      });
+    },
+    [],
+  );
+  const value = useMemo(
+    () => ({
+      ...state,
+      setCrossDatasetAttachmentsState,
+    }),
+    [setCrossDatasetAttachmentsState, state],
+  );
+
+  return (
+    <CrossDatasetAttachmentsContext.Provider value={value}>
+      {children}
+    </CrossDatasetAttachmentsContext.Provider>
+  );
+};
+
+export const useCrossDatasetAttachments = () => {
+  const context = useContext(CrossDatasetAttachmentsContext);
+
+  if (context === undefined) {
+    return DEFAULT_CONTEXT;
+  }
+
+  return context;
+};

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -53,3 +53,8 @@ export {
   useConversationViewFeatureToggles,
 } from './context/ConversationViewFeatureTogglesContext';
 export type { ConversationViewFeatureToggles } from './context/ConversationViewFeatureTogglesContext';
+
+export {
+  CrossDatasetAttachmentsProvider,
+  useCrossDatasetAttachments,
+} from './context/CrossDatasetAttachmentsContext';

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -26,6 +26,7 @@ import {
   DataQuery,
   Locale,
   QueryFilter,
+  QueryFilterType,
   TimeRange,
 } from '@epam/statgpt-shared-toolkit';
 import { StructureDataMaps } from '../models/structure-data';
@@ -740,6 +741,92 @@ export const buildFiltersMap = (
       return filterMap;
     }, new Map<string, Filter[]>());
 };
+
+export const getCompatibleDatasetUrns = (
+  filters: Filter[],
+  dataQueryUrns: string[],
+): Set<string> => {
+  const sharedFiltersWithSelections = filters.filter(
+    (f): f is SharedFilter =>
+      f.filterType === 'shared' &&
+      !f.isTimeDimension &&
+      (f.dimensionValues?.some((v) => v.isSelectedValue) ?? false),
+  );
+
+  if (!sharedFiltersWithSelections.length) {
+    return new Set(dataQueryUrns);
+  }
+
+  return new Set(
+    dataQueryUrns.filter((urn) =>
+      sharedFiltersWithSelections.every((filter) =>
+        filter.dimensionValues?.some(
+          (v) =>
+            v.isSelectedValue &&
+            v.sourceValues?.some((sv) => sv.datasetUrn === urn),
+        ),
+      ),
+    ),
+  );
+};
+
+export const getRestoredActiveDatasetUrns = (
+  dataQueries?: DataQuery[],
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+): string[] | undefined => {
+  const selectedSharedFilterDatasetUrnsMap = new Map<string, Set<string>>();
+
+  dataQueries?.forEach((dataQuery) => {
+    dataQuery.filters?.forEach((queryFilter) => {
+      if (
+        queryFilter.operator === QueryFilterType.BETWEEN ||
+        !queryFilter.values?.length
+      ) {
+        return;
+      }
+
+      const config = getSharedFilterConfigForFilter(
+        {
+          id: queryFilter.componentCode,
+          datasetUrn: dataQuery.urn,
+          filterType: 'dataset',
+        },
+        datasetDimensionsMetadataMap,
+      );
+
+      if (!config || config.id === COMMON_TIME_PERIOD_FILTER_ID) {
+        return;
+      }
+
+      const datasetUrns =
+        selectedSharedFilterDatasetUrnsMap.get(config.id) ?? new Set<string>();
+      datasetUrns.add(dataQuery.urn);
+      selectedSharedFilterDatasetUrnsMap.set(config.id, datasetUrns);
+    });
+  });
+
+  if (!selectedSharedFilterDatasetUrnsMap.size) {
+    return undefined;
+  }
+
+  return (
+    dataQueries
+      ?.filter((dataQuery) =>
+        Array.from(selectedSharedFilterDatasetUrnsMap.values()).every(
+          (datasetUrns) => datasetUrns.has(dataQuery.urn),
+        ),
+      )
+      .map((dataQuery) => dataQuery.urn) ?? []
+  );
+};
+
+export const getCrossDatasetSnapshotKey = (dataQueries?: DataQuery[]) =>
+  JSON.stringify(
+    dataQueries?.map((dataQuery) => ({
+      urn: dataQuery.urn,
+      filters: dataQuery.filters ?? [],
+    })) ?? [],
+  );
 
 export const getFiltersByConstraints = (
   filtersMap: Map<string, Filter[]>,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
https://github.com/epam/statgpt-global-trusted-data-commons/issues/221

### Description of changes

This PR fixes cross-dataset filter synchronization so Advanced View and inline message grids show the same filtered dataset set. Shared non-time filters now only apply to datasets that actually support the selected values, so selecting `Quarterly` shows only compatible datasets instead of falling back to unfiltered data for incompatible ones.

The cross-dataset data hook now tracks active compatible dataset URNs, avoids full dataset reloads for filter-only `dataQueries` updates, and restores the active dataset set from persisted conversation filters after refresh. A dedicated `CrossDatasetAttachmentsProvider` shares the filtered cross-dataset attachment snapshot between Advanced View and the inline message grid, keyed by both dataset URNs and filters to avoid stale reuse across messages with the same datasets but different filters.

Base/single-dataset mode remains on the existing attachment path and should not be affected by these changes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
