### PR TITLE
fix: assistant message always uses full available width

### DIFF
--- a/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
@@ -463,8 +463,8 @@ const Message: FC<Props> = ({
     >
       <div
         className={classNames(
-          'flex items-start max-w-full',
-          (isSystem || isEditing) && 'w-full',
+          'flex items-start',
+          isUser && !isEditing ? 'max-w-full' : 'w-full',
         )}
       >
         <div className="relative mr-2">


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes https://github.com/epam/statgpt-global-trusted-data-commons/issues/242

### Description of changes

  - Assistant (model) messages now stretch to the full available width instead of being sized to content
  - User messages, system messages, and the user-editing state are unchanged


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
