### PR TITLE
fix: dropdown UX improvements

### DIFF
--- a/libs/conversation-view/src/utils/__tests__/filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/filters.spec.ts
@@ -1,7 +1,6 @@
 import {
   clearFilterValues,
   getDatasetFilters,
-  getFilterDisplaySettings,
   getHierarchyOptions,
   getFilterIdentity,
   getFilterNodesBySelection,
@@ -581,27 +580,6 @@ describe('getFilterNodesBySelection', () => {
     const result = getFilterNodesBySelection(node);
     expect(result[0]).toMatchObject({ id: 'EUROPE', isSelectedValue: false });
     expect(result.slice(1).every((n) => !n.isSelectedValue)).toBe(true);
-  });
-});
-
-// ─── getFilterDisplaySettings ─────────────────────────────────────────────────
-
-describe('getFilterDisplaySettings', () => {
-  it('returns two entries with default titles when no titles are provided', () => {
-    const settings = getFilterDisplaySettings();
-    expect(settings).toEqual([
-      { key: FilterDisplayMode.HIERARCHY, title: 'Hierarchy' },
-      { key: FilterDisplayMode.FLAT_LIST, title: 'Flat list' },
-    ]);
-  });
-
-  it('uses provided custom titles', () => {
-    const settings = getFilterDisplaySettings({
-      hierarchy: 'Baumstruktur',
-      flatList: 'Flachliste',
-    } as any);
-    expect(settings[0].title).toBe('Baumstruktur');
-    expect(settings[1].title).toBe('Flachliste');
   });
 });
 

--- a/libs/conversation-view/src/utils/filters.ts
+++ b/libs/conversation-view/src/utils/filters.ts
@@ -350,19 +350,6 @@ export const getFilterNodesBySelection = (
   ];
 };
 
-export const getFilterDisplaySettings = (titles?: ConversationViewTitles) => {
-  return [
-    {
-      key: FilterDisplayMode.HIERARCHY,
-      title: titles?.hierarchy || 'Hierarchy',
-    },
-    {
-      key: FilterDisplayMode.FLAT_LIST,
-      title: titles?.flatList || 'Flat list',
-    },
-  ];
-};
-
 export const getHierarchyOptions = ({
   isHierarchical,
   availableHierarchies,

--- a/libs/ui-components/src/components/Dropdown/Dropdown.spec.tsx
+++ b/libs/ui-components/src/components/Dropdown/Dropdown.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { Dropdown } from './Dropdown';
+
+describe('Dropdown', () => {
+  it('closes previously opened dropdown when another dropdown opens', async () => {
+    const { getByText, queryByText } = render(
+      <>
+        <Dropdown
+          triggerButton={<button type="button">Open first</button>}
+          options={[{ key: 'first', title: 'First option' }]}
+        />
+        <Dropdown
+          triggerButton={<button type="button">Open second</button>}
+          options={[{ key: 'second', title: 'Second option' }]}
+        />
+      </>,
+    );
+
+    fireEvent.click(getByText('Open first'));
+    expect(getByText('First option')).toBeInTheDocument();
+
+    fireEvent.click(getByText('Open second'));
+    expect(getByText('Second option')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(queryByText('First option')).not.toBeInTheDocument();
+    });
+  });
+
+  it('makes dropdown content scrollable', () => {
+    const { container, getByText } = render(
+      <Dropdown
+        triggerButton={<button type="button">Open</button>}
+        options={[{ key: 'option', title: 'Option' }]}
+      />,
+    );
+
+    fireEvent.click(getByText('Open'));
+
+    expect(container.querySelector('.dropdown-container')).toHaveStyle({
+      overflowY: 'auto',
+    });
+  });
+});

--- a/libs/ui-components/src/components/Dropdown/Dropdown.tsx
+++ b/libs/ui-components/src/components/Dropdown/Dropdown.tsx
@@ -1,14 +1,16 @@
-import { FC, ReactNode, useState } from 'react';
+import { FC, ReactNode, useEffect, useId, useState } from 'react';
 import {
   useFloating,
   offset,
   flip,
   shift,
+  size,
   useClick,
   useDismiss,
   autoUpdate,
   useInteractions,
 } from '@floating-ui/react';
+import type { Middleware } from '@floating-ui/react';
 import classNames from 'classnames';
 import { DropdownItem } from '../../models/dropdown-item';
 
@@ -23,6 +25,32 @@ interface Props {
   onOptionSelect?: (key: string) => void;
 }
 
+const dropdownOpenEventName = 'statgpt-dropdown-open';
+const dropdownViewportPadding = 8;
+
+const keepDropdownWithinViewport: Middleware = {
+  name: 'keepDropdownWithinViewport',
+  fn({ y, rects }) {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+
+    const viewportHeight =
+      document.documentElement.clientHeight || window.innerHeight;
+    const visibleDropdownHeight = Math.min(
+      rects.floating.height,
+      Math.max(0, viewportHeight - dropdownViewportPadding * 2),
+    );
+    const minY = dropdownViewportPadding;
+    const maxY =
+      viewportHeight - visibleDropdownHeight - dropdownViewportPadding;
+
+    return {
+      y: Math.min(Math.max(y, minY), Math.max(minY, maxY)),
+    };
+  },
+};
+
 export const Dropdown: FC<Props> = ({
   triggerButton,
   options,
@@ -33,12 +61,28 @@ export const Dropdown: FC<Props> = ({
   openedClassName,
   onOptionSelect,
 }) => {
+  const dropdownId = useId();
   const [open, setOpen] = useState(false);
   const { refs, floatingStyles, context } = useFloating({
     open,
     onOpenChange: !disabled ? setOpen : void 0,
     placement: 'bottom-end',
-    middleware: [offset(8), flip(), shift()],
+    strategy: 'fixed',
+    middleware: [
+      offset(dropdownViewportPadding),
+      flip({ padding: dropdownViewportPadding }),
+      size({
+        padding: dropdownViewportPadding,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.maxHeight = `${Math.max(
+            0,
+            availableHeight,
+          )}px`;
+        },
+      }),
+      shift({ padding: dropdownViewportPadding }),
+      keepDropdownWithinViewport,
+    ],
     whileElementsMounted: autoUpdate,
   });
 
@@ -48,6 +92,36 @@ export const Dropdown: FC<Props> = ({
     click,
     dismiss,
   ]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    window.dispatchEvent(
+      new CustomEvent(dropdownOpenEventName, { detail: dropdownId }),
+    );
+  }, [dropdownId, open]);
+
+  useEffect(() => {
+    const closeDropdown = (event: Event) => {
+      if (event instanceof CustomEvent && event.detail !== dropdownId) {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener(dropdownOpenEventName, closeDropdown);
+
+    return () => {
+      window.removeEventListener(dropdownOpenEventName, closeDropdown);
+    };
+  }, [dropdownId]);
+
+  useEffect(() => {
+    if (disabled) {
+      setOpen(false);
+    }
+  }, [disabled]);
 
   return (
     <>
@@ -65,7 +139,7 @@ export const Dropdown: FC<Props> = ({
       {open && (
         <div
           ref={refs.setFloating}
-          style={floatingStyles}
+          style={{ ...floatingStyles, overflowY: 'auto' }}
           className="dropdown-menu-shadow dropdown-container z-10 flex flex-col rounded bg-white"
           {...getFloatingProps()}
         >


### PR DESCRIPTION
### Applicable issues

[No scroll if there are many items in 'Display order' list](https://github.com/epam/statgpt-global-trusted-data-commons/issues/218)
[Prev 'Display order' drop down is not closed after open next one](https://github.com/epam/statgpt-global-trusted-data-commons/issues/217)

### Description of changes

Fixed Dropdown overflow and interaction behavior:
- Long dropdowns now stay within the screen and scroll internally.
- Opening a new dropdown closes the previously opened one.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
