### PR TITLE
chore: update jsx to react-jsx in tsconfig for Next.js 16 alignment

### DIFF
--- a/apps/portals-example/tsconfig.json
+++ b/apps/portals-example/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "allowJs": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "noEmit": true,
     "incremental": true,
     "resolveJsonModule": true,
@@ -21,7 +21,8 @@
     "../../.next/types/**/*.ts",
     ".next/types/**/*.ts",
     "next-env.d.ts",
-    "../../dist/apps/portals-example/.next/types/**/*.ts"
+    "../../dist/apps/portals-example/.next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules", "jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/250

### Description of changes

Updated jsx compiler option from preserve to react-jsx in both tsconfig.base.json and apps/portals-example/tsconfig.json to align with Next.js 16 recommended configuration. Also added .next/dev/types/**/*.ts to the app's include array to pick up Next.js 16 dev-mode type generation.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
