### PR TITLE
fix: preserve scroll position in filter values panel during reload

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/FilterValues.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersValuesPanel/FilterValues.tsx
@@ -83,6 +83,7 @@ const FilterValues: FC<Props> = ({
   return (
     <div
       className={classNames(
+        'relative',
         isDisableValues && 'pointer-events-none opacity-[0.7]',
         isScrollable ? 'flex h-full min-h-0 flex-col' : 'flex flex-col',
       )}
@@ -99,9 +100,15 @@ const FilterValues: FC<Props> = ({
           <span className="h4 text-neutrals-1000">{selectedFilter?.title}</span>
         </div>
       )}
+      {isLoading && (
+        <div className="pointer-events-none absolute inset-0 z-10 min-h-12">
+          <Loader />
+        </div>
+      )}
       <div
         className={classNames(
           isScrollable ? 'min-h-0 flex-1 overflow-auto' : 'overflow-visible',
+          isLoading && 'pointer-events-none opacity-[0.7]',
         )}
         style={
           isScrollable && isMobile && !isLoading
@@ -109,11 +116,7 @@ const FilterValues: FC<Props> = ({
             : undefined
         }
       >
-        {isLoading ? (
-          <div className="h-full min-h-12">
-            <Loader />
-          </div>
-        ) : hierarchyTreeNodes?.length || isHierarchicalView ? (
+        {hierarchyTreeNodes?.length || isHierarchicalView ? (
           <FilterTreeView
             treeNodes={hierarchyTreeNodes ?? getFilterValuesTree(values)}
             checkboxIcon={checkboxIcon}


### PR DESCRIPTION
### Applicable issues

https://github.com/epam/statgpt-global-trusted-data-commons/issues/230

### Description of changes

When a user checks/unchecks a filter value, a constraints request is fired and the values list reloads. Previously, the loader replaced the list in the DOM, resetting scroll position to the top.

Instead of swapping the list for a loader, the loader is now rendered as an absolute overlay on top of the existing list content. The list stays in the DOM during reload, so scroll position is naturally preserved.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
