### PR TITLE
fix: correctly apply updated filters to show cross-dataset data

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -587,6 +587,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       dataQueries?.map((q) => q.urn) ?? [],
       dataQueries,
       datasetDimensionsMetadata.map,
+      appliedFiltersMap,
     );
     onMultipleDataFiltersChange?.(
       filtersParamsMap,

--- a/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
+++ b/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
@@ -44,6 +44,7 @@ import {
   filterMapByActiveDatasetUrns,
   getDataQueriesWithExpandedSharedDimensionFilters,
   getImplicitSharedWildcardFilterParams,
+  setDataQueryFiltersMap,
 } from '../utils/multiple-filters';
 
 export function useAttachmentsDataMultipleQueries(
@@ -399,10 +400,32 @@ export function useAttachmentsDataMultipleQueries(
           return;
         }
 
+        const queryFiltersMap = filtersMap
+          ? setDataQueryFiltersMap(dataQueries, filtersMap)
+          : undefined;
+        const dataQueriesWithAppliedFilters = queryFiltersMap
+          ? dataQueries.map((dataQuery) => ({
+              ...dataQuery,
+              filters: queryFiltersMap.get(dataQuery.urn) ?? [],
+            }))
+          : dataQueries;
+        const implicitWildcardFilterParams =
+          constraintsMap && structureDataMaps
+            ? getImplicitSharedWildcardFilterParams(
+                dataQueriesWithAppliedFilters,
+                structureDataMaps,
+                constraintsMap,
+                locale,
+                datasetDimensionsMetadata.map,
+              )
+            : undefined;
+        const resolvedFilterParamsMap =
+          implicitWildcardFilterParams?.filterParamsMap ?? filterParamsMap;
+
         dataQueries.forEach((dataQuery) => {
           getDataSetData(
             dataQuery,
-            filterParamsMap?.get(dataQuery?.urn) as DatasetQueryFilters,
+            resolvedFilterParamsMap?.get(dataQuery?.urn) as DatasetQueryFilters,
             getDataSetDataAction,
           )
             .then(({ dataMessage, structureDimensions }) => {
@@ -453,10 +476,13 @@ export function useAttachmentsDataMultipleQueries(
       }
     },
     [
+      datasetDimensionsMetadata.map,
       getDataSetDataAction,
       getPythonAttachment,
-      titles,
+      locale,
       onCodeAttachmentUpdated,
+      structureDataMaps,
+      titles,
     ],
   );
 

--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -1388,6 +1388,88 @@ describe('getCompatibleDatasetUrns', () => {
 
     expect(Array.from(compatibleUrns)).toEqual([DATASET_A_URN, DATASET_B_URN]);
   });
+
+  it('uses applied filters to keep a dataset that becomes an implicit wildcard after modal changes', () => {
+    const sharedCountryFilter: Filter = {
+      id: COMMON_COUNTRY_FILTER_ID,
+      filterType: 'shared',
+      sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
+      sourceFilterIdsByDataset: {
+        [DATASET_A_URN]: 'REF_AREA',
+        [DATASET_B_URN]: 'COUNTRY',
+      },
+      dimensionValues: [
+        {
+          id: 'name:united-states',
+          name: 'United States',
+          isSelectedValue: true,
+          sourceValues: [
+            { datasetUrn: DATASET_A_URN, id: 'US', name: 'United States' },
+          ],
+        },
+        {
+          id: 'name:canada',
+          name: 'Canada',
+          isSelectedValue: false,
+          sourceValues: [
+            { datasetUrn: DATASET_B_URN, id: 'CA', name: 'Canada' },
+          ],
+        },
+      ],
+    };
+    const staleDataQueries = [
+      {
+        urn: DATASET_A_URN,
+        filters: [
+          {
+            componentCode: 'REF_AREA',
+            operator: QueryFilterType.IN,
+            values: ['US'],
+          },
+        ],
+      },
+      {
+        urn: DATASET_B_URN,
+        filters: [
+          {
+            componentCode: 'COUNTRY',
+            operator: QueryFilterType.IN,
+            values: ['CA'],
+          },
+        ],
+      },
+    ] as DataQuery[];
+    const appliedFiltersMap = new Map<string, Filter[]>([
+      [
+        DATASET_A_URN,
+        [
+          {
+            id: 'REF_AREA',
+            datasetUrn: DATASET_A_URN,
+            filterType: 'dataset',
+            dimensionValues: [
+              {
+                id: 'US',
+                name: 'United States',
+                isSelectedValue: true,
+              },
+            ],
+          } as Filter,
+        ],
+      ],
+      [DATASET_B_URN, []],
+    ]);
+
+    const compatibleUrns = getCompatibleDatasetUrns(
+      [sharedCountryFilter],
+      [DATASET_A_URN, DATASET_B_URN],
+      staleDataQueries,
+      DATASET_DIMENSIONS_METADATA_MAP,
+      appliedFiltersMap,
+    );
+
+    expect(Array.from(compatibleUrns)).toEqual([DATASET_A_URN, DATASET_B_URN]);
+  });
 });
 
 describe('getConstraintsRequests', () => {

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -770,6 +770,7 @@ export const getCompatibleDatasetUrns = (
   dataQueryUrns: string[],
   dataQueries?: DataQuery[],
   datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
+  appliedFiltersMap?: Map<string, Filter[]>,
 ): Set<string> => {
   const sharedFiltersWithSelections = filters.filter(
     (f): f is SharedFilter =>
@@ -786,12 +787,6 @@ export const getCompatibleDatasetUrns = (
     datasetUrn: string,
     filter: SharedFilter,
   ): boolean => {
-    const dataQuery = dataQueries?.find((query) => query.urn === datasetUrn);
-
-    if (!dataQuery) {
-      return false;
-    }
-
     const nativeFilterId = getNativeFilterIdForSharedFilter(
       filter,
       datasetUrn,
@@ -799,6 +794,22 @@ export const getCompatibleDatasetUrns = (
     );
 
     if (!nativeFilterId) {
+      return false;
+    }
+
+    if (appliedFiltersMap) {
+      return !appliedFiltersMap
+        .get(datasetUrn)
+        ?.some(
+          (datasetFilter) =>
+            datasetFilter.id === nativeFilterId &&
+            datasetFilter.dimensionValues?.some((v) => v.isSelectedValue),
+        );
+    }
+
+    const dataQuery = dataQueries?.find((query) => query.urn === datasetUrn);
+
+    if (!dataQuery) {
       return false;
     }
 
@@ -1446,6 +1457,9 @@ export const getImplicitSharedWildcardFilterParams = (
   const compatibleUrns = getCompatibleDatasetUrns(
     preselectedFilters,
     dataQueries.map((dataQuery) => dataQuery.urn),
+    dataQueries,
+    datasetDimensionsMetadataMap,
+    expandedFiltersMap,
   );
   const compatibleDataQueries = dataQueries.filter((dataQuery) =>
     compatibleUrns.has(dataQuery.urn),


### PR DESCRIPTION
### Applicable issues

https://github.com/epam/statgpt-global-trusted-data-commons/issues/225

### Description of changes

Fixed filter apply flow for cross-dataset shared dimension filters.
After applying filters, the app now recalculates dataset requests using the newly applied modal filter state instead of stale saved dataQuery.filters. This lets datasets that become implicit wildcards participate immediately, and ensures api/dataset requests use merged shared dimension values without requiring a page refresh.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
