### PR TITLE
fix: respect manual user filter and don't fallback to wildcard

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -32,7 +32,11 @@ import { ConversationViewSidePanelOutlet } from '../ConversationView/SidePanel/C
 import { useConversationViewFeatureToggles } from '../../context/ConversationViewFeatureTogglesContext';
 import { ConversationViewTitlesProvider } from '../../context/ConversationViewTitlesContext';
 import { useCrossDatasetAttachments } from '../../context/CrossDatasetAttachmentsContext';
-import { getCrossDatasetSnapshotKey } from '../../utils/multiple-filters';
+import { useDatasetDimensionsMetadataMap } from '../../context/DatasetDimensionsMetadataMapContext';
+import {
+  getCrossDatasetSnapshotKey,
+  getRestoredActiveDatasetUrns,
+} from '../../utils/multiple-filters';
 
 interface Props {
   filtersProps: FiltersProps;
@@ -75,9 +79,14 @@ export const AdvancedView: FC<Props> = ({
   );
 
   const { isOpenedAdvancedView } = useAdvancedView();
-  const { setCrossDatasetAttachmentsState } = useCrossDatasetAttachments();
+  const {
+    activeDatasetUrns: sharedActiveDatasetUrns,
+    dataQueriesKey: sharedCrossDatasetDataQueriesKey,
+    setCrossDatasetAttachmentsState,
+  } = useCrossDatasetAttachments();
   const { isCrossDatasetModeOn, isMetadataInSidePanel } =
     useConversationViewFeatureToggles();
+  const datasetDimensionsMetadata = useDatasetDimensionsMetadataMap();
   const shouldShowDatasetInfo = !isMetadataInSidePanel;
   const datasets = attachmentsProps.datasets ?? [];
   const showDatasetTabs = datasets.length > 1 && !isCrossDatasetModeOn;
@@ -89,6 +98,13 @@ export const AdvancedView: FC<Props> = ({
     () => getCrossDatasetSnapshotKey(attachmentsProps.dataQueries),
     [attachmentsProps.dataQueries],
   );
+  const initialActiveDatasetUrns =
+    sharedCrossDatasetDataQueriesKey === crossDatasetDataQueriesKey
+      ? sharedActiveDatasetUrns
+      : getRestoredActiveDatasetUrns(
+          attachmentsProps.dataQueries,
+          datasetDimensionsMetadata.map,
+        );
 
   const conversationRef = useRef(props.filtersProps.conversation);
   conversationRef.current = props.filtersProps.conversation;
@@ -145,6 +161,7 @@ export const AdvancedView: FC<Props> = ({
   const {
     structureDataMaps,
     crossDatasetAttachments,
+    activeDatasetUrns,
     isLoadingGridData: isLoadingCrossDsGridData,
     onMultipleDataFiltersChange,
   } = useAttachmentsDataMultipleQueries(
@@ -155,6 +172,7 @@ export const AdvancedView: FC<Props> = ({
     formattingSettings,
     metadataSettings,
     lastMessageAttachments,
+    initialActiveDatasetUrns,
     handleCodeAttachmentUpdated,
   );
 
@@ -171,9 +189,13 @@ export const AdvancedView: FC<Props> = ({
     setCrossDatasetAttachmentsState({
       attachments: crossDatasetAttachments,
       dataQueriesKey: crossDatasetDataQueriesKey,
+      activeDatasetUrns: activeDatasetUrns
+        ? Array.from(activeDatasetUrns)
+        : undefined,
       isLoading: isLoadingCrossDsGridData,
     });
   }, [
+    activeDatasetUrns,
     attachmentsProps.dataQueries?.length,
     crossDatasetAttachments,
     crossDatasetDataQueriesKey,

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -31,6 +31,7 @@ import FilterSettings from '../Filters/FiltersModal/FiltersSettings';
 import ModalFooter from '../Filters/FiltersModal/ModalFooter';
 import {
   buildFiltersMap,
+  getCompatibleDatasetUrns,
   getConstraintsMapFromSettledResults,
   getConstraintsRequests,
   getFilledDatasetFiltersMap,
@@ -565,10 +566,14 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       datasetDimensionsMetadata.map,
     );
     const filtersParamsMap = getFiltersChangeParamsMap(appliedFiltersMap);
+    const compatibleUrns = getCompatibleDatasetUrns(
+      modalFilters,
+      dataQueries?.map((q) => q.urn) ?? [],
+    );
     onMultipleDataFiltersChange?.(
       filtersParamsMap,
       constraintsMapRef.current,
-      dataQueries,
+      dataQueries?.filter((q) => compatibleUrns.has(q.urn)),
       appliedFiltersMap,
       appliedFilters,
     );

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -39,6 +39,9 @@ const mockGetFilledDatasetFiltersMap = jest.fn(
 );
 const mockGetQueryFiltersMap = jest.fn(() => new Map());
 const mockSetDataQueryFiltersMap = jest.fn(() => new Map());
+const mockGetCompatibleDatasetUrns = jest.fn(
+  (_filters: Filter[], dataQueryUrns: string[]) => new Set(dataQueryUrns),
+);
 const mockHasUncachedConstraintRequests = jest.fn(() => false);
 const mockMergeConstraintsMaps = jest.fn(
   (
@@ -91,6 +94,8 @@ jest.mock('../../../../utils/multiple-filters', () => ({
     (mockGetQueryFiltersMap as any)(...args),
   setDataQueryFiltersMap: (...args: any[]) =>
     (mockSetDataQueryFiltersMap as any)(...args),
+  getCompatibleDatasetUrns: (...args: any[]) =>
+    (mockGetCompatibleDatasetUrns as any)(...args),
 }));
 
 jest.mock('../../../../utils/filters', () => ({
@@ -261,6 +266,9 @@ beforeEach(() => {
   mockGetFilledDatasetFiltersMap.mockReturnValue(new Map());
   mockGetQueryFiltersMap.mockReturnValue(new Map());
   mockSetDataQueryFiltersMap.mockReturnValue(new Map());
+  mockGetCompatibleDatasetUrns.mockImplementation(
+    (_filters: Filter[], dataQueryUrns: string[]) => new Set(dataQueryUrns),
+  );
   mockHasUncachedConstraintRequests.mockReturnValue(false);
   mockMergeConstraintsMaps.mockImplementation(
     (

--- a/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
@@ -57,7 +57,11 @@ import { ChoiceButtons } from '../../ConversationOnboarding/ChoiceButtons/Choice
 import { useAttachmentsDataMultipleQueries } from '../../../context/AttachmentsDataMultipleQueries';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
 import { useCrossDatasetAttachments } from '../../../context/CrossDatasetAttachmentsContext';
-import { getCrossDatasetSnapshotKey } from '../../../utils/multiple-filters';
+import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
+import {
+  getCrossDatasetSnapshotKey,
+  getRestoredActiveDatasetUrns,
+} from '../../../utils/multiple-filters';
 
 interface Props {
   message: MessageType;
@@ -133,6 +137,7 @@ const Message: FC<Props> = ({
   const [isDataSetAttachments, setIsDataSetAttachments] =
     useState<boolean>(false);
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
+  const datasetDimensionsMetadata = useDatasetDimensionsMetadataMap();
   const isUser = message.role === Role.User;
   const isSystem = message.role === Role.System;
   const {
@@ -182,6 +187,15 @@ const Message: FC<Props> = ({
       handleCodeAttachmentUpdated,
     );
 
+  const restoredActiveDatasetUrns = useMemo(
+    () =>
+      getRestoredActiveDatasetUrns(
+        attachmentsDataQueries,
+        datasetDimensionsMetadata.map,
+      ),
+    [attachmentsDataQueries, datasetDimensionsMetadata.map],
+  );
+
   const {
     crossDatasetAttachments,
     isLoadingGridData: isLoadingCrossDsGridData,
@@ -193,6 +207,7 @@ const Message: FC<Props> = ({
     formattingSettings,
     metadataSettings,
     message.custom_content?.attachments,
+    restoredActiveDatasetUrns,
     handleCodeAttachmentUpdated,
   );
   const { isOpenedAdvancedView } = useAdvancedView();

--- a/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
+++ b/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
@@ -39,6 +39,10 @@ import { MetadataSettings } from '../models/metadata';
 import { StructureDataMaps } from '../models/structure-data';
 import { createCrossDatasetChartingDataResolver } from '../utils/attachments/charting/cross-dataset-chart-data';
 import { scheduleDeferredWork } from '../utils/deferred-work';
+import {
+  filterDataQueriesByActiveDatasetUrns,
+  filterMapByActiveDatasetUrns,
+} from '../utils/multiple-filters';
 
 export function useAttachmentsDataMultipleQueries(
   actions: {
@@ -53,14 +57,26 @@ export function useAttachmentsDataMultipleQueries(
   formattingSettings?: FormatNumbersType,
   metadataSettings?: MetadataSettings,
   rawAttachments?: Attachment[],
+  initialActiveDatasetUrns?: string[],
   onCodeAttachmentUpdated?: (attachment: Attachment) => void,
 ) {
+  const normalizedInitialActiveDatasetUrns = Array.isArray(
+    initialActiveDatasetUrns,
+  )
+    ? initialActiveDatasetUrns
+    : undefined;
   const [structureDataMaps, setStructureDataMaps] =
     useState<StructureDataMaps>();
   const titles = useConversationViewTitles();
   const [datasetDimensionsSchemesMap, setDatasetDimensionsSchemesMap] =
     useState<Map<string, DatasetDimensionsScheme | undefined>>();
   const [isLoadingGridData, setIsLoadingGridData] = useState(false);
+  const [activeDatasetUrns, setActiveDatasetUrns] =
+    useState<Set<string> | null>(
+      normalizedInitialActiveDatasetUrns
+        ? new Set(normalizedInitialActiveDatasetUrns)
+        : null,
+    );
   const [
     isBuildingCrossDatasetGridAttachment,
     setIsBuildingCrossDatasetGridAttachment,
@@ -87,6 +103,10 @@ export function useAttachmentsDataMultipleQueries(
 
   const dataQueriesRef = useRef(compatibleDataQueries);
   dataQueriesRef.current = compatibleDataQueries;
+  const initialActiveDatasetUrnsRef = useRef(
+    normalizedInitialActiveDatasetUrns,
+  );
+  initialActiveDatasetUrnsRef.current = normalizedInitialActiveDatasetUrns;
 
   const dataQueriesUrnsKey = useMemo(
     () => compatibleDataQueries?.map((q) => q.urn).join(',') ?? '',
@@ -151,6 +171,10 @@ export function useAttachmentsDataMultipleQueries(
 
   useEffect(() => {
     async function loadDataSets(dq: DataQuery[]) {
+      const restoredDatasetUrns = initialActiveDatasetUrnsRef.current;
+      setActiveDatasetUrns(
+        restoredDatasetUrns ? new Set(restoredDatasetUrns) : null,
+      );
       setIsLoadingGridData(true);
 
       try {
@@ -202,13 +226,30 @@ export function useAttachmentsDataMultipleQueries(
       setIsBuildingCrossDatasetGridAttachment(true);
 
       const cancel = scheduleDeferredWork(() => {
+        const visibleDataQueries = filterDataQueriesByActiveDatasetUrns(
+          compatibleDataQueries,
+          activeDatasetUrns,
+        );
+        const visibleStructuresMap = filterMapByActiveDatasetUrns(
+          structuresMap,
+          activeDatasetUrns,
+        );
+        const visibleDataMessagesMap = filterMapByActiveDatasetUrns(
+          dataMessagesMap,
+          activeDatasetUrns,
+        );
+        const visibleDimensionsSchemesMap = filterMapByActiveDatasetUrns(
+          datasetDimensionsSchemesMap,
+          activeDatasetUrns,
+        );
+
         setCrossDatasetGridAttachment((prev) => ({
           ...prev,
           ...buildCrossDatasetGridAttachment(
-            structuresMap,
-            dataMessagesMap,
-            datasetDimensionsSchemesMap,
-            compatibleDataQueries || [],
+            visibleStructuresMap,
+            visibleDataMessagesMap,
+            visibleDimensionsSchemesMap,
+            visibleDataQueries,
             locale,
             formattingSettings,
             metadataSettings,
@@ -242,6 +283,7 @@ export function useAttachmentsDataMultipleQueries(
     titles,
     datasetDimensionsSchemesMap,
     isLoadingGridData,
+    activeDatasetUrns,
   ]);
 
   useEffect(() => {
@@ -253,13 +295,26 @@ export function useAttachmentsDataMultipleQueries(
       dataMessagesMap != null &&
       !isLoadingGridData
     ) {
+      const visibleDataQueries = filterDataQueriesByActiveDatasetUrns(
+        compatibleDataQueries,
+        activeDatasetUrns,
+      );
+      const visibleStructuresMap = filterMapByActiveDatasetUrns(
+        structuresMap,
+        activeDatasetUrns,
+      );
+      const visibleDataMessagesMap = filterMapByActiveDatasetUrns(
+        dataMessagesMap,
+        activeDatasetUrns,
+      );
+
       setCrossDatasetChartAttachment((prev) => ({
         ...prev,
         charting_data: undefined,
         getChartingData: createCrossDatasetChartingDataResolver(
-          structuresMap,
-          dataMessagesMap,
-          compatibleDataQueries || [],
+          visibleStructuresMap,
+          visibleDataMessagesMap,
+          visibleDataQueries,
           locale,
           chartStyles,
         ),
@@ -271,6 +326,7 @@ export function useAttachmentsDataMultipleQueries(
     locale,
     chartStyles,
     isLoadingGridData,
+    activeDatasetUrns,
   ]);
 
   const crossDatasetAttachments = useMemo(
@@ -292,6 +348,8 @@ export function useAttachmentsDataMultipleQueries(
     ): void => {
       try {
         setIsLoadingGridData(true);
+        const compatibleUrns = new Set(dataQueries?.map((q) => q.urn));
+        setActiveDatasetUrns(compatibleUrns);
         setStructureDataMaps((prevStructureDataMaps) => ({
           ...prevStructureDataMaps,
           constraintsMap,
@@ -369,6 +427,7 @@ export function useAttachmentsDataMultipleQueries(
     isLoadingGridData:
       isLoadingGridData || isBuildingCrossDatasetGridAttachment,
     crossDatasetAttachments,
+    activeDatasetUrns,
     onMultipleDataFiltersChange,
   };
 }

--- a/libs/conversation-view/src/context/CrossDatasetAttachmentsContext.tsx
+++ b/libs/conversation-view/src/context/CrossDatasetAttachmentsContext.tsx
@@ -14,6 +14,7 @@ import {
 interface CrossDatasetAttachmentsState {
   attachments?: Attachment[];
   dataQueriesKey?: string;
+  activeDatasetUrns?: string[];
   isLoading?: boolean;
   signature?: string;
 }
@@ -41,12 +42,14 @@ const getStateSignature = (
   try {
     return JSON.stringify({
       dataQueriesKey: state.dataQueriesKey,
+      activeDatasetUrns: state.activeDatasetUrns,
       isLoading: !!state.isLoading,
       attachments: state.attachments,
     });
   } catch {
     return JSON.stringify({
       dataQueriesKey: state.dataQueriesKey,
+      activeDatasetUrns: state.activeDatasetUrns,
       isLoading: !!state.isLoading,
       attachmentsLength: state.attachments?.length ?? 0,
     });

--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -1,18 +1,22 @@
 import {
   COMMON_COUNTRY_FILTER_ID,
   COMMON_FREQUENCY_FILTER_ID,
+  COMMON_TIME_PERIOD_FILTER_ID,
   buildFiltersMap,
   getConstraintsMap,
   getConstraintsMapFromSettledResults,
+  getCompatibleDatasetUrns,
   getDatasetNameFromFilters,
   getFilledDatasetFiltersMap,
   getFiltersByConstraints,
   getFiltersForQueryContext,
   getFiltersPreselectedByDataQueries,
+  getRestoredActiveDatasetUrns,
   isStructureDataMapsReady,
   mergeConstraintsMaps,
 } from '../multiple-filters';
 import type { Filter, SharedFilter } from '../../models/filters';
+import { DataQuery, QueryFilterType } from '@epam/statgpt-shared-toolkit';
 
 const mockFindCodelistByDimension = jest.fn();
 const mockGenerateShortUrn = jest.fn(
@@ -33,6 +37,7 @@ jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
   getAnnotationPeriod: jest.fn(() => ({ startPeriod: null, endPeriod: null })),
   getAvailableCodesFromConstrains: (...args: any[]) =>
     (mockGetAvailableCodesFromConstrains as any)(...args),
+  GET_v3_FILTER_ALL: 'all',
   TIME_PERIOD: 'TIME_PERIOD',
   TIME_PERIOD_START_ANNOTATION_KEY: 'TIME_PERIOD_START',
   TIME_PERIOD_END_ANNOTATION_KEY: 'TIME_PERIOD_END',
@@ -1135,5 +1140,157 @@ describe('shared filter expansion for datasets with no matching source values', 
     expect(dsBFilter?.dimensionValues?.map((v) => v.id)).not.toContain(
       'name:annual',
     );
+  });
+});
+
+describe('getCompatibleDatasetUrns', () => {
+  it('returns only datasets that support selected shared values', () => {
+    const sharedFrequencyFilter: Filter = {
+      id: COMMON_FREQUENCY_FILTER_ID,
+      filterType: 'shared',
+      sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
+      dimensionValues: [
+        {
+          id: 'name:daily',
+          name: 'Daily',
+          isSelectedValue: true,
+          sourceValues: [{ datasetUrn: DATASET_A_URN, id: 'D', name: 'Daily' }],
+        },
+        {
+          id: 'name:monthly',
+          name: 'Monthly',
+          isSelectedValue: false,
+          sourceValues: [
+            { datasetUrn: DATASET_A_URN, id: 'M', name: 'Monthly' },
+            { datasetUrn: DATASET_B_URN, id: 'M', name: 'Monthly' },
+          ],
+        },
+      ],
+    };
+
+    const compatibleUrns = getCompatibleDatasetUrns(
+      [sharedFrequencyFilter],
+      [DATASET_A_URN, DATASET_B_URN],
+    );
+
+    expect(Array.from(compatibleUrns)).toEqual([DATASET_A_URN]);
+  });
+
+  it('keeps all datasets when selected value is supported by all', () => {
+    const sharedFrequencyFilter: Filter = {
+      id: COMMON_FREQUENCY_FILTER_ID,
+      filterType: 'shared',
+      sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
+      dimensionValues: [
+        {
+          id: 'name:monthly',
+          name: 'Monthly',
+          isSelectedValue: true,
+          sourceValues: [
+            { datasetUrn: DATASET_A_URN, id: 'M', name: 'Monthly' },
+            { datasetUrn: DATASET_B_URN, id: 'M', name: 'Monthly' },
+          ],
+        },
+      ],
+    };
+
+    const compatibleUrns = getCompatibleDatasetUrns(
+      [sharedFrequencyFilter],
+      [DATASET_A_URN, DATASET_B_URN],
+    );
+
+    expect(Array.from(compatibleUrns)).toEqual([DATASET_A_URN, DATASET_B_URN]);
+  });
+});
+
+describe('getRestoredActiveDatasetUrns', () => {
+  it('restores only datasets that have the persisted shared filter selection', () => {
+    const dataQueries = [
+      {
+        urn: DATASET_A_URN,
+        filters: [],
+      },
+      {
+        urn: DATASET_B_URN,
+        filters: [
+          {
+            componentCode: 'FREQUENCY',
+            operator: QueryFilterType.IN,
+            values: ['Q'],
+          },
+        ],
+      },
+    ] as DataQuery[];
+
+    expect(
+      getRestoredActiveDatasetUrns(
+        dataQueries,
+        DATASET_DIMENSIONS_METADATA_MAP,
+      ),
+    ).toEqual([DATASET_B_URN]);
+  });
+
+  it('ignores time filters when restoring active datasets', () => {
+    const dataQueries = [
+      {
+        urn: DATASET_A_URN,
+        filters: [
+          {
+            componentCode: COMMON_TIME_PERIOD_FILTER_ID,
+            operator: QueryFilterType.BETWEEN,
+            values: ['2024-01-01', '2024-12-31'],
+          },
+        ],
+      },
+      {
+        urn: DATASET_B_URN,
+        filters: [
+          {
+            componentCode: COMMON_TIME_PERIOD_FILTER_ID,
+            operator: QueryFilterType.BETWEEN,
+            values: ['2024-01-01', '2024-12-31'],
+          },
+        ],
+      },
+    ] as DataQuery[];
+
+    expect(
+      getRestoredActiveDatasetUrns(
+        dataQueries,
+        DATASET_DIMENSIONS_METADATA_MAP,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('ignores wildcard filters when restoring active datasets', () => {
+    const dataQueries = [
+      {
+        urn: DATASET_A_URN,
+        filters: [
+          {
+            componentCode: 'FREQ',
+            operator: QueryFilterType.IN,
+            values: ['all'],
+          },
+        ],
+      },
+      {
+        urn: DATASET_B_URN,
+        filters: [
+          {
+            componentCode: 'FREQUENCY',
+            operator: QueryFilterType.IN,
+            values: ['Q'],
+          },
+        ],
+      },
+    ] as DataQuery[];
+
+    expect(
+      getRestoredActiveDatasetUrns(
+        dataQueries,
+        DATASET_DIMENSIONS_METADATA_MAP,
+      ),
+    ).toEqual([DATASET_B_URN]);
   });
 });

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -6,6 +6,7 @@ import {
   findCodelistByDimension,
   getAnnotationPeriod,
   generateShortUrn,
+  GET_v3_FILTER_ALL,
   getAvailableCodesFromConstrains,
   SeriesFilterDto,
   StructuralData,
@@ -26,6 +27,7 @@ import {
   DataQuery,
   Locale,
   QueryFilter,
+  QueryFilterType,
   TimeRange,
 } from '@epam/statgpt-shared-toolkit';
 import { StructureDataMaps } from '../models/structure-data';
@@ -674,6 +676,111 @@ export const buildFiltersMap = (
 
       return filterMap;
     }, new Map<string, Filter[]>());
+};
+
+export const getCompatibleDatasetUrns = (
+  filters: Filter[],
+  dataQueryUrns: string[],
+): Set<string> => {
+  const sharedFiltersWithSelections = filters.filter(
+    (f): f is SharedFilter =>
+      f.filterType === 'shared' &&
+      !f.isTimeDimension &&
+      (f.dimensionValues?.some((v) => v.isSelectedValue) ?? false),
+  );
+
+  if (!sharedFiltersWithSelections.length) {
+    return new Set(dataQueryUrns);
+  }
+
+  return new Set(
+    dataQueryUrns.filter((urn) =>
+      sharedFiltersWithSelections.every((filter) =>
+        filter.dimensionValues?.some(
+          (v) =>
+            v.isSelectedValue &&
+            v.sourceValues?.some((sv) => sv.datasetUrn === urn),
+        ),
+      ),
+    ),
+  );
+};
+
+export const filterDataQueriesByActiveDatasetUrns = (
+  dataQueries: DataQuery[] | undefined,
+  activeDatasetUrns: Set<string> | null,
+): DataQuery[] => {
+  if (!activeDatasetUrns) {
+    return dataQueries || [];
+  }
+
+  return (dataQueries || []).filter((dataQuery) =>
+    activeDatasetUrns.has(dataQuery.urn),
+  );
+};
+
+export const filterMapByActiveDatasetUrns = <T>(
+  map: Map<string, T>,
+  activeDatasetUrns: Set<string> | null,
+): Map<string, T> => {
+  if (!activeDatasetUrns) {
+    return map;
+  }
+
+  return new Map(
+    [...map].filter(([datasetUrn]) => activeDatasetUrns.has(datasetUrn)),
+  );
+};
+
+export const getRestoredActiveDatasetUrns = (
+  dataQueries?: DataQuery[],
+  datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+): string[] | undefined => {
+  const selectedSharedFilterDatasetUrnsMap = new Map<string, Set<string>>();
+
+  dataQueries?.forEach((dataQuery) => {
+    dataQuery.filters?.forEach((queryFilter) => {
+      if (
+        queryFilter.operator === QueryFilterType.BETWEEN ||
+        !queryFilter.values?.length ||
+        queryFilter.values.every((value) => value === GET_v3_FILTER_ALL)
+      ) {
+        return;
+      }
+
+      const config = getSharedFilterConfigForFilter(
+        {
+          id: queryFilter.componentCode,
+          datasetUrn: dataQuery.urn,
+          filterType: 'dataset',
+        },
+        datasetDimensionsMetadataMap,
+      );
+
+      if (!config || config.id === COMMON_TIME_PERIOD_FILTER_ID) {
+        return;
+      }
+
+      const datasetUrns =
+        selectedSharedFilterDatasetUrnsMap.get(config.id) ?? new Set<string>();
+      datasetUrns.add(dataQuery.urn);
+      selectedSharedFilterDatasetUrnsMap.set(config.id, datasetUrns);
+    });
+  });
+
+  if (!selectedSharedFilterDatasetUrnsMap.size) {
+    return undefined;
+  }
+
+  return (
+    dataQueries
+      ?.filter((dataQuery) =>
+        Array.from(selectedSharedFilterDatasetUrnsMap.values()).every(
+          (datasetUrns) => datasetUrns.has(dataQuery.urn),
+        ),
+      )
+      .map((dataQuery) => dataQuery.urn) ?? []
+  );
 };
 
 export const getCrossDatasetSnapshotKey = (dataQueries?: DataQuery[]) =>


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/225

### Description of changes

This PR restores cross-dataset filter compatibility logic for shared filters.

When a user selects a shared filter value, only datasets that support that value are requested and displayed. For example, if dataset A supports `D/M` and dataset B supports `M/Q`, selecting `D` shows only dataset A, while selecting `M` shows both datasets.

The change also keeps cross-dataset grid state stable between inline message view and Advanced View, including after page refresh. Active datasets are restored from saved data-query filters, so Advanced View no longer shows incompatible dataset values until filters are changed again.

Main changes:
- Filter cross-dataset requests/display by compatible dataset URNs.
- Restore active dataset state from persisted filters after refresh.
- Share active dataset state between inline and Advanced View grids.
- Add tests for compatible dataset selection and restored active dataset state.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
