### PR TITLE
fix: download security issue

### DIFF
--- a/libs/sdmx-toolkit/src/utils/__tests__/download.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/download.spec.ts
@@ -1,0 +1,87 @@
+import { FileColumnsAttribute, SdmxDataFormat } from '../../types';
+import { openDownloadWindow, sanitizeDownloadFilename } from '../download';
+
+describe('sanitizeDownloadFilename', () => {
+  it('replaces dangerous filename characters', () => {
+    expect(sanitizeDownloadFilename('../report:<2026>?.csv')).toBe(
+      'report_2026_.csv',
+    );
+  });
+
+  it('uses a fallback for empty filenames', () => {
+    expect(sanitizeDownloadFilename('   ...   ')).toBe('download');
+  });
+});
+
+describe('openDownloadWindow', () => {
+  const objectUrl = 'blob:http://localhost/download';
+  const originalFetch = global.fetch;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      blob: jest.fn().mockResolvedValue(new Blob(['id,value'])),
+    }) as unknown as typeof fetch;
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn().mockReturnValue(objectUrl),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+
+    global.fetch = originalFetch;
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: originalCreateObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: originalRevokeObjectURL,
+    });
+  });
+
+  it('downloads response blob without appending a link to the DOM', async () => {
+    const appendChildSpy = jest.spyOn(document.body, 'appendChild');
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation();
+
+    await openDownloadWindow(
+      'urn:test',
+      SdmxDataFormat.CSV,
+      'en',
+      FileColumnsAttribute.ID_NAME,
+      { filterKey: null, timeFilter: null },
+      '../unsafe:name.csv',
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('http://localhost/api/download?'),
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'same-origin',
+      }),
+    );
+    expect(appendChildSpy).not.toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    const link = clickSpy.mock.contexts[0] as HTMLAnchorElement;
+    expect(link.href).toBe(objectUrl);
+    expect(link.download).toBe('unsafe_name.csv');
+
+    jest.advanceTimersByTime(60_000);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(objectUrl);
+  });
+});

--- a/libs/sdmx-toolkit/src/utils/download.ts
+++ b/libs/sdmx-toolkit/src/utils/download.ts
@@ -3,6 +3,68 @@ import { FileColumnsAttribute, SdmxDataFormat } from '../types';
 
 const DOWNLOAD_PATH = '/api/download';
 const OBJECT_URL_REVOKE_DELAY_MS = 60_000;
+// eslint-disable-next-line no-control-regex
+const UNSAFE_FILENAME_CHARS = /[\x00-\x1F\x7F<>:"/\\|?*]/g;
+
+export const sanitizeDownloadFilename = (filename: string): string => {
+  const sanitized = filename
+    .normalize('NFKC')
+    .replace(UNSAFE_FILENAME_CHARS, '_')
+    .replace(/_+/g, '_')
+    .replace(/\s+/g, ' ')
+    .replace(/^[._ ]+/, '')
+    .trim();
+
+  return sanitized || 'download';
+};
+
+const createDownloadUrl = (
+  urn: string,
+  format: SdmxDataFormat,
+  language: string,
+  attribute: FileColumnsAttribute,
+  filters: DatasetQueryFilters,
+  filename: string,
+  isMetadata?: boolean,
+): string => {
+  const downloadUrl = new URL(DOWNLOAD_PATH, window.location.origin);
+
+  downloadUrl.search = new URLSearchParams({
+    urn,
+    format: format,
+    compress: 'false',
+    filename,
+    filters: JSON.stringify(filters),
+    attribute,
+    language,
+    isMetadata: isMetadata ? 'true' : 'none',
+  }).toString();
+
+  if (
+    downloadUrl.origin !== window.location.origin ||
+    downloadUrl.pathname !== DOWNLOAD_PATH
+  ) {
+    throw new Error('Invalid download URL');
+  }
+
+  return downloadUrl.toString();
+};
+
+const triggerBrowserDownload = (blob: Blob, filename: string): void => {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = objectUrl;
+  link.download = sanitizeDownloadFilename(filename);
+  link.rel = 'noopener noreferrer';
+
+  link.click();
+
+  window.setTimeout(
+    () => URL.revokeObjectURL(objectUrl),
+    OBJECT_URL_REVOKE_DELAY_MS,
+  );
+};
 
 export const openDownloadWindow = async (
   urn: string,
@@ -14,18 +76,16 @@ export const openDownloadWindow = async (
   isMetadata?: boolean,
   signal?: AbortSignal,
 ) => {
-  const queryParams = new URLSearchParams({
+  const safeFilename = sanitizeDownloadFilename(filename);
+  const link = createDownloadUrl(
     urn,
-    format: format,
-    compress: 'false',
-    filename,
-    filters: JSON.stringify(filters),
-    attribute,
+    format,
     language,
-    isMetadata: isMetadata ? 'true' : 'none',
-  }).toString();
-
-  const link = `${DOWNLOAD_PATH}?${queryParams}`;
+    attribute,
+    filters,
+    safeFilename,
+    isMetadata,
+  );
 
   const response = await fetch(link, {
     method: 'GET',
@@ -45,19 +105,5 @@ export const openDownloadWindow = async (
     return;
   }
 
-  const objectUrl = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-
-  a.href = objectUrl;
-  a.download = filename;
-  a.style.display = 'none';
-
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-
-  window.setTimeout(
-    () => URL.revokeObjectURL(objectUrl),
-    OBJECT_URL_REVOKE_DELAY_MS,
-  );
+  triggerBrowserDownload(blob, safeFilename);
 };


### PR DESCRIPTION
### Applicable issues

https://jiraeu.epam.com/browse/EPMDIAL-1408

### Description of changes

Prevent DOM XSS in download link handling:
  - Remove appendChild/removeChild — the anchor is clicked directly without being attached to the DOM, eliminating the
  flagged DOMXSS sink
  - Sanitize filename before writing to link.download to prevent unsanitized remote data from reaching the DOM
  - Harden URL construction with new URL() and origin/pathname assertion

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
