### PR TITLE
chore: replace prop drilling with React Context in conversation-list

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,16 +1,3 @@
 # node:24-alpine vulnerabilities in https://hub.docker.com/layers/library/node/24-alpine
 
-CVE-2026-26960 exp:2026-05-20
-CVE-2026-26996 exp:2026-05-20
-CVE-2026-27903 exp:2026-05-20
-CVE-2026-27904 exp:2026-05-20
-CVE-2026-22184 exp:2026-05-20
-CVE-2026-29786 exp:2026-05-20
-CVE-2026-31802 exp:2026-05-20
-CVE-2026-33671 exp:2026-05-20
-
-# libcrypto3 libssl3
-CVE-2026-28390  exp:2026-05-20
-
-# musl, musl-utils
-CVE-2026-40200 exp:2026-05-20
+CVE-2026-33671 exp:2026-06-20

--- a/libs/conversation-list/src/components/ActionMenu/ActionMenu.tsx
+++ b/libs/conversation-list/src/components/ActionMenu/ActionMenu.tsx
@@ -10,7 +10,6 @@ import { getZippedFile } from '../../utils/compress-zip';
 import { triggerDownload } from '../../utils/download';
 import ShareConversationModal from '@statgpt/share-conversation/src/components/ShareConversation/ShareConversationModal';
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
-import { ConversationStyles } from '../../models/conversation-list';
 import {
   Dropdown,
   DropdownItem,
@@ -20,10 +19,10 @@ import { ActionMenuItem } from '../../types/action-menu-item';
 import ConversationRename from '../ConversationRename/ConversationRename';
 import { ONBOARDING_MODEL_POSTFIX } from '@epam/statgpt-shared-toolkit';
 import classNames from 'classnames';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
   conversation: ConversationInfo;
-  conversationStyles: ConversationStyles;
   shareConversationProps?: ShareConversationProps;
   onConversationDelete: (conversation: ConversationInfo) => void;
   getConversation: (conversationId: string) => Promise<Conversation>;
@@ -36,7 +35,6 @@ interface Props {
 
 export const ActionMenu: FC<Props> = ({
   conversation,
-  conversationStyles,
   shareConversationProps,
   onConversationDelete,
   getConversation,
@@ -46,6 +44,7 @@ export const ActionMenu: FC<Props> = ({
   locale,
   isDisabled,
 }) => {
+  const conversationStyles = useConversationStyles();
   const items: DropdownItem[] = useMemo(() => {
     const baseActions = [
       {
@@ -155,10 +154,7 @@ export const ActionMenu: FC<Props> = ({
 
       {deleteModalState === PopUpState.Opened && (
         <ConversationDelete
-          titles={conversationStyles.titles}
           locale={locale}
-          disableModalDividers={conversationStyles.disableModalDividers}
-          isSmallButton={conversationStyles.isSmallModalButton}
           deleteConversation={deleteConversation}
           onCloseModal={onCloseDeleteModal}
         />
@@ -177,11 +173,8 @@ export const ActionMenu: FC<Props> = ({
         <ConversationRename
           conversation={conversation}
           locale={locale}
-          titles={conversationStyles.titles}
           renameConversation={onRenameConversation}
           onCloseModal={onCloseRenameModal}
-          disableModalDividers={conversationStyles.disableModalDividers}
-          isSmallButton={conversationStyles.isSmallModalButton}
         />
       )}
     </>

--- a/libs/conversation-list/src/components/ConversationDelete/ConversationDelete.tsx
+++ b/libs/conversation-list/src/components/ConversationDelete/ConversationDelete.tsx
@@ -2,12 +2,9 @@
 
 import { Button, Popup, PopUpSize } from '@epam/statgpt-ui-components';
 import { FC } from 'react';
-import { ConversationListTitles } from '../../models/titles';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
-  disableModalDividers?: boolean;
-  isSmallButton?: boolean;
-  titles: ConversationListTitles;
   locale: string;
   onCloseModal: () => void;
   deleteConversation: () => void;
@@ -15,12 +12,11 @@ interface Props {
 
 const ConversationDelete: FC<Props> = ({
   onCloseModal,
-  disableModalDividers,
   deleteConversation,
-  isSmallButton,
-  titles,
   locale,
 }) => {
+  const { titles, disableModalDividers, isSmallModalButton } =
+    useConversationStyles();
   return (
     <Popup
       heading={titles?.deleteTitle ?? 'Delete conversation'}
@@ -39,7 +35,7 @@ const ConversationDelete: FC<Props> = ({
         <Button
           buttonClassName="cancel-button"
           title={titles?.cancel ?? 'Cancel'}
-          isSmallButton={isSmallButton}
+          isSmallButton={isSmallModalButton}
           onClick={(e) => {
             e.stopPropagation();
             onCloseModal();
@@ -48,7 +44,7 @@ const ConversationDelete: FC<Props> = ({
         <Button
           buttonClassName="text-button-primary text-button-primary-error"
           title={titles?.delete ?? 'Delete'}
-          isSmallButton={isSmallButton}
+          isSmallButton={isSmallModalButton}
           onClick={(e) => {
             e.stopPropagation();
             deleteConversation();

--- a/libs/conversation-list/src/components/ConversationItem/ConversationItem.tsx
+++ b/libs/conversation-list/src/components/ConversationItem/ConversationItem.tsx
@@ -4,14 +4,12 @@
 import { FC, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { ConversationInfo } from '@epam/ai-dial-shared';
-import {
-  ConversationListActions,
-  ConversationStyles,
-} from '../../models/conversation-list';
+import { ConversationListActions } from '../../models/conversation-list';
 import { HighlightText } from '@epam/statgpt-ui-components';
 import { ActionMenu } from '../ActionMenu/ActionMenu';
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
 import { getClearedConversationName } from '@epam/statgpt-shared-toolkit';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
   conversation: ConversationInfo;
@@ -20,7 +18,6 @@ interface Props {
   searchQuery?: string;
   isDisabled?: boolean;
   locale: string;
-  conversationStyles: ConversationStyles;
   onConversationClick: (folder: string, conversationId: string) => void;
   actions: ConversationListActions;
 }
@@ -33,9 +30,9 @@ const ConversationItem: FC<Props> = ({
   actions,
   locale,
   isDisabled,
-  conversationStyles,
   shareConversationProps,
 }) => {
+  const { titles, conversationItemIcon } = useConversationStyles();
   const conversationItemRef = useRef<HTMLDivElement | null>(null);
   const conversationName = getClearedConversationName(conversation?.name);
 
@@ -85,16 +82,10 @@ const ConversationItem: FC<Props> = ({
         !isDisabled &&
         onConversationClick(conversation.folderId, conversation?.id)
       }
-      title={
-        isDisabled
-          ? conversationStyles?.titles?.noActionsAllowed
-          : conversationName
-      }
+      title={isDisabled ? titles?.noActionsAllowed : conversationName}
     >
       <div className="flex min-w-0 flex-1 items-center">
-        {conversationStyles.conversationItemIcon
-          ? conversationStyles.conversationItemIcon
-          : null}
+        {conversationItemIcon ? conversationItemIcon : null}
 
         <h3
           className={classNames(
@@ -104,11 +95,7 @@ const ConversationItem: FC<Props> = ({
               ? 'conversation-item-text-active'
               : '',
           )}
-          title={
-            isDisabled
-              ? conversationStyles?.titles?.noActionsAllowed
-              : conversationName
-          }
+          title={isDisabled ? titles?.noActionsAllowed : conversationName}
         >
           {searchQuery?.length ? (
             <HighlightText
@@ -122,7 +109,6 @@ const ConversationItem: FC<Props> = ({
       </div>
       <ActionMenu
         locale={locale}
-        conversationStyles={conversationStyles}
         conversation={conversation}
         onConversationDelete={actions.deleteConversation}
         getConversation={actions.getConversation}

--- a/libs/conversation-list/src/components/ConversationList/ConversationList.tsx
+++ b/libs/conversation-list/src/components/ConversationList/ConversationList.tsx
@@ -28,6 +28,7 @@ import {
   ConversationStyles,
   GroupedConversations,
 } from '../../models/conversation-list';
+import { ConversationStylesContext } from '../../context/ConversationStylesContext';
 import { getConversationsGroupedByDate } from '../../utils/conversations-grouping';
 import { ConversationInfo } from '@epam/ai-dial-shared';
 import {
@@ -210,7 +211,7 @@ export const ConversationList: FC<Props> = ({
   return isLoading ? (
     <Loader />
   ) : (
-    <>
+    <ConversationStylesContext.Provider value={conversationStyles}>
       {!isCollapsed && (
         <div
           className={classNames(
@@ -225,8 +226,6 @@ export const ConversationList: FC<Props> = ({
           )}
           <ConversationsSearchField
             searchQuery={searchQuery}
-            searchIcon={conversationStyles.searchIcon}
-            titles={conversationStyles.titles}
             isExpandedSearch={isExpandedSearch}
             onSearchConversations={onSearchConversations}
             toggleSearchField={toggleSearchField}
@@ -243,11 +242,10 @@ export const ConversationList: FC<Props> = ({
           <>
             {conversations?.length === 0 &&
             sharedConversations?.length === 0 ? (
-              <NoConversations titles={conversationStyles.titles} />
+              <NoConversations />
             ) : isSearchConversations ? (
               <ConversationsSearchResult
                 locale={locale}
-                conversationStyles={conversationStyles}
                 conversations={[...sharedConversations, ...conversations]}
                 searchQuery={searchQuery}
                 selectedConversationId={selectedConversationId}
@@ -269,7 +267,6 @@ export const ConversationList: FC<Props> = ({
                       isDisabled={isStreaming}
                       key={groupLabel}
                       groupLabel={groupLabel}
-                      conversationStyles={conversationStyles}
                       groupedConversations={conversations}
                       handleConversationClick={handleConversationClick}
                       actions={{
@@ -287,6 +284,6 @@ export const ConversationList: FC<Props> = ({
         ) : null}
       </div>
       {children}
-    </>
+    </ConversationStylesContext.Provider>
   );
 };

--- a/libs/conversation-list/src/components/ConversationRename/ConversationRename.tsx
+++ b/libs/conversation-list/src/components/ConversationRename/ConversationRename.tsx
@@ -4,13 +4,10 @@ import { ConversationInfo } from '@epam/ai-dial-shared';
 import { getClearedConversationName } from '@epam/statgpt-shared-toolkit';
 import { Button, Input, Popup, PopUpSize } from '@epam/statgpt-ui-components';
 import { FC, useState } from 'react';
-import { ConversationListTitles } from '../../models/titles';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
   conversation: ConversationInfo;
-  disableModalDividers?: boolean;
-  isSmallButton?: boolean;
-  titles: ConversationListTitles;
   locale: string;
   onCloseModal: () => void;
   renameConversation: (conversationId: string, name: string) => void;
@@ -21,10 +18,9 @@ const ConversationRename: FC<Props> = ({
   onCloseModal,
   renameConversation,
   locale,
-  disableModalDividers,
-  titles,
-  isSmallButton,
 }) => {
+  const { titles, disableModalDividers, isSmallModalButton } =
+    useConversationStyles();
   const [value, setValue] = useState<string>(conversation?.name || '');
   const onInputChange = (value: string) => {
     setValue(value);
@@ -60,7 +56,7 @@ const ConversationRename: FC<Props> = ({
         <Button
           buttonClassName="cancel-button"
           title={titles?.cancel ?? 'Cancel'}
-          isSmallButton={isSmallButton}
+          isSmallButton={isSmallModalButton}
           onClick={(e) => {
             e.stopPropagation();
             onCloseModal();
@@ -69,7 +65,7 @@ const ConversationRename: FC<Props> = ({
         <Button
           buttonClassName="text-button-primary text-button-primary"
           title={titles?.save ?? 'Rename'}
-          isSmallButton={isSmallButton}
+          isSmallButton={isSmallModalButton}
           disabled={!value}
           onClick={(e) => {
             e.stopPropagation();

--- a/libs/conversation-list/src/components/ConversationsGroup/ConversationsGroup.tsx
+++ b/libs/conversation-list/src/components/ConversationsGroup/ConversationsGroup.tsx
@@ -9,18 +9,15 @@ import {
   sortConversationsByUpdatedAt,
 } from '../../utils/conversations-grouping';
 import ConversationItem from '../ConversationItem/ConversationItem';
-import {
-  ConversationListActions,
-  ConversationStyles,
-} from '../../models/conversation-list';
+import { ConversationListActions } from '../../models/conversation-list';
 import { IconCaretRightFilled } from '@tabler/icons-react';
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
   groupLabel: string;
   groupedConversations: ConversationInfo[];
   selectedConversationId?: string;
-  conversationStyles: ConversationStyles;
   actions: ConversationListActions;
   locale: string;
   isDisabled?: boolean;
@@ -33,12 +30,12 @@ const ConversationsGroup: FC<Props> = ({
   actions,
   selectedConversationId,
   groupLabel,
-  conversationStyles,
   groupedConversations,
   shareConversationProps,
   locale,
   isDisabled,
 }) => {
+  const { titles } = useConversationStyles();
   const [isGroupCollapsed, setIsGroupCollapsed] = useState<boolean>(false);
 
   const toggleGroupCollapse = useCallback(() => {
@@ -58,7 +55,7 @@ const ConversationsGroup: FC<Props> = ({
           )}
         />
         <span className="body-3 conversation-group-items-title-text">
-          {getLabelByGroup(groupLabel, conversationStyles?.titles)}
+          {getLabelByGroup(groupLabel, titles)}
         </span>
       </div>
       {!isGroupCollapsed && (
@@ -74,7 +71,6 @@ const ConversationsGroup: FC<Props> = ({
                 locale={locale}
                 isDisabled={isDisabled}
                 key={conversation.id || conversation.name}
-                conversationStyles={conversationStyles}
                 conversation={conversation}
                 selectedConversationId={selectedConversationId}
                 onConversationClick={handleConversationClick}

--- a/libs/conversation-list/src/components/ConversationsSearch/ConversationsSearchField.tsx
+++ b/libs/conversation-list/src/components/ConversationsSearch/ConversationsSearchField.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import { FC, ReactNode } from 'react';
+import { FC } from 'react';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import { Button, IconButton, InputWithIcon } from '@epam/statgpt-ui-components';
-import { ConversationListTitles } from '../../models/titles';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
   searchQuery?: string;
   isExpandedSearch?: boolean;
-  titles?: ConversationListTitles;
-  searchIcon?: ReactNode;
   onSearchConversations?: (search: string) => void;
   toggleSearchField?: () => void;
 }
@@ -17,11 +15,10 @@ interface Props {
 const ConversationsSearchField: FC<Props> = ({
   searchQuery,
   isExpandedSearch,
-  titles,
-  searchIcon,
   onSearchConversations,
   toggleSearchField,
 }) => {
+  const { titles, searchIcon } = useConversationStyles();
   return (
     <>
       {isExpandedSearch ? (

--- a/libs/conversation-list/src/components/ConversationsSearch/ConversationsSearchResult.tsx
+++ b/libs/conversation-list/src/components/ConversationsSearch/ConversationsSearchResult.tsx
@@ -5,20 +5,17 @@ import { ConversationInfo } from '@epam/ai-dial-shared';
 import { FC, useEffect, useState } from 'react';
 
 import ConversationItem from '../ConversationItem/ConversationItem';
-import {
-  ConversationListActions,
-  ConversationStyles,
-} from '../../models/conversation-list';
+import { ConversationListActions } from '../../models/conversation-list';
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
 import { getClearedConversationName } from '@epam/statgpt-shared-toolkit';
 import { sortConversationsByUpdatedAt } from '../../utils/conversations-grouping';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
 interface Props {
   conversations: ConversationInfo[];
   selectedConversationId?: string;
   searchQuery?: string;
   locale: string;
-  conversationStyles: ConversationStyles;
   actions: ConversationListActions;
   shareConversationProps?: ShareConversationProps;
   handleConversationClick: (folder: string, conversationId: string) => void;
@@ -29,13 +26,13 @@ const ConversationsSearchResult: FC<Props> = ({
   conversations,
   selectedConversationId,
   searchQuery,
-  conversationStyles,
   handleConversationClick,
   actions,
   locale,
   shareConversationProps,
   isDisabled,
 }) => {
+  const { titles } = useConversationStyles();
   const [filteredConversations, setFilteredConversations] = useState<
     ConversationInfo[]
   >([]);
@@ -56,14 +53,13 @@ const ConversationsSearchResult: FC<Props> = ({
     <>
       {!filteredConversations?.length ? (
         <h3 className="text-neutrals-800">
-          {conversationStyles?.titles?.noConversation ?? 'No conversations yet'}
+          {titles?.noConversation ?? 'No conversations yet'}
         </h3>
       ) : (
         filteredConversations.map((conversation) => (
           <ConversationItem
             locale={locale}
             key={conversation.id}
-            conversationStyles={conversationStyles}
             conversation={conversation}
             searchQuery={searchQuery}
             selectedConversationId={selectedConversationId}

--- a/libs/conversation-list/src/components/NoConversations/NoConversations.tsx
+++ b/libs/conversation-list/src/components/NoConversations/NoConversations.tsx
@@ -1,13 +1,10 @@
 'use client';
 
 import { FC } from 'react';
-import { ConversationListTitles } from '../../models/titles';
+import { useConversationStyles } from '../../context/ConversationStylesContext';
 
-interface Props {
-  titles?: ConversationListTitles;
-}
-
-const NoConversations: FC<Props> = ({ titles }) => {
+const NoConversations: FC = () => {
+  const { titles } = useConversationStyles();
   return (
     <div className="flex flex-col p-8 text-center">
       <p className="text-neutrals-800">

--- a/libs/conversation-list/src/context/ConversationStylesContext.ts
+++ b/libs/conversation-list/src/context/ConversationStylesContext.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { ConversationStyles } from '../models/conversation-list';
+
+export const ConversationStylesContext =
+  createContext<ConversationStyles | null>(null);
+
+export function useConversationStyles(): ConversationStyles {
+  const context = useContext(ConversationStylesContext);
+  if (!context) {
+    throw new Error(
+      'useConversationStyles must be used within ConversationStylesContext.Provider',
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-portal-frontend/issues/345

### Description of changes

Introduces `ConversationStylesContext` as an internal implementation detail of the `conversation-list` package. The top-level `ConversationList` component populates the context from its existing `conversationStyles` prop, and all nested components consume it directly via `useConversationStyles()`. No changes to the public API or to `ConversationListWrapper` in the portal app.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
