### PR TITLE
fix: refresh conversation list when rename conversation from the search list

### DIFF
--- a/libs/conversation-list/src/components/ConversationList/ConversationList.tsx
+++ b/libs/conversation-list/src/components/ConversationList/ConversationList.tsx
@@ -257,6 +257,7 @@ export const ConversationList: FC<Props> = ({
                 actions={{
                   ...actions,
                   deleteConversation: handleDeleteConversation,
+                  renameConversation: handleRenameConversation,
                 }}
               />
             ) : (


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/238

### Description of changes

`ConversationsSearchResult` was passed the raw `renameConversation` API action, while the grouped view correctly used the wrapped `handleRenameConversation` which re-fetches both conversation lists and updates state after the rename.

Fix: Pass `renameConversation: handleRenameConversation` to `ConversationsSearchResult's` actions prop, consistent with how it's already wired in the grouped view.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
