### PR TITLE
fix: hierarchy tree parent checkbox not re-checking children

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersSettings.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersSettings.tsx
@@ -200,7 +200,9 @@ const FilterSettings: FC<Props> = ({
           const nodeValue = mappedNodes.find(
             (node) => node?.id === dimensionValue?.id,
           );
-          return nodeValue || dimensionValue;
+          return nodeValue
+            ? { ...dimensionValue, isSelectedValue: nodeValue.isSelectedValue }
+            : dimensionValue;
         }) ?? []),
         ...newEntries,
       ],

--- a/libs/conversation-view/src/utils/__tests__/filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/filters.spec.ts
@@ -552,34 +552,34 @@ describe('getFilterNodesBySelection', () => {
     expect(result.slice(1).every((n) => n.isSelectedValue)).toBe(true);
   });
 
-  it('deselects parent but keeps children selected when parent is selected and all children are selected', () => {
+  it('deselects parent and all children when parent is selected and all children are selected', () => {
     const node = makeNode('EUROPE', true, [
       makeNode('FR', true),
       makeNode('DE', true),
     ]);
     const result = getFilterNodesBySelection(node);
     expect(result[0]).toMatchObject({ id: 'EUROPE', isSelectedValue: false });
-    expect(result.slice(1).every((n) => n.isSelectedValue)).toBe(true);
+    expect(result.slice(1).every((n) => !n.isSelectedValue)).toBe(true);
   });
 
-  it('selects parent and deselects all children when parent is unselected and all children are selected', () => {
+  it('selects parent and all children when parent is unselected and all children are selected', () => {
     const node = makeNode('EUROPE', false, [
       makeNode('FR', true),
       makeNode('DE', true),
     ]);
     const result = getFilterNodesBySelection(node);
     expect(result[0]).toMatchObject({ id: 'EUROPE', isSelectedValue: true });
-    expect(result.slice(1).every((n) => !n.isSelectedValue)).toBe(true);
+    expect(result.slice(1).every((n) => n.isSelectedValue)).toBe(true);
   });
 
-  it('deselects parent and all children when parent is unselected but children are mixed', () => {
+  it('selects parent and all children when parent is unselected but children are mixed', () => {
     const node = makeNode('EUROPE', false, [
       makeNode('FR', true),
       makeNode('DE', false),
     ]);
     const result = getFilterNodesBySelection(node);
-    expect(result[0]).toMatchObject({ id: 'EUROPE', isSelectedValue: false });
-    expect(result.slice(1).every((n) => !n.isSelectedValue)).toBe(true);
+    expect(result[0]).toMatchObject({ id: 'EUROPE', isSelectedValue: true });
+    expect(result.slice(1).every((n) => n.isSelectedValue)).toBe(true);
   });
 });
 

--- a/libs/conversation-view/src/utils/__tests__/hierarchy-view.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/hierarchy-view.spec.ts
@@ -450,6 +450,109 @@ describe('applySelectionToTree', () => {
       },
     ]);
   });
+
+  it('marks parent as selected when all non-disabled children are selected', () => {
+    const nodes: FilterTreeNodeProps[] = [
+      {
+        id: 'WORLD',
+        children: [
+          { id: 'FR', children: [] },
+          { id: 'DE', children: [] },
+        ],
+      },
+    ];
+
+    expect(applySelectionToTree(nodes, new Set(['FR', 'DE']))).toEqual([
+      {
+        id: 'WORLD',
+        isSelectedValue: true,
+        children: [
+          { id: 'FR', isSelectedValue: true, children: [] },
+          { id: 'DE', isSelectedValue: true, children: [] },
+        ],
+      },
+    ]);
+  });
+
+  it('marks parent as not selected when only some children are selected', () => {
+    const nodes: FilterTreeNodeProps[] = [
+      {
+        id: 'WORLD',
+        children: [
+          { id: 'FR', children: [] },
+          { id: 'DE', children: [] },
+        ],
+      },
+    ];
+
+    expect(applySelectionToTree(nodes, new Set(['FR']))).toEqual([
+      {
+        id: 'WORLD',
+        isSelectedValue: false,
+        children: [
+          { id: 'FR', isSelectedValue: true, children: [] },
+          { id: 'DE', isSelectedValue: false, children: [] },
+        ],
+      },
+    ]);
+  });
+
+  it('ignores disabled children when deriving parent selection', () => {
+    const nodes: FilterTreeNodeProps[] = [
+      {
+        id: 'WORLD',
+        children: [
+          { id: 'FR', children: [] },
+          { id: 'DE', disabled: true, children: [] },
+        ],
+      },
+    ];
+
+    expect(applySelectionToTree(nodes, new Set(['FR']))).toEqual([
+      {
+        id: 'WORLD',
+        isSelectedValue: true,
+        children: [
+          { id: 'FR', isSelectedValue: true, children: [] },
+          { id: 'DE', disabled: true, isSelectedValue: false, children: [] },
+        ],
+      },
+    ]);
+  });
+
+  it('derives selection through multiple nesting levels', () => {
+    const nodes: FilterTreeNodeProps[] = [
+      {
+        id: 'WORLD',
+        children: [
+          {
+            id: 'EU',
+            children: [
+              { id: 'FR', children: [] },
+              { id: 'DE', children: [] },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(applySelectionToTree(nodes, new Set(['FR', 'DE']))).toEqual([
+      {
+        id: 'WORLD',
+        isSelectedValue: true,
+        children: [
+          {
+            id: 'EU',
+            isSelectedValue: true,
+            children: [
+              { id: 'FR', isSelectedValue: true, children: [] },
+              { id: 'DE', isSelectedValue: true, children: [] },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 describe('toggleTreeNodeExpansion', () => {

--- a/libs/conversation-view/src/utils/filters.ts
+++ b/libs/conversation-view/src/utils/filters.ts
@@ -316,30 +316,9 @@ const setSelectedChildrenNodes = (
 export const getFilterNodesBySelection = (
   node: FilterTreeNodeProps,
 ): FilterTreeNodeProps[] => {
-  const enabledChildren = node.children?.filter((child) => !child.disabled);
-  const allChildrenSelected = enabledChildren?.every(
-    (child) => child.isSelectedValue,
-  );
-  const allChildrenUnselected = enabledChildren?.every(
-    (child) => !child.isSelectedValue,
-  );
-
   if (!node.isSelectedValue) {
-    if (allChildrenUnselected) {
-      return [
-        { ...node, isSelectedValue: true },
-        ...setSelectedChildrenNodes(getAllChildrenNodes(node), true),
-      ];
-    }
-    if (allChildrenSelected) {
-      return [
-        { ...node, isSelectedValue: true },
-        ...setSelectedChildrenNodes(getAllChildrenNodes(node), false),
-      ];
-    }
-  } else if (node.isSelectedValue && allChildrenSelected) {
     return [
-      { ...node, isSelectedValue: false },
+      { ...node, isSelectedValue: true },
       ...setSelectedChildrenNodes(getAllChildrenNodes(node), true),
     ];
   }

--- a/libs/conversation-view/src/utils/hierarchy-view.ts
+++ b/libs/conversation-view/src/utils/hierarchy-view.ts
@@ -235,13 +235,25 @@ export function applySelectionToTree(
   nodes: FilterTreeNodeProps[],
   selectedIds: Set<string>,
 ): FilterTreeNodeProps[] {
-  return nodes.map((node) => ({
-    ...node,
-    isSelectedValue: selectedIds.has(node.id),
-    children: node.children
+  return nodes.map((node) => {
+    const updatedChildren = node.children?.length
       ? applySelectionToTree(node.children, selectedIds)
-      : undefined,
-  }));
+      : node.children;
+
+    let isSelectedValue: boolean;
+    if (selectedIds.has(node.id)) {
+      isSelectedValue = true;
+    } else if (updatedChildren?.length) {
+      const enabledChildren = updatedChildren.filter((c) => !c.disabled);
+      isSelectedValue =
+        enabledChildren.length > 0 &&
+        enabledChildren.every((c) => !!c.isSelectedValue);
+    } else {
+      isSelectedValue = false;
+    }
+
+    return { ...node, isSelectedValue, children: updatedChildren };
+  });
 }
 
 export function toggleTreeNodeExpansion(


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/191

### Description of changes

**Problem**
In the hierarchy filter view, unchecking a parent node correctly unchecked all its children, but clicking the parent again to re-check them had no visible effect. Users were forced to re-select each leaf item individually.

**Root cause**
Structural group nodes are organisational hierarchy codes — they are never stored in `dimensionValues`, which holds only actual data/leaf codes. `applySelectionToTree` computed `isSelectedValue` solely from a direct ID lookup in `selectedIds`, so group nodes were permanently stuck as unchecked regardless of their children's state. Because group nodes always appeared unchecked, clicking one called `getFilterNodesBySelection` with `isSelectedValue`: false correctly, but on the next render the parent still showed unchecked.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
