### PR TITLE
feat: add collapsible chat panel in advanced view mode

### DIFF
--- a/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
@@ -324,9 +324,9 @@ const ConversationViewWrapper: FC<Props> = ({
     hideDownloadTextInConversationView: true,
     hideDownloadIconInAdvancedView: true,
     downloadChevronIcon: <ChevronSolidDownIcon className="size-6" />,
-    infoDownloadIcon: <InfoIcon className="text-primary size-6" />,
+    infoDownloadIcon: <InfoIcon className="size-6 text-primary" />,
     successDownloadIcon: (
-      <SuccessIcon className="text-semantic-success size-6" />
+      <SuccessIcon className="size-6 text-semantic-success" />
     ),
     downloadInProgressActionIcon: <Reset className="size-4" />,
     downloadErrorActionIcon: <ExternalLink className="size-4" />,
@@ -351,7 +351,7 @@ const ConversationViewWrapper: FC<Props> = ({
     }),
     openLinkTitle: t(AttachmentsI18nKeys.OPEN_URL),
     dataGridTitle: t(AttachmentsI18nKeys.DATA_GRID),
-    errorDownloadIcon: <ErrorIcon className="text-semantic-error size-6" />,
+    errorDownloadIcon: <ErrorIcon className="size-6 text-semantic-error" />,
     datasetIcon: <Dataset className="size-5" />,
     chartingIcons,
     copyTitle: t(ChatI18nKeys.COPY),
@@ -359,7 +359,7 @@ const ConversationViewWrapper: FC<Props> = ({
     copyHoverTooltip: t(ChatI18nKeys.COPY),
     copyIcon: <Copy className="size-4" />,
     copiedIcon: <CheckIcon className="size-4" />,
-    limitationInfoIcon: <InfoBubble className="text-hues-900 size-4" />,
+    limitationInfoIcon: <InfoBubble className="size-4 text-hues-900" />,
     limitationInfoContentClassName: 'py-1 px-2 rounded',
     downloadTitles: {
       partialDataset: t(DownloadI18nKeys.PARTIAL_DATASET),
@@ -427,7 +427,7 @@ const ConversationViewWrapper: FC<Props> = ({
   };
 
   const limitMessages: LimitMessages = {
-    warningIcon: <WarningIcon className="text-semantic-warning size-4" />,
+    warningIcon: <WarningIcon className="size-4 text-semantic-warning" />,
     largeQuery: t(AdvancedViewI18nKeys.LARGE_QUERY),
     showingLimit: (limit: number) =>
       t(AdvancedViewI18nKeys.SHOWING_LIMIT, { limit }),
@@ -472,7 +472,7 @@ const ConversationViewWrapper: FC<Props> = ({
               title: t(ChatI18nKeys.CONVERSATION_ACCESS_ERROR_TITLE),
               text: t(ChatI18nKeys.CONVERSATION_ACCESS_ERROR_TEXT),
             }}
-            errorIcon={<ErrorIcon className="text-semantic-error size-6" />}
+            errorIcon={<ErrorIcon className="size-6 text-semantic-error" />}
             onClose={() => setShowNotFoundAlert(false)}
           />
         )}
@@ -567,7 +567,7 @@ const ConversationViewWrapper: FC<Props> = ({
               isOpenedAdvancedView ? (
                 <button
                   type="button"
-                  className="text-primary cursor-pointer"
+                  className="cursor-pointer text-primary"
                   aria-label={t(AppI18nKeys.COLLAPSE)}
                   onClick={() => setIsChatCollapsed(true)}
                 >

--- a/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
@@ -2,6 +2,7 @@
 
 import {
   AdvancedView,
+  CollapsedChatPanel,
   ConversationView,
   DatasetInfoOptions,
   useAdvancedView,
@@ -79,6 +80,8 @@ import Edit from '../../../public/images/messages/edit.svg';
 import Down from '../../../public/images/chat/down.svg';
 import ThumbPressed from '../../../public/images/messages/thumb-filled.svg';
 import Reset from '../../../public/images/reset.svg';
+import Collapse from '../../../public/images/menu/collapse.svg';
+import Expand from '../../../public/images/menu/expand.svg';
 import ExternalLink from '../../../public/images/external-link.svg';
 import GearIcon from '../../../public/images/gear.svg';
 import ResetArrowIcon from '../../../public/images/reset-arrow.svg';
@@ -124,6 +127,7 @@ const ConversationViewWrapper: FC<Props> = ({
   const [datasets, setDatasets] = useState<Dataflow[]>();
   const [isConversationNotFound, setIsConversationNotFound] = useState(false);
   const [showNotFoundAlert, setShowNotFoundAlert] = useState(false);
+  const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const { locale, id }: { locale: string; id: string[] } = useParams();
   const chartingIcons = {
     [ChartingIcon.NEXT]: <ChevronRight width={20} height={20} />,
@@ -141,6 +145,10 @@ const ConversationViewWrapper: FC<Props> = ({
     setIsConversationNotFound(false);
     setShowNotFoundAlert(false);
   }, [conversationKey]);
+
+  useEffect(() => {
+    if (!isOpenedAdvancedView) setIsChatCollapsed(false);
+  }, [isOpenedAdvancedView]);
 
   const handleConversationNotFound = useCallback(() => {
     setIsConversationNotFound(true);
@@ -316,9 +324,9 @@ const ConversationViewWrapper: FC<Props> = ({
     hideDownloadTextInConversationView: true,
     hideDownloadIconInAdvancedView: true,
     downloadChevronIcon: <ChevronSolidDownIcon className="size-6" />,
-    infoDownloadIcon: <InfoIcon className="size-6 text-primary" />,
+    infoDownloadIcon: <InfoIcon className="text-primary size-6" />,
     successDownloadIcon: (
-      <SuccessIcon className="size-6 text-semantic-success" />
+      <SuccessIcon className="text-semantic-success size-6" />
     ),
     downloadInProgressActionIcon: <Reset className="size-4" />,
     downloadErrorActionIcon: <ExternalLink className="size-4" />,
@@ -343,7 +351,7 @@ const ConversationViewWrapper: FC<Props> = ({
     }),
     openLinkTitle: t(AttachmentsI18nKeys.OPEN_URL),
     dataGridTitle: t(AttachmentsI18nKeys.DATA_GRID),
-    errorDownloadIcon: <ErrorIcon className="size-6 text-semantic-error" />,
+    errorDownloadIcon: <ErrorIcon className="text-semantic-error size-6" />,
     datasetIcon: <Dataset className="size-5" />,
     chartingIcons,
     copyTitle: t(ChatI18nKeys.COPY),
@@ -351,7 +359,7 @@ const ConversationViewWrapper: FC<Props> = ({
     copyHoverTooltip: t(ChatI18nKeys.COPY),
     copyIcon: <Copy className="size-4" />,
     copiedIcon: <CheckIcon className="size-4" />,
-    limitationInfoIcon: <InfoBubble className="size-4 text-hues-900" />,
+    limitationInfoIcon: <InfoBubble className="text-hues-900 size-4" />,
     limitationInfoContentClassName: 'py-1 px-2 rounded',
     downloadTitles: {
       partialDataset: t(DownloadI18nKeys.PARTIAL_DATASET),
@@ -419,7 +427,7 @@ const ConversationViewWrapper: FC<Props> = ({
   };
 
   const limitMessages: LimitMessages = {
-    warningIcon: <WarningIcon className="size-4 text-semantic-warning" />,
+    warningIcon: <WarningIcon className="text-semantic-warning size-4" />,
     largeQuery: t(AdvancedViewI18nKeys.LARGE_QUERY),
     showingLimit: (limit: number) =>
       t(AdvancedViewI18nKeys.SHOWING_LIMIT, { limit }),
@@ -464,7 +472,7 @@ const ConversationViewWrapper: FC<Props> = ({
               title: t(ChatI18nKeys.CONVERSATION_ACCESS_ERROR_TITLE),
               text: t(ChatI18nKeys.CONVERSATION_ACCESS_ERROR_TEXT),
             }}
-            errorIcon={<ErrorIcon className="size-6 text-semantic-error" />}
+            errorIcon={<ErrorIcon className="text-semantic-error size-6" />}
             onClose={() => setShowNotFoundAlert(false)}
           />
         )}
@@ -478,12 +486,21 @@ const ConversationViewWrapper: FC<Props> = ({
         'flex flex-row justify-center h-full w-full bg-white',
       )}
     >
+      {isOpenedAdvancedView && isChatCollapsed && (
+        <CollapsedChatPanel
+          conversationName={conversation?.name}
+          expandTitle={t(AppI18nKeys.EXPAND)}
+          expandIcon={<Expand width={20} height={20} />}
+          onExpand={() => setIsChatCollapsed(false)}
+        />
+      )}
       <div
         className={classNames(
           'flex flex-col h-full',
           isOpenedAdvancedView
             ? 'w-[422px] border border-neutrals-400'
             : 'w-full',
+          isOpenedAdvancedView && isChatCollapsed && 'hidden',
         )}
       >
         <div className={classNames('flex-1 min-h-0')}>
@@ -546,6 +563,18 @@ const ConversationViewWrapper: FC<Props> = ({
             }}
             scrollBottomIcon={<Down width={20} height={20} />}
             limitMessages={limitMessages}
+            headerRightSlot={
+              isOpenedAdvancedView ? (
+                <button
+                  type="button"
+                  className="text-primary cursor-pointer"
+                  aria-label={t(AppI18nKeys.COLLAPSE)}
+                  onClick={() => setIsChatCollapsed(true)}
+                >
+                  <Collapse width={20} height={20} />
+                </button>
+              ) : undefined
+            }
           >
             <Footer />
           </ConversationView>

--- a/libs/conversation-view/src/components/CollapsedChatPanel/CollapsedChatPanel.tsx
+++ b/libs/conversation-view/src/components/CollapsedChatPanel/CollapsedChatPanel.tsx
@@ -35,10 +35,10 @@ export const CollapsedChatPanel: FC<Props> = ({
   onExpand,
 }) => {
   return (
-    <div className="border-neutrals-400 flex h-full w-[51px] shrink-0 flex-col items-center border bg-white">
+    <div className="flex h-full w-[51px] shrink-0 flex-col items-center border border-neutrals-400 bg-white">
       <button
         type="button"
-        className="text-primary mt-[84px] flex size-9 items-center justify-center"
+        className="mt-[84px] flex size-9 items-center justify-center text-primary"
         aria-label={expandTitle}
         title={expandTitle}
         onClick={onExpand}
@@ -47,7 +47,7 @@ export const CollapsedChatPanel: FC<Props> = ({
       </button>
       <div className="flex min-h-0 flex-1 flex-col items-center overflow-hidden pb-[88px] pt-[72px]">
         <span
-          className="h3 min-h-0 flex-1 text-neutrals-1000 text-center [writing-mode:vertical-rl] rotate-180 truncate"
+          className="h3 min-h-0 flex-1 rotate-180 truncate text-center text-neutrals-1000 [writing-mode:vertical-rl]"
           title={conversationName}
         >
           {conversationName}

--- a/libs/conversation-view/src/components/CollapsedChatPanel/CollapsedChatPanel.tsx
+++ b/libs/conversation-view/src/components/CollapsedChatPanel/CollapsedChatPanel.tsx
@@ -1,0 +1,58 @@
+import { FC, ReactNode } from 'react';
+
+interface Props {
+  conversationName: string | undefined;
+  expandTitle: string;
+  expandIcon: ReactNode;
+  onExpand: () => void;
+}
+
+/**
+ * CollapsedChatPanel renders the collapsed state of the chat panel
+ * when advanced view is open, showing an expand button and the conversation
+ * title rotated vertically.
+ *
+ * @example
+ * Basic usage
+ * ```tsx
+ * <CollapsedChatPanel
+ *   conversationName="Q3 Revenue Analysis"
+ *   expandTitle="Expand"
+ *   expandIcon={<ExpandIcon width={20} height={20} />}
+ *   onExpand={() => setCollapsed(false)}
+ * />
+ * ```
+ *
+ * @param conversationName - Title displayed vertically; renders empty when undefined.
+ * @param expandTitle - Accessible label and tooltip for the expand button.
+ * @param expandIcon - Icon element rendered inside the expand button.
+ * @param onExpand - Called when the user clicks the expand button.
+ */
+export const CollapsedChatPanel: FC<Props> = ({
+  conversationName,
+  expandTitle,
+  expandIcon,
+  onExpand,
+}) => {
+  return (
+    <div className="border-neutrals-400 flex h-full w-[51px] shrink-0 flex-col items-center border bg-white">
+      <button
+        type="button"
+        className="text-primary mt-[84px] flex size-9 items-center justify-center"
+        aria-label={expandTitle}
+        title={expandTitle}
+        onClick={onExpand}
+      >
+        {expandIcon}
+      </button>
+      <div className="flex min-h-0 flex-1 flex-col items-center overflow-hidden pb-[88px] pt-[72px]">
+        <span
+          className="h3 min-h-0 flex-1 text-neutrals-1000 text-center [writing-mode:vertical-rl] rotate-180 truncate"
+          title={conversationName}
+        >
+          {conversationName}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/libs/conversation-view/src/components/CollapsedChatPanel/__tests__/CollapsedChatPanel.spec.tsx
+++ b/libs/conversation-view/src/components/CollapsedChatPanel/__tests__/CollapsedChatPanel.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CollapsedChatPanel } from '../CollapsedChatPanel';
+
+describe('CollapsedChatPanel', () => {
+  const defaultProps = {
+    conversationName: 'Q3 Revenue Analysis',
+    expandTitle: 'Expand',
+    expandIcon: <span data-testid="expand-icon" />,
+    onExpand: jest.fn(),
+  };
+
+  it('renders the conversation name', () => {
+    render(<CollapsedChatPanel {...defaultProps} />);
+
+    expect(screen.getByText('Q3 Revenue Analysis')).toBeTruthy();
+  });
+
+  it('renders empty title span when conversationName is undefined', () => {
+    const { container } = render(
+      <CollapsedChatPanel {...defaultProps} conversationName={undefined} />,
+    );
+
+    const span = container.querySelector('span.truncate');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toBe('');
+  });
+
+  it('renders the expand icon', () => {
+    render(<CollapsedChatPanel {...defaultProps} />);
+
+    expect(screen.getByTestId('expand-icon')).toBeTruthy();
+  });
+
+  it('calls onExpand when the expand button is clicked', () => {
+    const onExpand = jest.fn();
+    render(<CollapsedChatPanel {...defaultProps} onExpand={onExpand} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets aria-label and title on the expand button', () => {
+    render(<CollapsedChatPanel {...defaultProps} expandTitle="Open chat" />);
+
+    const button = screen.getByRole('button', { name: 'Open chat' });
+    expect(button.getAttribute('aria-label')).toBe('Open chat');
+    expect(button.getAttribute('title')).toBe('Open chat');
+  });
+});

--- a/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
+++ b/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
@@ -141,6 +141,7 @@ interface Props {
   isFinalMessage?: boolean;
   limitMessages: LimitMessages;
   attachmentsConfig?: AttachmentsConfig;
+  headerRightSlot?: ReactNode;
   children?: ReactNode;
 }
 
@@ -172,6 +173,7 @@ export const ConversationView: FC<Props> = ({
   isFinalMessage,
   limitMessages,
   attachmentsConfig,
+  headerRightSlot,
   children,
 }) => {
   const [conversationSignal, setConversationSignal] =
@@ -903,6 +905,7 @@ export const ConversationView: FC<Props> = ({
             isOpenedAdvancedView={isOpenedAdvancedView}
             isShowShareButton={!isReadonlyConversation && !isShowOnboarding}
             shareConversationProps={shareConversationProps}
+            rightSlot={headerRightSlot}
           />
         )}
         <div className="flex min-h-0 w-full flex-1">

--- a/libs/conversation-view/src/components/ConversationViewHeader/ConversationViewHeader.tsx
+++ b/libs/conversation-view/src/components/ConversationViewHeader/ConversationViewHeader.tsx
@@ -40,7 +40,7 @@ const ConversationViewHeader: FC<Props> = ({
         >
           {conversation?.name}
         </span>
-        <div className="flex gap-4 items-center ml-3">
+        <div className="ml-3 flex items-center gap-4">
           {!isOpenedAdvancedView && isShowShareButton && (
             <div className="flex gap-x-2">
               <ShareConversation

--- a/libs/conversation-view/src/components/ConversationViewHeader/ConversationViewHeader.tsx
+++ b/libs/conversation-view/src/components/ConversationViewHeader/ConversationViewHeader.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @nx/enforce-module-boundaries */
 import { Conversation } from '@epam/ai-dial-shared';
 import classNames from 'classnames';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 
 import ShareConversation from '@statgpt/share-conversation/src/components/ShareConversation/ShareConversation';
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
@@ -12,6 +12,7 @@ interface Props {
   isOpenedAdvancedView?: boolean;
   isShowShareButton?: boolean;
   shareConversationProps?: ShareConversationProps;
+  rightSlot?: ReactNode;
 }
 
 const ConversationViewHeader: FC<Props> = ({
@@ -20,6 +21,7 @@ const ConversationViewHeader: FC<Props> = ({
   isOpenedAdvancedView,
   isShowShareButton,
   shareConversationProps,
+  rightSlot,
 }) => {
   return (
     <>
@@ -38,7 +40,7 @@ const ConversationViewHeader: FC<Props> = ({
         >
           {conversation?.name}
         </span>
-        <div className="flex gap-4">
+        <div className="flex gap-4 items-center ml-3">
           {!isOpenedAdvancedView && isShowShareButton && (
             <div className="flex gap-x-2">
               <ShareConversation
@@ -48,6 +50,7 @@ const ConversationViewHeader: FC<Props> = ({
               />
             </div>
           )}
+          {rightSlot}
         </div>
       </header>
     </>

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -24,6 +24,7 @@ export { AdvancedView } from './components/AdvancedView/AdvancedView';
 export { ConversationView } from './components/ConversationView/ConversationView';
 export { ChatFooter } from './components/ChatFooter/ChatFooter';
 export { ChatOnboardingFooter } from './components/ChatOnboardingFooter/ChatOnboardingFooter';
+export { CollapsedChatPanel } from './components/CollapsedChatPanel/CollapsedChatPanel';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 export type { ShareConversationProps } from '../../share-conversation/src/models/share-conversation';
 export type { DatasetInfoOptions } from './components/AdvancedView/DatasetInfo';


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/258

### Description of changes

Adds a collapsible chat panel for when advanced view is open. A collapse button in the chat header folds the panel into a narrow vertical bar showing the conversation name (truncated if too long). An expand button restores it. The panel auto-expands when advanced view is closed.
  
- New `CollapsedChatPanel` library component with accessible buttons (`type="button"`, `aria-label`) and unit tests
- `headerRightSlot` prop added to `ConversationView` for injecting the collapse trigger into the header
- `rightSlot` prop added to `ConversationViewHeader` (internal)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
