### PR TITLE
fix:  add excluded operator for cross-dataset shared dimension filters

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -589,6 +589,26 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       datasetDimensionsMetadata.map,
       appliedFiltersMap,
     );
+
+    const incompatibleUrns = (dataQueries?.map((q) => q.urn) ?? []).filter(
+      (urn) => !compatibleUrns.has(urn),
+    );
+    for (const urn of incompatibleUrns) {
+      const filters = appliedFiltersMap.get(urn);
+      if (filters) {
+        appliedFiltersMap.set(
+          urn,
+          filters.map((filter) =>
+            !filter.isTimeDimension &&
+            filter.dimensionValues?.length &&
+            !filter.dimensionValues.some((v) => v.isSelectedValue)
+              ? { ...filter, isExcluded: true }
+              : filter,
+          ),
+        );
+      }
+    }
+
     onMultipleDataFiltersChange?.(
       filtersParamsMap,
       constraintsMapRef.current,

--- a/libs/conversation-view/src/components/Attachments/AttachmentDetails/AttachmentDetails.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentDetails/AttachmentDetails.tsx
@@ -52,7 +52,7 @@ const AttachmentDetails: FC<Props> = ({
           } else {
             sharedFiltersMap.set(detail.id, { ...detail });
           }
-        } else {
+        } else if (detail.valuesTitles?.length) {
           datasetOnlyFilters.push(detail);
         }
       });

--- a/libs/conversation-view/src/models/filters.ts
+++ b/libs/conversation-view/src/models/filters.ts
@@ -31,6 +31,7 @@ interface FilterBase {
   isHierarchical?: boolean;
   isDisabled?: boolean;
   displayMode?: string;
+  isExcluded?: boolean;
 }
 
 export interface DatasetFilter extends FilterBase {

--- a/libs/conversation-view/src/utils/__tests__/attachments-details.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/attachments-details.spec.ts
@@ -1,0 +1,181 @@
+import { getAttachmentInfoList } from '../attachments-details';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetLocalizedName = jest.fn();
+const mockGetDimensions = jest.fn();
+const mockFindCodelistByDimension = jest.fn();
+const mockGetConcept = jest.fn();
+const mockGetSharedFilterIdForDatasetDimension = jest.fn();
+const mockGetDateString = jest.fn();
+const mockGetTimePeriod = jest.fn();
+
+jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  getLocalizedName: (...args: any[]) => mockGetLocalizedName(...args),
+  getDimensions: (...args: any[]) => mockGetDimensions(...args),
+  findCodelistByDimension: (...args: any[]) =>
+    mockFindCodelistByDimension(...args),
+  getConcept: (...args: any[]) => mockGetConcept(...args),
+}));
+
+jest.mock('@epam/statgpt-shared-toolkit', () => ({
+  QueryFilterType: { IN: 'in', BETWEEN: 'between', EXCLUDED: 'excluded' },
+  getTimePeriod: (...args: any[]) => mockGetTimePeriod(...args),
+}));
+
+jest.mock('../attachments/time-period', () => ({
+  getDateString: (...args: any[]) => mockGetDateString(...args),
+}));
+
+jest.mock('../multiple-filters', () => ({
+  getSharedFilterIdForDatasetDimension: (...args: any[]) =>
+    mockGetSharedFilterIdForDatasetDimension(...args),
+}));
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DATASET_A_URN = 'AGENCY:DF_A(1.0)';
+const DATASET_B_URN = 'AGENCY:DF_B(1.0)';
+const SHARED_FREQ_ID = 'SHARED_FREQ';
+const LOCALE = 'en';
+
+const emptyStructuresMap = new Map<string, any>([
+  [DATASET_A_URN, {}],
+  [DATASET_B_URN, {}],
+]);
+
+// ─── Default mock reset ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockGetLocalizedName.mockReturnValue(undefined);
+  mockGetDimensions.mockReturnValue({ dimensions: [], timeDimensions: [] });
+  mockFindCodelistByDimension.mockReturnValue(null);
+  mockGetConcept.mockReturnValue(null);
+  mockGetSharedFilterIdForDatasetDimension.mockImplementation(
+    (_urn: string, componentCode: string) =>
+      componentCode === 'FREQ' ? SHARED_FREQ_ID : componentCode,
+  );
+  mockGetDateString.mockReturnValue('2020-01');
+  mockGetTimePeriod.mockReturnValue('2020');
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const inFilter = (values: string[]) => ({
+  componentCode: 'FREQ',
+  operator: 'in',
+  values,
+});
+
+const excludedFilter = () => ({
+  componentCode: 'FREQ',
+  operator: 'excluded',
+  values: [],
+});
+
+// ─── getAttachmentInfoList ────────────────────────────────────────────────────
+
+describe('getAttachmentInfoList', () => {
+  it('shows values from a sibling dataset when one dataset changes to EXCLUDED', () => {
+    const previousDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['M'])] },
+      { urn: DATASET_B_URN, filters: [inFilter(['A'])] },
+    ] as any[];
+    const currentDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['D'])] },
+      { urn: DATASET_B_URN, filters: [excludedFilter()] },
+    ] as any[];
+
+    const result = getAttachmentInfoList(
+      previousDataQueries,
+      currentDataQueries,
+      emptyStructuresMap,
+      LOCALE,
+    );
+
+    expect(result[0].queryFiltersDetails).toEqual([
+      { id: SHARED_FREQ_ID, title: undefined, valuesTitles: ['D'] },
+    ]);
+    expect(result[1].queryFiltersDetails).toEqual([
+      { id: SHARED_FREQ_ID, title: undefined, valuesTitles: ['D'] },
+    ]);
+  });
+
+  it('shows sibling values for EXCLUDED even when the sibling filter did not change', () => {
+    const previousDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['D'])] },
+      { urn: DATASET_B_URN, filters: [inFilter(['A'])] },
+    ] as any[];
+    const currentDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['D'])] },
+      { urn: DATASET_B_URN, filters: [excludedFilter()] },
+    ] as any[];
+
+    const result = getAttachmentInfoList(
+      previousDataQueries,
+      currentDataQueries,
+      emptyStructuresMap,
+      LOCALE,
+    );
+
+    expect(result[0].queryFiltersDetails).toEqual([]);
+    expect(result[1].queryFiltersDetails).toEqual([
+      { id: SHARED_FREQ_ID, title: undefined, valuesTitles: ['D'] },
+    ]);
+  });
+
+  it('drops the filter entry when all datasets change to EXCLUDED and no sibling has active values', () => {
+    const previousDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['D'])] },
+      { urn: DATASET_B_URN, filters: [inFilter(['A'])] },
+    ] as any[];
+    const currentDataQueries = [
+      { urn: DATASET_A_URN, filters: [excludedFilter()] },
+      { urn: DATASET_B_URN, filters: [excludedFilter()] },
+    ] as any[];
+
+    const result = getAttachmentInfoList(
+      previousDataQueries,
+      currentDataQueries,
+      emptyStructuresMap,
+      LOCALE,
+    );
+
+    expect(result[0].queryFiltersDetails).toEqual([]);
+    expect(result[1].queryFiltersDetails).toEqual([]);
+  });
+
+  it('returns normal changed filter details when no EXCLUDED filters are involved', () => {
+    const previousDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['M'])] },
+    ] as any[];
+    const currentDataQueries = [
+      { urn: DATASET_A_URN, filters: [inFilter(['D'])] },
+    ] as any[];
+
+    const result = getAttachmentInfoList(
+      previousDataQueries,
+      currentDataQueries,
+      new Map([[DATASET_A_URN, {}]]) as any,
+      LOCALE,
+    );
+
+    expect(result[0].queryFiltersDetails).toEqual([
+      { id: SHARED_FREQ_ID, title: undefined, valuesTitles: ['D'] },
+    ]);
+  });
+
+  it('returns empty details when the filter did not change', () => {
+    const filters = [inFilter(['D'])];
+    const dataQueries = [{ urn: DATASET_A_URN, filters }] as any[];
+
+    const result = getAttachmentInfoList(
+      dataQueries,
+      dataQueries,
+      new Map([[DATASET_A_URN, {}]]) as any,
+      LOCALE,
+    );
+
+    expect(result[0].queryFiltersDetails).toEqual([]);
+  });
+});

--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -1425,6 +1425,71 @@ describe('getCompatibleDatasetUrns', () => {
     expect(Array.from(compatibleUrns)).toEqual([DATASET_A_URN, DATASET_B_URN]);
   });
 
+  it('excludes a dataset whose filter entry is present in appliedFiltersMap but has no selected values', () => {
+    const sharedCountryFilter: Filter = {
+      id: COMMON_COUNTRY_FILTER_ID,
+      filterType: 'shared',
+      sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
+      sourceFilterIdsByDataset: {
+        [DATASET_A_URN]: 'REF_AREA',
+        [DATASET_B_URN]: 'COUNTRY',
+      },
+      dimensionValues: [
+        {
+          id: 'name:united-states',
+          name: 'United States',
+          isSelectedValue: true,
+          sourceValues: [
+            { datasetUrn: DATASET_A_URN, id: 'US', name: 'United States' },
+          ],
+        },
+        {
+          id: 'name:canada',
+          name: 'Canada',
+          isSelectedValue: false,
+          sourceValues: [
+            { datasetUrn: DATASET_B_URN, id: 'CA', name: 'Canada' },
+          ],
+        },
+      ],
+    };
+    const appliedFiltersMap = new Map<string, Filter[]>([
+      [
+        DATASET_A_URN,
+        [
+          {
+            id: 'REF_AREA',
+            datasetUrn: DATASET_A_URN,
+            filterType: 'dataset',
+            dimensionValues: [{ id: 'US', isSelectedValue: true }],
+          } as Filter,
+        ],
+      ],
+      [
+        DATASET_B_URN,
+        [
+          {
+            id: 'COUNTRY',
+            datasetUrn: DATASET_B_URN,
+            filterType: 'dataset',
+            isExcluded: true,
+            dimensionValues: [{ id: 'CA', isSelectedValue: false }],
+          } as Filter,
+        ],
+      ],
+    ]);
+
+    const compatibleUrns = getCompatibleDatasetUrns(
+      [sharedCountryFilter],
+      [DATASET_A_URN, DATASET_B_URN],
+      undefined,
+      DATASET_DIMENSIONS_METADATA_MAP,
+      appliedFiltersMap,
+    );
+
+    expect(Array.from(compatibleUrns)).toEqual([DATASET_A_URN]);
+  });
+
   it('uses applied filters to keep a dataset that becomes an implicit wildcard after modal changes', () => {
     const sharedCountryFilter: Filter = {
       id: COMMON_COUNTRY_FILTER_ID,
@@ -1659,6 +1724,45 @@ describe('hasImplicitSharedWildcard', () => {
     ).toBe(false);
   });
 
+  it('returns false when one dataset has an EXCLUDED filter for the shared dimension', () => {
+    const structureDataMaps = buildStructureDataMaps(
+      new Map([
+        [DATASET_A_URN, [{ id: 'FREQ' }]],
+        [DATASET_B_URN, [{ id: 'FREQUENCY' }]],
+      ]),
+    );
+    const dataQueries = [
+      {
+        urn: DATASET_A_URN,
+        filters: [
+          {
+            componentCode: 'FREQ',
+            operator: QueryFilterType.IN,
+            values: ['D'],
+          },
+        ],
+      },
+      {
+        urn: DATASET_B_URN,
+        filters: [
+          {
+            componentCode: 'FREQUENCY',
+            operator: QueryFilterType.EXCLUDED,
+            values: [],
+          },
+        ],
+      },
+    ] as any;
+
+    expect(
+      hasImplicitSharedWildcard(
+        dataQueries,
+        structureDataMaps,
+        DATASET_DIMENSIONS_METADATA_MAP,
+      ),
+    ).toBe(false);
+  });
+
   it('ignores time dimensions', () => {
     const structureDataMaps = buildStructureDataMaps(
       new Map([
@@ -1877,6 +1981,38 @@ describe('getRestoredActiveDatasetUrns', () => {
         DATASET_DIMENSIONS_METADATA_MAP,
       ),
     ).toBeUndefined();
+  });
+
+  it('does not restore a dataset whose shared dimension filter is EXCLUDED', () => {
+    const dataQueries = [
+      {
+        urn: DATASET_A_URN,
+        filters: [
+          {
+            componentCode: 'FREQ',
+            operator: QueryFilterType.IN,
+            values: ['D'],
+          },
+        ],
+      },
+      {
+        urn: DATASET_B_URN,
+        filters: [
+          {
+            componentCode: 'FREQUENCY',
+            operator: QueryFilterType.EXCLUDED,
+            values: [],
+          },
+        ],
+      },
+    ] as DataQuery[];
+
+    expect(
+      getRestoredActiveDatasetUrns(
+        dataQueries,
+        DATASET_DIMENSIONS_METADATA_MAP,
+      ),
+    ).toEqual([DATASET_A_URN]);
   });
 });
 

--- a/libs/conversation-view/src/utils/__tests__/query-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/query-filters.spec.ts
@@ -36,7 +36,7 @@ jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
 }));
 
 jest.mock('@epam/statgpt-shared-toolkit', () => ({
-  QueryFilterType: { IN: 'in', BETWEEN: 'between' },
+  QueryFilterType: { IN: 'in', BETWEEN: 'between', EXCLUDED: 'excluded' },
 }));
 
 // ─── Default mock reset ───────────────────────────────────────────────────────
@@ -192,6 +192,34 @@ describe('setDataQueryFilters', () => {
       operator: 'in',
       values: ['FR'],
     });
+  });
+
+  it('emits an EXCLUDED filter with empty values when isExcluded is true', () => {
+    const filter: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      isExcluded: true,
+      dimensionValues: [{ id: 'A', isSelectedValue: false }],
+    };
+
+    const result = setDataQueryFilters([filter]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      componentCode: 'FREQ',
+      operator: 'excluded',
+      values: [],
+    });
+  });
+
+  it('does not emit EXCLUDED for a filter without isExcluded even when no values are selected', () => {
+    const filter: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'A', isSelectedValue: false }],
+    };
+
+    expect(setDataQueryFilters([filter])).toEqual([]);
   });
 
   it('builds a BETWEEN filter with MM-DD-YYYY formatted dates for a time dimension filter', () => {

--- a/libs/conversation-view/src/utils/attachments-details.ts
+++ b/libs/conversation-view/src/utils/attachments-details.ts
@@ -24,6 +24,21 @@ import { getDateString } from './attachments/time-period';
 import { AttachmentInfo } from '../models/attachments';
 import { getSharedFilterIdForDatasetDimension } from './multiple-filters';
 
+const getStructurePartsForDataQuery = (
+  dataQuery: DataQuery,
+  datasetStructuresMap: Map<string, StructuralData | undefined>,
+) => {
+  const structures = datasetStructuresMap?.get(dataQuery?.urn);
+  const conceptSchemes = structures?.conceptSchemes || [];
+  const codelists = structures?.codelists || [];
+  const dimensionsList = getDimensions(structures as StructuralData);
+  const dimensions = [
+    ...(dimensionsList?.dimensions || []),
+    ...(dimensionsList?.timeDimensions || []),
+  ];
+  return { structures, conceptSchemes, codelists, dimensions };
+};
+
 export const getAttachmentInfoList = (
   previousDataQueries: DataQuery[],
   currentDataQueries: DataQuery[],
@@ -31,41 +46,72 @@ export const getAttachmentInfoList = (
   locale: string,
   datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): AttachmentInfo[] => {
+  const currentValuesByFilterId = new Map<string, string[]>();
+  currentDataQueries?.forEach((dataQuery) => {
+    const { conceptSchemes, codelists, dimensions } =
+      getStructurePartsForDataQuery(dataQuery, datasetStructuresMap);
+    getQueryFiltersDetails(
+      (dataQuery?.filters ?? []).filter(
+        (f) => f.operator !== QueryFilterType.EXCLUDED,
+      ),
+      dataQuery?.urn,
+      dimensions,
+      conceptSchemes,
+      codelists,
+      locale,
+      datasetDimensionsMetadataMap,
+    ).forEach((detail) => {
+      if (detail.valuesTitles?.length) {
+        const existing = currentValuesByFilterId.get(detail.id) ?? [];
+        currentValuesByFilterId.set(
+          detail.id,
+          Array.from(new Set([...existing, ...detail.valuesTitles])),
+        );
+      }
+    });
+  });
+
   return currentDataQueries?.map((dataQuery) => {
     const previousDataQuery = previousDataQueries?.find(
       (previousDataQuery) => previousDataQuery?.urn === dataQuery?.urn,
     );
-    const structures = datasetStructuresMap?.get(dataQuery?.urn);
-    const conceptSchemes = structures?.conceptSchemes || [];
-    const codelists = structures?.codelists || [];
-    const dimensionsList = getDimensions(structures as StructuralData);
-    const dimensions = [
-      ...(dimensionsList?.dimensions || []),
-      ...(dimensionsList?.timeDimensions || []),
-    ];
+    const { structures, conceptSchemes, codelists, dimensions } =
+      getStructurePartsForDataQuery(dataQuery, datasetStructuresMap);
+
+    const rawChanged = getUpdatedQueryFiltersDetails(
+      getQueryFiltersDetails(
+        previousDataQuery?.filters || [],
+        dataQuery?.urn,
+        dimensions,
+        conceptSchemes,
+        codelists,
+        locale,
+        datasetDimensionsMetadataMap,
+      ),
+      getQueryFiltersDetails(
+        dataQuery?.filters ?? [],
+        dataQuery?.urn,
+        dimensions,
+        conceptSchemes,
+        codelists,
+        locale,
+        datasetDimensionsMetadataMap,
+      ),
+    );
+
+    const queryFiltersDetails = rawChanged
+      .map((detail) => {
+        if (detail.valuesTitles?.length) return detail;
+        const siblingValues = currentValuesByFilterId.get(detail.id);
+        return siblingValues?.length
+          ? { ...detail, valuesTitles: siblingValues }
+          : null;
+      })
+      .filter((d): d is QueryFilterDetails => d !== null);
 
     return {
       datasetName: getLocalizedName(structures?.dataflows?.[0], locale),
-      queryFiltersDetails: getUpdatedQueryFiltersDetails(
-        getQueryFiltersDetails(
-          previousDataQuery?.filters || [],
-          dataQuery?.urn,
-          dimensions,
-          conceptSchemes,
-          codelists,
-          locale,
-          datasetDimensionsMetadataMap,
-        ),
-        getQueryFiltersDetails(
-          dataQuery?.filters ?? [],
-          dataQuery?.urn,
-          dimensions,
-          conceptSchemes,
-          codelists,
-          locale,
-          datasetDimensionsMetadataMap,
-        ),
-      ),
+      queryFiltersDetails,
     };
   });
 };

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -823,13 +823,14 @@ export const getCompatibleDatasetUrns = (
     }
 
     if (appliedFiltersMap) {
-      return !appliedFiltersMap
-        .get(datasetUrn)
-        ?.some(
-          (datasetFilter) =>
-            datasetFilter.id === nativeFilterId &&
-            datasetFilter.dimensionValues?.some((v) => v.isSelectedValue),
-        );
+      const datasetFilters = appliedFiltersMap.get(datasetUrn) ?? [];
+      const matchingFilter = datasetFilters.find(
+        (f) => f.id === nativeFilterId,
+      );
+      if (!matchingFilter) {
+        return true;
+      }
+      return false;
     }
 
     const dataQuery = dataQueries?.find((query) => query.urn === datasetUrn);

--- a/libs/conversation-view/src/utils/query-filters.ts
+++ b/libs/conversation-view/src/utils/query-filters.ts
@@ -86,6 +86,7 @@ const buildQueryFiltersCore = (
     ?.filter(
       (filter) =>
         filter.timeRange ||
+        filter.isExcluded ||
         filter.dimensionValues?.some((value) => value.isSelectedValue),
     )
     .map((filter) => {
@@ -97,6 +98,14 @@ const buildQueryFiltersCore = (
             formatTimePeriod(filter?.timeRange?.startPeriod || undefined) || '',
             formatTimePeriod(filter?.timeRange?.endPeriod || undefined) || '',
           ],
+        };
+      }
+
+      if (filter.isExcluded) {
+        return {
+          componentCode: filter?.id as string,
+          operator: QueryFilterType.EXCLUDED,
+          values: [],
         };
       }
 

--- a/libs/shared-toolkit/src/types/query-filter-type.ts
+++ b/libs/shared-toolkit/src/types/query-filter-type.ts
@@ -1,4 +1,5 @@
 export enum QueryFilterType {
   IN = 'in',
   BETWEEN = 'between',
+  EXCLUDED = 'excluded',
 }


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/225

### Description of changes

**QueryFilterType** - Added a new excluded operator.

**Filter marking on apply** — When filters are applied in multi-dataset mode, datasets that have no compatible values for a selected shared filter are explicitly marked as excluded rather than left with an empty filter state.

**Persisting excluded state** — The excluded marker is saved to the conversation so that on page reload the system can distinguish "this dataset was intentionally excluded" from "this dataset has no filter yet (implicit wildcard)".

**Wildcard detection** — The implicit wildcard logic now correctly ignores datasets that were explicitly excluded, preventing them from re-entering the cross-dataset view after a reload.

**Attachment details display** — The system message correctly shows the active filter values from participating datasets even when a sibling dataset transitions to excluded. Empty filter entries and empty dataset sections are no longer rendered.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
