### PR TITLE
fix: dropdown rendering behind modal overlay

### DIFF
--- a/apps/portals-example/src/scss/calendar.scss
+++ b/apps/portals-example/src/scss/calendar.scss
@@ -42,7 +42,7 @@ $calendar-width: $inner-width;
   &.open {
     @apply bg-white;
     @apply px-[12px] py-[16px];
-    @apply z-[100002] !important;
+    @apply z-[100003] !important;
     min-width: $calendar-width !important;
     &:before,
     &:after {

--- a/apps/portals-example/tailwind.config.js
+++ b/apps/portals-example/tailwind.config.js
@@ -66,6 +66,7 @@ module.exports = {
       zIndex: {
         tooltip: '100000',
         modal: '100001',
+        dropdown: '100002',
       },
     },
   },

--- a/libs/ui-components/src/components/Dropdown/Dropdown.tsx
+++ b/libs/ui-components/src/components/Dropdown/Dropdown.tsx
@@ -142,7 +142,7 @@ export const Dropdown: FC<Props> = ({
           <div
             ref={refs.setFloating}
             style={{ ...floatingStyles, overflowY: 'auto' }}
-            className="dropdown-menu-shadow dropdown-container z-10 flex flex-col rounded bg-white"
+            className="dropdown-menu-shadow dropdown-container z-dropdown flex flex-col rounded bg-white"
             {...getFloatingProps()}
           >
             {content && content}


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/239

### Description of changes

Both **Dropdown** and **Popup** use **FloatingPortal**, which mounts content as siblings directly under `<body>`. The dropdown's `z-10`  was below the modal's `z-modal` (100001), causing dropdowns opened inside a modal (e.g. **Filters**) to render behind the overlay.

Added a dropdown level (100002) to the Tailwind `z-index` scale and updated **Dropdown.tsx** to use it. 

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
