### PR TITLE
chore: add filter system spec series and spec maintenance conventions

### DIFF
--- a/.claude/rules/spec-conventions.md
+++ b/.claude/rules/spec-conventions.md
@@ -1,0 +1,34 @@
+# Spec conventions
+
+## When specs must be updated
+
+Any edit to a file listed in `specs/filters/README.md` under **Key Source Files**
+must be accompanied by a corresponding update to the relevant spec in the same
+change. Spec drift is a defect — treat it the same as a failing test.
+
+The relevant spec for a given file is identified by:
+1. The "Key files" section at the top of each spec, or
+2. The spec table in `specs/filters/README.md`
+
+## Scope
+
+`specs/filters/` covers the full lifecycle of filters, dataset merging, constraints,
+persistence, grids, Python attachment, applied-filters display, and chart attachments.
+Read `specs/filters/README.md` for the full index and file-to-spec mapping.
+
+## What counts as a spec-impacting change
+
+- Adding, removing, or renaming a function described in a spec
+- Changing the shape of a data type described in a spec
+- Changing the order or gating of async steps described in a data-flow spec
+- Adding a new invariant or gotcha
+- Removing a gotcha that was fixed
+
+Minor internal refactors with no externally visible behaviour change do not require
+a spec update — but when in doubt, update.
+
+## Line numbers
+
+Line numbers in specs are approximate starting points. Use function and symbol names
+for navigation. Update line numbers when you can; do not block a spec update because
+you cannot verify every number.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,13 @@ No Redux or Zustand. State is managed via **React Context + useState** only. Ser
 
 Chat responses use SSE (Server-Sent Events). `ChatMessagesContext` tracks the `isStreaming` flag. The `/api/chat` route proxies streaming responses from the DIAL API.
 
+### Documentation
+
+Specs for the filter / dataset-merging / chart-rendering system live in
+`specs/filters/`. See `specs/filters/README.md` for the index. When editing files
+covered by those specs, update the relevant spec in the same change — see
+`.claude/rules/spec-conventions.md`.
+
 ### Styling
 
 Tailwind CSS 3.4 with a custom CSS-variable-based color system defined in `tailwind.config.js`. The compiled stylesheet is output to `dist/libs/ui-components/index.css` via `npm run build:styles`.

--- a/specs/filters/01-domain-model.md
+++ b/specs/filters/01-domain-model.md
@@ -1,0 +1,247 @@
+# Domain Model
+
+This document covers the core data types that everything else in the filter/merging
+system is built on. Read this first; the other specs assume this vocabulary.
+
+---
+
+## The Persistence Layer: `DataQuery` and `QueryFilter`
+
+`DataQuery` (`libs/shared-toolkit/src/models/data-query.ts`) is the **record of
+what the user asked for**. One `DataQuery` per active dataset. It is serialised to
+JSON and stored in the conversation (see `05-system-message-persistence.md`).
+
+```ts
+interface DataQuery {
+  title?: string;
+  urn: string;                  // SDMX dataflow URN — uniquely identifies the dataset
+  sdmx1Source?: string;         // Optional SDMX v1 source override
+  metadata: {
+    countryDimension: string;   // Dimension ID that plays the "country" role in this dataset
+    indicatorDimensions: string[];
+    timePeriodDimension?: string;
+    keyDimensionIdsInDsdOrder?: string[];
+    datasetUrl?: string;
+  };
+  filters?: QueryFilter[];      // The user's dimension selections, serialised
+}
+```
+
+`QueryFilter` is a single dimension selection inside a `DataQuery`:
+
+```ts
+interface QueryFilter {
+  componentCode: string;        // Dimension ID (e.g. "REF_AREA", "FREQ")
+  operator: QueryFilterType;    // 'in' | 'between' | 'excluded'
+  values: string[];
+}
+```
+
+Three operators exist:
+
+| Operator | Use case | `values` content |
+|---|---|---|
+| `in` | User selected specific values | Array of code IDs, e.g. `["FRA","DEU"]` |
+| `between` | Time period range | `[startDate, endDate]` formatted as `MM-DD-YYYY` (or ISO for Python attachment) |
+| `excluded` | Dimension is explicitly excluded from the query | Empty array |
+
+A wildcard (all values) is represented as `{ operator: "in", values: ["*"] }` using
+the `GET_v3_FILTER_ALL = "*"` constant from `@epam/statgpt-sdmx-toolkit`.
+
+---
+
+## The UI Layer: `Filter` and `FilterValue`
+
+`Filter` (`libs/conversation-view/src/models/filters.ts`) is the **runtime
+representation** used by the UI. It is derived from `DataQuery` + SDMX structural
+data. It lives in React state and is never written to the conversation directly.
+
+`Filter` is a union type:
+
+```ts
+type Filter = DatasetFilter | SharedFilter;
+```
+
+### `DatasetFilter`
+
+Tied to one dataset:
+
+```ts
+interface DatasetFilter extends FilterBase {
+  filterType: 'dataset';
+  datasetUrn?: string;          // Which dataset owns this dimension
+}
+```
+
+### `SharedFilter`
+
+Spans multiple datasets (Country, Frequency, Time Period):
+
+```ts
+interface SharedFilter extends FilterBase {
+  filterType: 'shared';
+  datasetUrn?: undefined;                           // Intentionally absent
+  sourceDatasetUrns?: string[];                     // All datasets that contributed
+  sourceFilterIdsByDataset?: Record<string, string>; // datasetUrn → native dimension ID
+}
+```
+
+The `sourceFilterIdsByDataset` map is the key to the whole merging story: it
+answers "for Dataset A, which dimension ID corresponds to this shared COUNTRY
+filter?" Without it, expansion back to per-dataset filters would need to re-run
+the matching logic every time.
+
+### `FilterBase` (shared fields)
+
+```ts
+interface FilterBase {
+  id?: string;                  // Dimension ID (for dataset filters) or shared ID (COUNTRY / FREQUENCY / TIME_PERIOD)
+  title?: string;               // Display name
+  dimensionValues?: FilterValue[];
+  isSelectedFilter?: boolean;   // Whether this filter is currently open in the UI
+  isTimeDimension?: boolean;    // True for TIME_PERIOD dimensions
+  timeRange?: TimeRange;        // Used instead of dimensionValues for time dimensions
+  isHierarchical?: boolean;     // Whether codes have parent-child relationships
+  isDisabled?: boolean;
+  displayMode?: string;         // 'HIERARCHY' | 'FLAT_LIST' | hierarchy URN
+  isExcluded?: boolean;         // Maps to operator: 'excluded' in QueryFilter
+}
+```
+
+### `FilterValue`
+
+One selectable item inside a filter:
+
+```ts
+interface FilterValue {
+  id: string;                   // Code ID used in API calls
+  name?: string;                // Localised display label
+  isSelectedValue?: boolean;
+  isExpanded?: boolean;         // Hierarchy node expanded state
+  parent?: string;              // Parent code ID for hierarchical codelists
+  sourceValues?: FilterValueSource[]; // Only present on shared filter values
+}
+```
+
+`sourceValues` is the per-value equivalent of `sourceFilterIdsByDataset`. When a
+shared filter value is "France", `sourceValues` records:
+- Dataset A: `{ datasetUrn: "...A...", id: "FR", name: "France" }`
+- Dataset B: `{ datasetUrn: "...B...", id: "FRA", name: "France" }`
+
+This lets `expandSharedFilter` translate the user's "France" selection back to the
+correct code in each dataset.
+
+---
+
+## The Structural Layer: Dimensions and Metadata
+
+### `Dimension` (from `@epam/statgpt-sdmx-toolkit`)
+
+Raw SDMX structural metadata for one dimension in a dataset. Comes from the
+`/structure` API. Key fields: `id`, `type` (`DimensionType.TIME_DIMENSION` or
+regular), reference to codelist.
+
+### `DatasetDimensionsMetadataMap`
+
+Deployment-time configuration (`libs/sdmx-toolkit/src/models/datasets-metadata.ts`).
+Built from the server response at startup:
+
+```ts
+type DatasetDimensionsMetadataMap = Record<
+  ShortUrn,                             // Short dataset identifier
+  Record<DimensionKey, DimensionConfig> // dimensionId → config
+>;
+
+interface DimensionConfig {
+  alias: string | null;
+  subtype?: 'FREQUENCY' | 'REGION' | null;
+  dimensionType: 'INDICATOR' | 'NON_INDICATOR' | 'TIME_PERIOD';
+  allValues: DimensionAllValues | null;
+}
+```
+
+This is how the system knows that `REF_AREA` in Dataset A and `GEO` in Dataset B
+are both the "region/country" dimension — they both have `subtype: 'REGION'`.
+
+### `DatasetDimensionsScheme`
+
+A lightweight derived summary per dataset (`libs/sdmx-toolkit/src/models/dataset-dimensions-scheme.ts`):
+
+```ts
+interface DatasetDimensionsScheme {
+  timePeriod: string | undefined;  // The time dimension ID
+  frequency: string | undefined;   // The frequency dimension ID
+  region: string | undefined;      // The country/region dimension ID
+  indicators: string[];            // Indicator dimension IDs
+  other: string[];                 // All other dimension IDs
+}
+```
+
+Used primarily by the cross-dataset grid to know which column goes where.
+
+---
+
+## The Constraint Layer: `DataConstraints`
+
+SDMX constraints (`libs/sdmx-toolkit/src/models/structural-metadata/constraints.ts`)
+tell the client which dimension-value combinations actually exist in the data:
+
+```ts
+interface DataConstraints {
+  cubeRegions?: CubeRegion[];
+  annotations?: ...;            // Contains TIME_PERIOD start/end keys
+}
+
+interface CubeRegion {
+  isIncluded?: boolean;         // true = listed values are included; false = excluded
+  memberSelection?: MemberSelection[];
+}
+
+interface MemberSelection {
+  included: boolean;
+  componentId: string;          // Dimension ID
+  selectionValues: MemberSelectionValue[];
+}
+
+interface MemberSelectionValue {
+  memberValue: string;          // Allowed code
+}
+```
+
+In practice the app calls the constraints endpoint with the user's current
+non-shared filter selections as input and gets back the allowed values for all
+other dimensions. This makes it so that selecting "Annual" in Frequency greys out
+countries that have no annual data.
+
+The time range is not in `cubeRegions` — it lives in `annotations` under the keys
+`TIME_PERIOD_START_ANNOTATION_KEY` and `TIME_PERIOD_END_ANNOTATION_KEY`, extracted
+by `getAnnotationPeriod()` from `@epam/statgpt-sdmx-toolkit`.
+
+---
+
+## How the Layers Relate
+
+```
+Deployment config
+  └─ DatasetDimensionsMetadataMap   (static, loaded once)
+       └─ tells us which dimension plays which semantic role
+
+SDMX Structural API
+  └─ Dimension[]                    (per dataset, loaded on first use)
+       └─ combined with codelists → FilterValue[]
+
+SDMX Constraints API
+  └─ DataConstraints[]              (per dataset, re-fetched on filter changes)
+       └─ limits which FilterValues are enabled
+
+User interaction
+  └─ Filter[] (React state)         (merged/shared filters shown in UI)
+       └─ on submit → QueryFilter[] (per-dataset, stored in DataQuery)
+            └─ DataQuery[]          (stored in system message, sent to LLM)
+```
+
+The central asymmetry to keep in mind: the **UI works with merged `Filter[]`**
+(one picker for Country across all datasets), but the **API always receives
+per-dataset `QueryFilter[]`** (each dataset gets its own native dimension ID and
+code values). The merging and expansion code in `multiple-filters.ts` is what
+bridges these two representations.

--- a/specs/filters/02-single-dataset-filters.md
+++ b/specs/filters/02-single-dataset-filters.md
@@ -1,0 +1,194 @@
+# Single-Dataset Filters
+
+This spec covers the filter lifecycle for **one dataset in isolation**: how
+`Filter[]` objects are constructed from SDMX structural data, how saved filter
+state is restored when a conversation is reopened, how constraint responses update
+the available values, and how the final selection is serialised back into
+`QueryFilter[]` for persistence and API calls.
+
+The multi-dataset merging layer sits on top of everything described here — it
+calls these same utilities per dataset before combining results.
+
+---
+
+## 1. Building Filters from Structural Data
+
+**Entry point:** `getDatasetFilters()` in
+`libs/conversation-view/src/utils/filters.ts:27`
+
+This function takes SDMX structural data and produces the initial `Filter[]` for a
+dataset — one filter per dimension, with all available values populated.
+
+```
+Dimension[] + StructuralData + StructureItemBase[] + locale + datasetUrn
+  → Filter[]
+```
+
+For each dimension it:
+1. Finds the associated codelist (via `findCodelistByDimension`)
+2. Calls `getAvailableCodes()` to produce `FilterValue[]` — codes filtered by
+   what's structurally allowed and localised to the current locale
+3. Sets `isHierarchical = true` if any code has a `parent` reference
+4. Sets `displayMode` to `HIERARCHY` if hierarchical, `FLAT_LIST` otherwise
+5. Sets `isTimeDimension = true` for dimensions of type `DimensionType.TIME_DIMENSION`
+
+At this stage all values have `isSelectedValue = false` — nothing is selected yet.
+
+### Filling values from constraints
+
+After the first constraints response arrives, `getFilledFilters()`
+(`libs/conversation-view/src/utils/get-filled-filters.ts:11`) replaces the
+dimension values with constraint-filtered ones:
+
+1. For each dimension, calls `getAvailableCodesFromConstrains()` — this returns
+   only the codes the SDMX server said are available given the current filter state
+2. Merges selection state: any value that was selected in the old filter and still
+   appears in the constraint response keeps its `isSelectedValue = true`
+3. **Preserves extra selected values** not in the constraint response — these are
+   hierarchy-only codes that are valid in a hierarchy view but absent from the
+   constraint cube region. Without this, selecting a parent code and then
+   refreshing constraints would silently deselect it.
+
+The `getFilledDatasetFiltersMap()` function in `multiple-filters.ts:640` is the
+multi-dataset wrapper: it calls `getFiltersWithValuesMap()`, which calls
+`getAvailableCodesFromConstrains()` directly for each dataset, and returns empty
+`dimensionValues` when constraints or data messages are not yet available. Note:
+the "preserve extra selected hierarchy codes" logic described above lives in
+`getFilledFilters()`, which is called by `getFiltersByConstraints()` — the
+interactive-update path — not by `getFilledDatasetFiltersMap()`.
+
+---
+
+## 2. Restoring Saved State (Preselection)
+
+When a conversation is reopened, `DataQuery[]` is read from the system message
+(see `05-system-message-persistence.md`). The saved `QueryFilter[]` inside each
+`DataQuery` need to be applied to the freshly-built `Filter[]`.
+
+**Entry point:** `getFiltersPreselectedByDataQuery()` in
+`libs/conversation-view/src/utils/filters.ts:175`
+
+For each filter in the `Filter[]` it looks for a matching `QueryFilter` by
+`componentCode === filter.id`:
+
+- **Time dimension:** Parses the `BETWEEN` values back to `Date` objects, then
+  intersects with the constraints-derived time range from `getAnnotationPeriod()`.
+  If both exist, the tighter of the two ranges wins — the saved range is clipped to
+  what the constraint says is actually available.
+
+- **Regular dimension:** Sets `isSelectedValue = true` on any `FilterValue` whose
+  `id` is in `filterFromAttachment.values`.
+
+- **No saved filter for this dimension:** Leaves the filter as-is (no selection).
+
+### Multi-dataset variant
+
+`getFiltersPreselectedByDataQueries()` in `multiple-filters.ts:673` wraps the
+above for multiple datasets. It has one additional behaviour: **wildcard
+propagation**. If Dataset A has an explicit COUNTRY selection and Dataset B has no
+COUNTRY filter saved at all (implicit wildcard), and both datasets contribute to a
+shared COUNTRY filter, then Dataset B's values are all selected so the shared
+filter shows them as selected. Without this, the shared filter UI would show
+Dataset A's countries as selected but Dataset B's as unselected, which is
+misleading.
+
+---
+
+## 3. Responding to User Selection Changes
+
+Two mutation utilities in `filters.ts` handle the common cases:
+
+**`updateFiltersWithSelectedItem(filters, selectedFilter)`** — marks one filter as
+the currently open/active one (`isSelectedFilter = true`), clears the flag on all
+others. Used when the user opens a filter panel.
+
+**`updateFiltersWithDisplayMode(filters, currentFilter, displayMode)`** — updates
+the display mode (flat list, hierarchy, or a named hierarchy URN) for one filter.
+
+**`getFiltersAfterDelete(filters, deletedFilter)`** and
+**`getFiltersAfterClear(filters)`** — both call `clearFilterValues()` which sets
+all `isSelectedValue = false` and clears `timeRange`. "Delete" clears one specific
+filter; "Clear all" clears every filter.
+
+**Hierarchical selection:** When a user selects a node in a hierarchical filter,
+`getFilterNodesBySelection()` in `filters.ts:316` cascades the selection state to
+all descendants. Selecting a parent selects all children; deselecting a parent
+deselects all children.
+
+---
+
+## 4. Serialising Filters to QueryFilter[]
+
+When the user confirms their selection, the UI layer calls `setDataQueryFilters()`
+(or `buildDataQueryWithMergedFilters()` for the full DataQuery merge).
+
+**`setDataQueryFilters(filters, datasetUrn)`** in `query-filters.ts:186`
+
+This is the core serialisation step. It calls `buildQueryFiltersCore()` which:
+
+1. Calls `getFiltersForQueryContext(filters, datasetUrn)` to get only the filters
+   relevant to this dataset (handles shared filter expansion — see spec 03)
+2. Keeps only filters that have something to say: a time range, an excluded flag,
+   or at least one selected value
+3. For each kept filter:
+   - **Time dimension:** produces `{ operator: 'between', values: [start, end] }`
+     formatted as `MM-DD-YYYY`
+   - **Excluded:** produces `{ operator: 'excluded', values: [] }`
+   - **Regular selection:** produces `{ operator: 'in', values: [selectedIds...] }`
+
+Note: `buildQueryFiltersForPythonAttachment()` is identical but formats dates as
+`YYYY-MM-DD` (ISO). It is used when building the filter string sent to the Python
+code execution environment.
+
+**`buildDataQueryWithMergedFilters(dataQuery, uiFilters)`** in `query-filters.ts:160`
+
+A higher-level function that produces a complete updated `DataQuery`. It:
+1. Builds `updatedFiltersFromUI` via `buildQueryFiltersForPythonAttachment`
+2. Computes `uiFilterCodes` — the set of dimension IDs the UI is controlling
+   (both directly and via shared filter expansion)
+3. For any UI-controlled dimension that ends up with no selection,
+   adds a wildcard filter `{ operator: 'in', values: ['*'] }` — this explicitly
+   tells the API "all values", rather than leaving the filter absent (which could
+   be misinterpreted)
+4. Keeps any "hidden" filters — `QueryFilter` entries in the original `DataQuery`
+   whose `componentCode` is not in the UI-controlled set. These are filters set
+   outside the UI (e.g. by the LLM) that the user didn't touch.
+
+---
+
+## 5. Computing the Time Series Key
+
+Alongside the filter values, the app builds a `DatasetQueryFilters` object:
+
+```ts
+interface DatasetQueryFilters {
+  filterKey: string;   // time-series key: dimension values concatenated in DSD order
+  timeFilter: string;  // time period filter string for the SDMX data API
+}
+```
+
+`getQueryFilters()` in `query-filters.ts:41` produces this. The `filterKey` is
+built by `getTimeSeriesFilterKey()` from sdmx-toolkit — it takes the
+dimension selections in their DSD-defined order and concatenates them, which
+matches the SDMX data URL key format (`A.FRA+DEU.GDP`).
+
+`timeFilter` is built by `getQueryTimePeriodFilters()` from sdmx-toolkit and
+represents the time period as a SDMX-formatted period string.
+
+These two strings are what actually get sent to the SDMX data API.
+
+---
+
+## Invariants
+
+- A filter with no selected values and no time range is simply omitted from
+  `QueryFilter[]` — there is no "empty selection" serialisation.
+- A wildcard (`*`) filter only appears when the UI explicitly cleared a dimension
+  that previously had a selection. It is never generated for dimensions that were
+  never touched.
+- Selected values not present in the current constraint response are still
+  preserved in `Filter[]` (for hierarchy codes). They are not persisted to
+  `QueryFilter[]` unless they were actually selected.
+- `filterType: 'dataset'` is always set on filters passed to serialisation
+  functions — shared filters must be expanded first.
+

--- a/specs/filters/03-shared-filters-merging.md
+++ b/specs/filters/03-shared-filters-merging.md
@@ -1,0 +1,287 @@
+# Shared Filters — Merging and Expansion
+
+This is the conceptually hardest part of the system. When two or more datasets are
+active simultaneously, the app needs to present a single "Country" picker, a single
+"Frequency" picker, and a single "Time Period" picker — even though each dataset
+uses different dimension IDs and different code values to represent these concepts.
+
+All of this logic lives in
+`libs/conversation-view/src/utils/multiple-filters.ts`.
+
+---
+
+## The Core Problem
+
+Dataset A has a dimension called `REF_AREA` with codes `FRA`, `DEU`, `USA`.
+Dataset B has a dimension called `GEO` with codes `FR`, `DE`, `US`.
+
+Both represent "Country/Region". If we show two separate pickers, the user must
+select the same country twice. Worse, they might select inconsistent values.
+
+The solution: detect that both dimensions play the `REGION` role (via
+`DatasetDimensionsMetadataMap`), **merge their values by name** into one shared
+`SharedFilter`, and when the user submits, **expand** that shared filter back into
+two separate `DatasetFilter` entries — one for each dataset, using the correct
+native codes.
+
+Three dimensions get this treatment, identified by the constants:
+
+```ts
+COMMON_COUNTRY_FILTER_ID    = 'COUNTRY'
+COMMON_FREQUENCY_FILTER_ID  = 'FREQUENCY'
+COMMON_TIME_PERIOD_FILTER_ID = 'TIME_PERIOD'
+```
+
+---
+
+## Recognising a Shared Dimension
+
+`SHARED_FILTERS_CONFIG` (`multiple-filters.ts:142`) defines the three shared
+filter types and their matching rules:
+
+```ts
+[
+  { id: 'COUNTRY',     subtype: 'REGION',     getMergedValueKey: nameBasedMatcher },
+  { id: 'FREQUENCY',   subtype: 'FREQUENCY',  getMergedValueKey: nameBasedMatcher },
+  { id: 'TIME_PERIOD', subtype: undefined,    getMergedValueKey: (v) => v.id },
+]
+```
+
+`isMatchingSharedFilterConfig()` decides whether a `DatasetFilter` belongs to a
+shared filter category. The rules, in priority order:
+
+1. If it's already a `SharedFilter`, match by ID equality.
+2. For TIME_PERIOD: match if `filter.isTimeDimension === true`, or if
+   `DimensionConfig.dimensionType === 'TIME_PERIOD'`, or if the filter ID is
+   literally `'TIME_PERIOD'`.
+3. For COUNTRY and FREQUENCY: match if the dimension's `subtype` in
+   `DatasetDimensionsMetadataMap` equals `'REGION'` or `'FREQUENCY'`
+   respectively. Fallback: match by ID equality (e.g. if a dimension is literally
+   named `'COUNTRY'` but has no subtype configured).
+
+This means the subtype from deployment metadata is the primary signal. ID matching
+is just a fallback for datasets where deployment config is incomplete.
+
+---
+
+## Merging: `mergeSharedFilters()`
+
+`mergeSharedFilters(filters, datasetDimensionsMetadataMap)` at `multiple-filters.ts:295`
+
+Takes a flat `Filter[]` (mix of dataset-specific filters from all datasets) and
+returns a new `Filter[]` where the shared dimensions have been collapsed into
+single `SharedFilter` entries.
+
+**Algorithm:**
+
+1. Walk every filter. If it matches a shared config and has a `datasetUrn`, put it
+   in a bucket keyed by the shared config ID (`groupedFilters` map). Otherwise
+   keep it in `otherFilters`.
+
+2. For each shared config, if the bucket has entries, call
+   `mergeSharedFilterValues()` to combine the values, then build one `SharedFilter`.
+
+3. The resulting `SharedFilter` gets:
+   - `id`: the shared config ID (`'COUNTRY'`, `'FREQUENCY'`, or `'TIME_PERIOD'`)
+   - `filterType: 'shared'`
+   - `datasetUrn: undefined`
+   - `sourceDatasetUrns`: all dataset URNs that contributed
+   - `sourceFilterIdsByDataset`: `{ "urn-A": "REF_AREA", "urn-B": "GEO" }`
+   - `dimensionValues`: the merged values (see below)
+   - `timeRange`: for TIME_PERIOD, the union of all dataset time ranges
+
+4. Return `[...sharedFilters, ...otherFilters]` — shared filters first, then all
+   the dataset-specific filters that didn't match any shared config.
+
+### Merging values: `mergeSharedFilterValues()`
+
+At `multiple-filters.ts:255`. Produces the unified `FilterValue[]` for a shared
+filter from multiple datasets' individual filters.
+
+For COUNTRY and FREQUENCY the merge key is the **normalised value name**
+(`name.trim().toLowerCase()`). For TIME_PERIOD it's the **value ID** itself.
+
+Name-based matching is why "France" in Dataset A (`FRA`) and "France" in Dataset B
+(`FR`) become one entry in the shared filter — they have the same name.
+
+For each unique merge key the result is one `FilterValue` with:
+- `id`: the merge key itself (e.g. `"name:france"`)
+- `name`: the human-readable label
+- `isSelectedValue`: `true` if it was selected in *any* source dataset
+- `sourceValues`: one `FilterValueSource` per dataset that had this value
+
+```ts
+// Example: shared COUNTRY value for "France"
+{
+  id: "name:france",
+  name: "France",
+  isSelectedValue: true,
+  sourceValues: [
+    { datasetUrn: "urn-A", id: "FRA", name: "France" },
+    { datasetUrn: "urn-B", id: "FR",  name: "France" },
+  ]
+}
+```
+
+If a value has no name (unusual but possible), the fallback key is
+`"dataset:{urn}:id:{valueId}"` — making it dataset-unique rather than shared.
+
+---
+
+## Expansion: `expandSharedFilter()`
+
+At `multiple-filters.ts:457`. The reverse of merging. Takes one `SharedFilter` and
+produces a `DatasetFilter[]` — one per contributing dataset.
+
+**Time dimension path** (`expandSharedTimeFilter`): Simply copies the
+`SharedFilter` to each `sourceDatasetUrn`, replacing `id` with the native time
+dimension ID and setting `filterType: 'dataset'`. The `timeRange` is preserved
+as-is (no per-dataset translation needed for time ranges).
+
+**Non-time dimension path** (`mapSharedDimensionValuesByDataset`): For each
+selected `FilterValue` in the shared filter, reads its `sourceValues` to find
+which dataset has which native code. Produces one `DatasetFilter` per dataset
+with translated `dimensionValues`.
+
+```
+SharedFilter "COUNTRY", selected: ["name:france"]
+  sourceValues of "name:france":
+    { datasetUrn: "urn-A", id: "FRA" }
+    { datasetUrn: "urn-B", id: "FR"  }
+
+→ DatasetFilter { datasetUrn: "urn-A", id: "REF_AREA", dimensionValues: [{ id: "FRA", isSelectedValue: true }] }
+→ DatasetFilter { datasetUrn: "urn-B", id: "GEO",      dimensionValues: [{ id: "FR",  isSelectedValue: true }] }
+```
+
+### Resolving the native dimension ID
+
+`getNativeFilterIdForSharedFilter(filter, datasetUrn, metadataMap)` at
+`multiple-filters.ts:356` resolves which dimension ID to use in the expanded
+`DatasetFilter`. Priority order:
+
+1. `filter.sourceFilterIdsByDataset[datasetUrn]` — explicit recorded mapping
+   (always the first choice; set at merge time)
+2. For TIME_PERIOD: look up the dimension with
+   `dimensionType === 'TIME_PERIOD'` in the metadata map
+3. For COUNTRY/FREQUENCY: look up the dimension with the matching `subtype`
+
+### `buildFiltersMap()`
+
+`buildFiltersMap(filters, constraintsMap, ...)` at `multiple-filters.ts:764`
+
+The top-level expansion function. Takes the full UI `Filter[]` (which may contain
+both `SharedFilter` and `DatasetFilter` entries), expands all shared filters,
+and returns `Map<datasetUrn, Filter[]>` — ready to be serialised per dataset.
+
+Also applies `limitTimeRangeByConstraints()` on any time filter: clips the user's
+selected time range to the bounds the constraint says are available for that
+dataset.
+
+---
+
+## Dataset Compatibility: `getCompatibleDatasetUrns()`
+
+At `multiple-filters.ts:793`. When the user selects specific countries in the
+shared COUNTRY filter, not all datasets may have data for those countries. This
+function returns the subset of datasets whose data is compatible with the current
+shared filter selections.
+
+A dataset is compatible if, for every shared filter that has explicit selections,
+at least one selected value has a `sourceValue` pointing to that dataset — OR the
+dataset has no filter for that dimension at all (implicit wildcard, meaning it
+accepts any value).
+
+The **implicit wildcard** case: Dataset B was loaded but its `REF_AREA` dimension
+was never given an explicit filter in the saved `DataQuery`. This means "all
+countries" — it doesn't restrict Dataset B's inclusion even if Dataset A has
+specific countries selected. `hasImplicitWildcardForSharedFilter()` detects this
+by checking whether the dataset's native dimension has an explicit filter in
+`appliedFiltersMap` (or in the original `DataQuery` as fallback).
+
+---
+
+## Detecting Filter Asymmetry: `hasImplicitSharedWildcard()`
+
+At `multiple-filters.ts:1273`. A diagnostic function that checks whether the
+current state has an "asymmetry" across datasets for a shared dimension: one
+dataset has explicit values selected while another dataset has no filter at all.
+
+This matters because when Dataset A selects `FRA` and Dataset B has no filter, the
+data result from Dataset B would cover all countries — but the merged grid or chart
+would show them side-by-side. This is confusing UX. The system uses this flag to
+trigger `getImplicitSharedWildcardFilterParams()` which expands Dataset B's filter
+to only include countries that actually exist in its constraints, making the
+behaviour explicit.
+
+---
+
+## Expanding Implicit Wildcards: `getDataQueriesWithExpandedSharedDimensionFilters()`
+
+At `multiple-filters.ts:966`. Only runs when there are 2+ datasets and constraints
+are available.
+
+For each shared dimension (COUNTRY, FREQUENCY — not TIME_PERIOD), it compares
+datasets that have explicit selections with datasets that have no filter. If the
+"missing" dataset has available values in its constraints, those values are added to
+the explicit dataset's filter — effectively saying "also include any value that
+exists in the datasets that don't have an explicit filter yet."
+
+This is a one-directional expansion: it adds to the explicit filter, never removes
+from it. The result is that data from all active datasets is included in the merged
+result.
+
+---
+
+## Restoring Active Datasets: `getRestoredActiveDatasetUrns()`
+
+At `multiple-filters.ts:889`. When a conversation is reopened, this function
+reconstructs which datasets were "active" (deselected datasets are remembered as
+inactive). It looks for shared-dimension filters that have explicit non-empty
+values. If all datasets that shared any one of those dimensions have those explicit
+values, they were all active. If only some do, only those were active.
+
+Returns `undefined` if no shared filter selections exist — meaning all datasets are
+active by default.
+
+---
+
+## Summary: Merge → UI → Expand Pipeline
+
+```
+Structural data loaded for each dataset
+  ↓
+getDatasetFilters() per dataset
+  → [DatasetFilter[], DatasetFilter[], ...]    (flat, one per dimension per dataset)
+
+mergeSharedFilters()
+  → [SharedFilter(COUNTRY), SharedFilter(FREQ), SharedFilter(TIME), DatasetFilter, ...]
+                                                (UI-facing: merged pickers + dataset-specific ones)
+
+User selects values in the merged pickers
+  ↓
+buildFiltersMap()
+  → Map<urn, DatasetFilter[]>                  (expanded back, with native IDs and codes)
+
+limitTimeRangeByConstraints() applied per dataset
+  ↓
+setDataQueryFilters() per dataset
+  → Map<urn, QueryFilter[]>                    (ready for persistence and API calls)
+```
+
+---
+
+## Invariants
+
+- A `SharedFilter` never has a `datasetUrn`. Its `sourceDatasetUrns` lists which
+  datasets contributed.
+- `sourceFilterIdsByDataset` is always populated at merge time and is the primary
+  source of truth for which dimension ID to use during expansion. Metadata-based
+  lookup is a fallback.
+- Time period merging takes the **widest** time range (min of starts, max of ends)
+  so the shared time picker shows the full range available across all datasets.
+- Time period expansion takes the **narrowest** range allowed by each dataset's
+  constraints.
+- COUNTRY/FREQUENCY values are matched by name, not by code. Two datasets must use
+  the same display name for the same concept to be merged. If names differ, each
+  ends up as a separate entry in the shared filter.
+

--- a/specs/filters/04-constraints-fetching.md
+++ b/specs/filters/04-constraints-fetching.md
@@ -1,0 +1,187 @@
+# Constraints Fetching
+
+SDMX constraints tell the client which dimension-value combinations actually exist
+in the data. Without them, a user could select "Annual frequency + Country X" and
+get an empty result because that combination doesn't exist. Constraints drive which
+checkboxes are enabled in the filter UI and clip the available time range.
+
+This spec covers when constraints are fetched, what is included in the request,
+how responses are cached, and how they flow into filter values.
+
+---
+
+## What a Constraint Request Is
+
+The constraint endpoint accepts a dataset URN and an optional list of
+`SeriesFilterDto[]` — the current non-time-period selections — and returns a
+`DataConstraints` object listing which values are available for every dimension
+given those selections. In SDMX terms this is a "content constraint".
+
+```ts
+interface SeriesFilterDto {
+  componentCode: string;       // dimension ID
+  operator: SeriesFilterOperator.EQUALS;
+  value: string;               // comma-separated code IDs, e.g. "FRA,DEU"
+}
+```
+
+The time period dimension is always excluded from the request filters — the
+available time range comes from constraint `annotations`, not from cube regions.
+
+---
+
+## Two Fetching Paths
+
+There are two distinct places where constraints are fetched, for different purposes.
+
+### Path 1 — Initial load (`attachments-data.ts`)
+
+`getDataConstraintsMap()` at
+`libs/conversation-view/src/utils/attachments/attachments-data.ts:25`
+
+Called during `getStructureDataMaps()` to populate constraints for the first time
+when a conversation is opened or a new dataset is added. It uses the filters
+already saved in the `DataQuery` (from the system message) as the request input.
+
+Source: `getFiltersDtoMapFromDataQuery()` from sdmx-toolkit — converts each
+`DataQuery`'s `QueryFilter[]` to `SeriesFilterDto[]`, excluding the TIME_PERIOD
+dimension.
+
+The constraint responses are `Promise.allSettled` — a failure for one dataset
+doesn't block the others.
+
+### Path 2 — Interactive updates (`multiple-filters.ts`)
+
+`getConstraintsRequests()` at `multiple-filters.ts:1207`
+
+Called when the user changes filter selections in the UI, to refresh available
+values. The key difference from Path 1 is **shared filter exclusion**.
+
+`getConstraintFilters()` at `multiple-filters.ts:1180` decides what to include in
+the constraint request:
+
+- If the source filters contain any `SharedFilter` entries (i.e. the UI is in
+  multi-dataset mode with merged pickers), **shared filters are excluded** from the
+  request — except for `TIME_PERIOD`. This is intentional: sending a shared
+  COUNTRY filter with Dataset-A codes to Dataset-B's constraint endpoint would
+  produce wrong results because Dataset-B uses different codes.
+- If no shared filters are present (single-dataset mode), all filters are sent as-is.
+- TIME_PERIOD is always excluded from constraint requests regardless (its range
+  comes from annotations).
+
+The result: each dataset's constraint request only includes filters that are
+native to that dataset.
+
+---
+
+## Request Cache
+
+All constraint requests (and structure requests) go through a module-level in-memory
+cache in `libs/conversation-view/src/utils/request-cache.ts`.
+
+The cache has two layers:
+
+| Map | Contents | Behaviour |
+|---|---|---|
+| `resolvedRequests` | Completed results | Returned immediately on repeat call |
+| `inFlightRequests` | In-progress `Promise`s | Second call awaits the same promise |
+
+This prevents duplicate API calls when multiple components or effects request the
+same data simultaneously.
+
+**Cache key:** `buildRequestCacheKey(...parts)` — simply `JSON.stringify(parts)`.
+The full key includes the action function's name plus the serialised arguments, so
+`getConstraints("urn-A", [{ componentCode: "FREQ", value: "A" }])` has a different
+key from `getConstraints("urn-A", [{ componentCode: "FREQ", value: "A,Q" }])`.
+
+**Important:** This cache is **never invalidated during a session**. Once a
+constraint response is cached, it stays forever for that page load. A browser
+refresh clears it.
+
+### Normalisation for cache consistency
+
+`normalizeConstraintFilters()` at
+`libs/conversation-view/src/utils/normalize-constraint-filters.ts:3`
+
+Before building the cache key, filter DTOs are normalised:
+1. Values within each filter are sorted (`"FRA,DEU"` → `"DEU,FRA"`)
+2. Filters are sorted by `componentCode` alphabetically
+
+This ensures that selecting "France then Germany" vs "Germany then France" produces
+the same cache key and doesn't trigger redundant API calls.
+
+### Detecting uncached requests
+
+`hasUncachedConstraintRequests()` at `multiple-filters.ts:1243`
+
+Returns `true` if any dataset in the current query would produce a cache miss.
+Used to decide whether a new round of constraint fetching is needed after filter
+changes — if everything is cached, skip the async work entirely.
+
+---
+
+## How Constraints Flow Into Filter Values
+
+After constraints are fetched they are stored in `StructureDataMaps.constraintsMap`
+as `Map<datasetUrn, DataConstraints[] | undefined>`.
+
+**Applying to filter values:**
+
+`getFilledFilters()` (see `02-single-dataset-filters.md`) calls
+`getAvailableCodesFromConstrains()` from sdmx-toolkit. For each dimension it:
+1. Takes the full codelist for that dimension
+2. Filters to only the codes listed in the constraint's `cubeRegions` where
+   `isIncluded = true`
+3. For hierarchical codelists, preserves parent codes even if the constraint didn't
+   explicitly list them (so the tree renders correctly)
+4. Returns localised `FilterValue[]`
+
+Any code absent from the constraint response is simply not returned — the
+corresponding checkbox is not shown (or is shown as disabled, depending on context).
+
+**Applying to time range:**
+
+`getAnnotationPeriod(constraints[0].annotations)` from sdmx-toolkit extracts
+`TIME_PERIOD_START_ANNOTATION_KEY` and `TIME_PERIOD_END_ANNOTATION_KEY` from the
+first constraint's annotations array. This defines the earliest and latest dates
+available in the dataset.
+
+`limitTimeRangeByConstraints()` at `multiple-filters.ts:500` clips any
+user-selected time range to these bounds. The clamping rules:
+- If the entire requested range is **before** the available range → snap both ends
+  to the earliest available date
+- If the entire requested range is **after** the available range → snap both ends
+  to the latest available date
+- Otherwise → clip start and end independently
+
+**Initial constraints for the time picker:**
+
+`getInitialConstraints()` at `multiple-filters.ts:1367` handles the time filter
+display in the filter panel:
+- Single-dataset mode: returns `initialConstraints` directly
+- Multi-dataset mode + shared time filter: synthesises a merged constraint whose
+  time range is the **union** (earliest start, latest end) across all active
+  datasets — so the shared time picker shows the full possible range
+
+---
+
+## Merging Constraint Maps
+
+When constraints are refreshed incrementally (e.g. one dataset's filter changes
+while others stay the same), `mergeConstraintsMaps()` at `multiple-filters.ts:1354`
+merges the new results over the existing map. Entries from the updated map overwrite
+entries in the base map; datasets not in the updated map keep their existing
+constraint data.
+
+---
+
+## Invariants
+
+- TIME_PERIOD is never sent as a constraint request filter.
+- Shared (COUNTRY, FREQUENCY) filters are never sent to constraint requests in
+  multi-dataset mode.
+- The request cache never evicts — stale constraints are only possible if the
+  underlying data changes during a session (rare for statistical datasets).
+- A dataset with `constraintsMap.get(urn) === undefined` (entry absent) means
+  constraints haven't loaded yet. A dataset with an empty array `[]` means
+  constraints loaded but returned nothing.

--- a/specs/filters/05-system-message-persistence.md
+++ b/specs/filters/05-system-message-persistence.md
@@ -1,0 +1,183 @@
+# System Message Persistence
+
+Filter state must survive page reloads and be shareable: if a user sets up filters
+and then the page refreshes (or a colleague opens the shared conversation link),
+the exact same selections should reappear. This is achieved by persisting filter
+state into the conversation history as a special system message.
+
+---
+
+## The Storage Format
+
+Filter state is written as a `Role.System` message at the tail of the message list
+at the time of the filter change. It has no visible text content — its payload lives
+in `custom_content.attachments`.
+
+One attachment per active dataset, each containing a JSON-serialised `DataQuery`:
+
+```json
+{
+  "role": "system",
+  "content": "",
+  "custom_content": {
+    "attachments": [
+      {
+        "type": "application/json",
+        "title": "Dataset A title",
+        "data": "{\"urn\":\"urn:sdmx:...\",\"metadata\":{...},\"filters\":[...]}"
+      },
+      {
+        "type": "application/json",
+        "title": "Dataset B title",
+        "data": "..."
+      }
+    ],
+    "form_schema": { ... }
+  }
+}
+```
+
+The `form_schema` field is carried forward from the last assistant message found
+in the array — it holds any form/button configuration the LLM produced and must
+not be lost when the system message is rewritten.
+
+---
+
+## Write Path
+
+### `prepareSystemMessage()`
+
+`libs/conversation-view/src/utils/system-message.ts:6`
+
+Builds a fresh system `Message` from the current `DataQuery[]` and filter state.
+
+Accepts two alternative ways to supply per-dataset filters:
+
+| Mode | When used |
+|---|---|
+| `queryFiltersMap: Map<urn, QueryFilter[]>` | Multi-dataset: each dataset has its own filter list |
+| `filters + currentDataQuery` | Single-dataset: one filter list applied to the matching DataQuery |
+
+For each `DataQuery` in `dataQueries`, the filter selection is resolved as follows:
+
+- **Multi-dataset** (`queryFiltersMap` provided): `queryFiltersMap.get(dataQuery.urn)`
+- **Single-dataset**: `filters` if `currentDataQuery.urn === dataQuery.urn`; otherwise
+  the existing `dataQuery.filters` — non-targeted datasets keep their saved selections
+
+The resolved filters are serialised as `{ urn, metadata, filters }` and stored in
+`attachment.data` as a JSON string.
+
+### `updateMessagesWithSystemMessage()`
+
+`libs/conversation-view/src/utils/system-message.ts:40`
+
+Updates the message list with the freshly built system message:
+
+1. Check if the **last** message has `role === Role.System` — if so, pop it
+2. Push the new system message
+
+The pop only fires when the last message is already a system message. If the last
+message is a user or assistant message (e.g. after the user sent a follow-up), the
+old system message (if any, now mid-array) is left untouched and a second system
+message is appended. See the Invariants section.
+
+### When is this called?
+
+Both single-dataset (`Filters.tsx`) and multi-dataset (`MultiDatasetFilters.tsx`)
+filter components call `updateMessagesWithSystemMessage` inside their filter-change
+callbacks, then call `updateConversation()` with the updated message list. This
+triggers an API call that persists the conversation to the backend.
+
+---
+
+## Read Path
+
+### Step 1 — Parsing attachments from a message
+
+`Message.tsx` reads attachments from each rendered message via
+`parseMessageAttachments(message)`, then calls `getDataQueries(attachments)` from
+`libs/conversation-view/src/utils/attachments/parse-data-query.ts:5`.
+
+`getDataQueries` filters attachments to JSON type, then calls
+`getDataQueryFromJson()` on each one's `.data` string.
+
+### Step 2 — `getDataQueryFromJson()`
+
+`parse-data-query.ts:33`. Handles **backward compatibility** with older
+conversation formats that used snake_case field names:
+
+| New field | Old fallback |
+|---|---|
+| `componentCode` | `component_code` |
+| `countryDimension` | `country_dimension` |
+| `indicatorDimensions` | `indicator_dimensions` |
+
+This means conversations saved months ago still parse correctly even after field
+renames.
+
+### Step 3 — Passing DataQuery to the view
+
+The parsed `DataQuery[]` is set into local state as `attachmentsDataQueries` and
+passed down to `AdvancedView` and the `Filters` component as props.
+
+Each message is rendered independently, so when multiple system messages exist in
+the array they all render. Only the latest one is connected to the active filter UI
+(the earlier ones are historical snapshots and no longer drive any live component).
+
+For the system message specifically (`message.role === Role.System`), `Message.tsx`
+also reads the **previous message's** attachments (typically the assistant message
+that triggered the filter UI) to build `AttachmentInfoList` — a display list showing
+which datasets are active and what their filter summaries are.
+
+### Step 4 — Restoring filter selections
+
+Once `DataQuery[]` is available and structural data + constraints have loaded,
+`getFiltersPreselectedByDataQuery()` (single-dataset) or
+`getFiltersPreselectedByDataQueries()` (multi-dataset) applies the saved
+`QueryFilter[]` back onto the freshly-built `Filter[]`.
+
+This is described in detail in `02-single-dataset-filters.md` (section 2) and
+`03-shared-filters-merging.md` (Restoring Active Datasets section).
+
+---
+
+## What Is and Is Not Persisted
+
+| Persisted | Not persisted |
+|---|---|
+| Selected dimension values (`QueryFilter[]`) | Which filter panel is open (`isSelectedFilter`) |
+| Selected time range (as `BETWEEN` values) | Display mode (flat list / hierarchy) |
+| Dataset URNs and metadata | Hierarchy expansion state |
+| `form_schema` from the last assistant message | Constraint responses (re-fetched on load) |
+| Dataset title | Disabled/enabled state of values |
+
+Filter UI state (which panel is open, how values are displayed) is always reset on
+reload. Only the **selections** — which values the user picked — are restored.
+
+---
+
+## Invariants
+
+- **The system message is at the tail only immediately after a filter change.**
+  Once the user sends a follow-up chat message, `finalizeConversation` saves
+  `[...existingMessages, userMsg, assistantMsg]` — the old system message becomes
+  mid-array.
+
+- **Multiple system messages can accumulate.** If the user sets filters, sends a
+  chat message, and then changes filters again, `updateMessagesWithSystemMessage`
+  finds an assistant message at the end (not a system message), leaves the old
+  system message in place, and appends a new one. The conversation can then contain
+  two system messages: one embedded mid-array, one at the tail.
+
+- **The latest system message wins on read.** `replace-python-attachment.ts` uses a
+  backward scan (`for i = length-1; i >= 0`) to find the most recent system message.
+  Earlier ones are stale snapshots.
+
+- Every filter change triggers a full rewrite of the tail system message — partial
+  updates do not exist.
+
+- Absence of a system message is valid: it means default filters (no selections).
+  The app initialises `Filter[]` with all values unselected in that case.
+
+- The `data` field in each attachment is a JSON string (double-serialised). Parsing
+  requires `JSON.parse(attachment.data)`, not direct object access.

--- a/specs/filters/06-cross-dataset-grid.md
+++ b/specs/filters/06-cross-dataset-grid.md
@@ -1,0 +1,195 @@
+# Cross-Dataset Grid
+
+When the LLM returns data from two or more datasets simultaneously, a single grid
+must display them together. The cross-dataset grid solves this by **concatenating
+rows from all datasets into one flat array** — it is not a SQL-style join. Each row
+knows which dataset it came from, and every column's value-getter dispatches on that
+identity to look up the native dimension ID for that row's dataset.
+
+All logic lives under
+`libs/conversation-view/src/utils/attachments/cross-dataset-grid/`.
+
+---
+
+## Pipeline Overview
+
+```
+buildCrossDatasetGridAttachment(dataQueries, structuresMap, dataMessagesMap, ...)
+  ↓
+buildCrossDatasetGridColumns(...)   →  ColDef[]
+buildCrossDatasetGridData(...)      →  GridData[]   (one row per time-series per dataset)
+  ↓
+{ title, gridContent: { columns, data } }   →   ag-grid-react renders it
+```
+
+`buildCrossDatasetGridAttachment` is the single entry point. It returns a plain
+object that is stored as an attachment on the assistant message and later read by the
+grid component to initialise ag-grid.
+
+Two parameters accepted by `buildCrossDatasetGridContent` — `_constraintsMap` and
+`_selectedTimePeriod` — are currently unused (underscore-prefixed); they are plumbed
+for future use and can be ignored.
+
+---
+
+## Column Layout
+
+Left to right, as produced by `buildCrossDatasetGridColumns`:
+
+| Column group | Source | Notes |
+|---|---|---|
+| Metadata | `getCrossDatasetMetadataColumn` | Fixed left-anchor column |
+| Agency | dataset info | String from structural metadata |
+| Dataset name | dataset info | Human-readable dataset title |
+| Country / Region | `dimensions-columns.ts` | One column; value dispatched by row urn |
+| Indicator(s) | `dimensions-columns.ts` | 1 col in Compact mode; N cols in Extended mode |
+| Frequency | `dimensions-columns.ts` | One column; value dispatched by row urn |
+| Other dimensions | `dimensions-columns.ts` | Built with `hide: true` |
+| Time period | `timeseries-columns.ts` | One column per unique period string |
+| Chart | `getChartColumn` | Fixed right-anchor column |
+
+The time period columns are always rightmost before the chart column and are sorted
+by `sortPeriods()` from sdmx-toolkit (handles `YYYY`, `YYYY-Q#`, `YYYY-M##`
+formats).
+
+---
+
+## Value-Getter Pattern
+
+This is the load-bearing piece. Because each row belongs to a different dataset,
+the same "Country" column must look up a different native dimension ID depending on
+which dataset the row is from.
+
+Every dimension column's value-getter follows the same pattern:
+
+```ts
+function getCellParams(data, structuresMap) {
+  const urn = data?.dataset?.urn;
+  const structures = urn == null ? undefined : structuresMap.get(urn);
+  return { data, urn, structures };
+}
+```
+
+The runtime flow for, say, the Country column:
+
+1. Read `params.data.dataset.urn` — which dataset this row belongs to
+2. Look up `datasetDimensionsSchemesMap.get(urn).region` — the native dimension ID
+   that plays the "region/country" role in this dataset (e.g. `REF_AREA` for
+   Dataset A, `GEO` for Dataset B)
+3. Read `params.data[nativeDimensionId]` — the localised display value already
+   embedded in the row
+
+The same dispatch applies to Frequency (`scheme.frequency`) and Time Period
+(`scheme.timePeriod`). Indicator columns differ only in which IDs from
+`scheme.indicators` are used. "Other" dimensions use `scheme.other`.
+
+This means the column definitions are **shared across all datasets** — there is no
+per-dataset column set. The per-dataset variation is entirely inside value-getters.
+
+---
+
+## View Modes
+
+`CrossDatasetGridViewMode` has two values: `Compact` (default) and `Extended`. The
+mode only affects the indicator columns.
+
+| Mode | Indicator columns | Cell value |
+|---|---|---|
+| `Compact` | One column ("Indicator") | All indicator dimension values concatenated with `INDICATORS_CONCATENATION_SYMBOL` (`.`) |
+| `Extended` | One column per unique indicator dimension ID across all active datasets | Each column shows the value for its specific indicator dimension, blank if the row's dataset doesn't have that dimension |
+
+Compact is the default and hides multi-dimension complexity behind a single cell.
+Extended is useful when datasets have different indicator structures and the user
+needs to see each dimension separately.
+
+---
+
+## Row Construction
+
+`buildCrossDatasetGridData` iterates `dataQueries` in order. For each dataset it
+calls `getRowsData(timeSeries, ...)` which produces one `GridData` row per
+time-series (i.e. per unique combination of non-time dimension values). Time period
+values are keyed directly by their period string (e.g. `"2020"`, `"2021-Q1"`).
+
+Each row is then tagged before being pushed to the shared array:
+
+```ts
+rows.push(...dsRows.map(row => ({
+  ...row,
+  dataset: { urn },
+  datasetTitle,
+})));
+```
+
+The final array is a flat concatenation. There is no key-based merging of rows from
+different datasets — a "France" row from Dataset A and a "France" row from Dataset B
+are two separate grid rows.
+
+`getRowsData` also calls `extendDataWithChart()` to attach chart-rendering metadata
+to each row for the chart column.
+
+---
+
+## Time Period Columns
+
+Time periods are **unioned across all datasets** with deduplication.
+
+`collectTimePeriods()` in `timeseries-columns.ts` iterates every entry in
+`dataMessagesMap`, collects all period strings into a `Set`, then sorts the result
+with `sortPeriods()`. One `ColDef` is emitted per unique period.
+
+Each time-period column's value-getter:
+
+```ts
+params.data[period]?.value?.[0]?.value || null
+```
+
+where `period` is the column's period string. If the row's dataset has no data for
+that period, the cell is `null` (blank).
+
+This means datasets with different time coverages display correctly side-by-side:
+Dataset A's 2010–2020 columns are blank for Dataset B's rows when Dataset B only
+covers 2015–2022.
+
+---
+
+## Active Dataset Filtering
+
+Before the grid is built, `getCompatibleDatasetUrns()` (see `03-shared-filters-merging.md`)
+filters `dataQueries` to only the datasets compatible with the current shared filter
+selections. Datasets excluded by country or frequency selections are not passed to
+`buildCrossDatasetGridAttachment` and produce no rows or columns.
+
+---
+
+## Snapshot Key
+
+`getCrossDatasetSnapshotKey(dataQueries)` in `multiple-filters.ts:1086`:
+
+```ts
+JSON.stringify(dataQueries.map(q => ({ urn: q.urn, filters: q.filters })))
+```
+
+This is a **change-detection key**, not a cache key. The component compares the
+current snapshot key against the previous one to decide whether to rebuild the grid.
+A key change means a different set of active datasets or filter selections — both
+require a full rebuild.
+
+---
+
+## Invariants
+
+- Each row carries `dataset.urn`; this is the only way value-getters know which
+  native dimension ID to use. Rows without this field would render blank in all
+  dimension columns.
+- Rows are concatenated, never merged. Two datasets with matching dimension values
+  produce two rows, not one.
+- Time period columns are derived from the loaded data messages, not from
+  constraints. If data for a period is absent from the response, that period's
+  column does not appear.
+- `sortPeriods()` determines column order; insertion order from `dataMessagesMap`
+  does not matter.
+- View mode (`Compact`/`Extended`) only changes the indicator column layout.
+  Country, Frequency, Time Period, and Other columns are identical in both modes.
+- Column definitions are stateless with respect to dataset identity — all
+  dataset-specific logic is in value-getters, not in column structure.

--- a/specs/filters/07-data-flow.md
+++ b/specs/filters/07-data-flow.md
@@ -1,0 +1,226 @@
+# Data Flow
+
+The other specs in this series cover individual components — domain model, filter
+construction, merging, constraints, persistence, grid. This spec covers the
+**temporal dimension**: in what order things happen, what must complete before what,
+and which parts of the system are state vs. refs vs. cached. It is the map for the
+whole system.
+
+Three sequences are described: initial load, filter change, and conversation reload.
+
+---
+
+## Sequence 1 — Cold Open: Conversation → Filter UI Ready
+
+This sequence covers what happens between opening a conversation and the filter
+modal being interactive with correct available values and restored selections.
+
+### Phase 0 — Structural metadata (synchronous server data)
+
+Before the React tree mounts, the Next.js Server Component in
+`[locale]/layout.tsx` fetches deployment config and SDMX metadata
+(`DatasetDimensionsMetadataMap`). This data is injected into context providers and
+is available synchronously to all client components. No async fetch needed for it.
+
+### Phase 1 — Parse the stored filter state
+
+`Message.tsx` reads the system message from the conversation history, calls
+`getDataQueries()` on its attachments, and produces `DataQuery[]`. These are passed
+down as `attachmentsDataQuery` (single-dataset) or `attachmentsDataQueries`
+(multi-dataset). For the data structures involved see `01-domain-model.md`; for how
+the system message is located see `05-system-message-persistence.md`.
+
+At this point the app knows **what was selected**, but not yet the full filter
+structure (dimension labels, codelist, hierarchy).
+
+### Phase 2 — Structure and constraint loading
+
+**Single-dataset** (`Filters.tsx`): a `useEffect` triggers on
+`dimensions / structures / structureDimensions`. It calls `getDatasetFilters()`
+to build the skeleton `Filter[]` with no values selected, then immediately
+starts `handleFiltersWithConstraints()` which fires `getConstraints()` and awaits
+the response. Until the response arrives the filter UI shows a loading state.
+
+**Multi-dataset** (`AttachmentsDataMultipleQueries` context): three async steps
+run in sequence:
+
+```
+loadDimensionsSchemes(dataQueries)              // Phase 2a — lightweight, fast
+  ↓
+loadConstraintsMap(dataQueries)                 // Phase 2b — parallel, one request per dataset
+  ↓
+loadStructureData(dataQueries, constraintsMap)  // Phase 2c — two-wave load (see below)
+```
+
+Phase 2c runs two `Promise.allSettled` rounds inside `getStructureDataMaps`:
+
+1. **Wave 1** — load dataset details (codelist + structural metadata) for all datasets
+2. **Callback** — once wave 1 results are available, the caller checks for implicit
+   shared wildcards via `getImplicitSharedWildcardFilterParams()`. If any dataset is
+   missing a shared-dimension filter that another dataset has, the callback returns
+   expanded filter params and sets `activeDatasetUrns`. See
+   `03-shared-filters-merging.md` (Expanding Implicit Wildcards).
+3. **Wave 2** — if the callback returned filter params, load data again with those
+   params. Otherwise, load data without extra constraints.
+
+Individual dataset failures are caught by `Promise.allSettled` and do not block
+the other datasets. The resulting `structureDataMaps` is set into context
+incrementally — it is partial until both waves complete.
+
+`isStructureDataMapsReady()` (`multiple-filters.ts`) checks that all four required
+maps (`dimensionsMap`, `structuresMap`, `structureDimensionsMap`, `constraintsMap`)
+are present before the filter UI proceeds.
+
+### Phase 3 — Fill values and preselect
+
+Once structure data is ready, `getFilledDatasetFiltersMap()` replaces skeleton
+`Filter[]` values with constraint-filtered localised `FilterValue[]` (see
+`02-single-dataset-filters.md` section 1). Then `getFiltersPreselectedByDataQuery()`
+(or the multi-dataset variant) applies the saved `QueryFilter[]` to mark the correct
+values as selected (see `02-single-dataset-filters.md` section 2).
+
+**One-time gate**: both `Filters.tsx` and `MultiDatasetFilters.tsx` guard
+preselection with a `useRef(false)` flag (`isPreselectedFromDataQuery`). Preselection
+runs exactly once — the first time structure data is ready. If dimensions or
+structures change afterwards (dataset swap), the flag prevents preselection from
+overwriting any edits the user has already made in the modal.
+
+At this point the filter UI is ready: values are populated, prior selections are
+restored, and the modal can be opened.
+
+---
+
+## Sequence 2 — User Changes a Filter → Persisted
+
+This sequence covers what happens between the user clicking "Apply" in the filter
+modal and the new state being saved to the backend.
+
+### Step 1 — Serialise selections to QueryFilter[]
+
+`onApply()` in `Filters.tsx` calls `getQueryFilters()` which internally calls
+`buildQueryFiltersCore()` → `setDataQueryFilters()`. Each selected dimension becomes
+a `QueryFilter` with `operator: 'in'` and the selected code IDs. Time period becomes
+`operator: 'between'` with `MM-DD-YYYY` formatted dates. See
+`02-single-dataset-filters.md` section 4.
+
+For multi-dataset, `onApply()` in `MultiDatasetFilters.tsx` first calls
+`buildFiltersMap()` to expand shared filters back to per-dataset native IDs, then
+`getCompatibleDatasetUrns()` to exclude datasets whose filter selections are
+incompatible. Incompatible datasets' filters are marked `isExcluded: true`.
+
+### Step 2 — Build and persist the system message
+
+`onFiltersChange` / `onMultipleDataFiltersChange` is called with the serialised
+filters. Inside the callback, `updateMessagesWithSystemMessage()` rebuilds the tail
+of the message list:
+
+- If the last message is already a `Role.System` message, it is replaced
+- Otherwise the new system message is appended
+
+The resulting `messages` array is passed to `updateConversation()`, which fires a
+`PUT` API call. See `05-system-message-persistence.md` for the storage format
+and invariants.
+
+### Step 3 — Trigger data refresh
+
+After persistence, the filter components call the data-loading action for each
+active dataset with the updated `QueryFilter[]`. This fires new SDMX data API calls
+and ultimately re-renders the grid or chart attachments.
+
+Constraint re-fetching follows the same rules described in `04-constraints-fetching.md`:
+shared filters are excluded from multi-dataset constraint requests; `TIME_PERIOD` is
+always excluded.
+
+---
+
+## Sequence 3 — Conversation Reload → Filters Restored
+
+This sequence covers what happens when a conversation is reopened (page refresh or
+shared link) and previously saved filter state must be reconstructed.
+
+### Step 1 — Locate the system message
+
+`replace-python-attachment.ts` and the message rendering loop both do a **backward
+scan** of the message array to find the most recent `Role.System` message. Earlier
+system messages (mid-array from old filter changes) are ignored for driving the
+active filter UI. See `05-system-message-persistence.md` (Invariants) for why
+multiple system messages can exist.
+
+### Step 2 — Parse DataQuery from attachments
+
+`parseMessageAttachments(message)` → `getDataQueries(attachments)` →
+`getDataQueryFromJson()`. The JSON parser handles the backward-compatibility field
+renames (`component_code` → `componentCode`, etc.) documented in
+`05-system-message-persistence.md` (Read Path, Step 2).
+
+The resulting `DataQuery[]` is the sole source of prior filter selections. Nothing
+else survives a page reload: constraint responses, hierarchy expansion state, and
+which filter panel was open are all lost.
+
+### Step 3 — Reload structure and constraints
+
+Sequences exactly as Phase 2 of Sequence 1. The `DataQuery[]` drives the initial
+constraint request in `getDataConstraintsMap()` (`attachments-data.ts`): each
+dataset's existing `QueryFilter[]` is converted to `SeriesFilterDto[]` and sent as
+the request input. This means the first constraint response reflects the user's saved
+selections, not an empty selection.
+
+### Step 4 — Apply preselection
+
+`getFiltersPreselectedByDataQuery()` matches each saved `QueryFilter` to its
+`Filter` by `componentCode === filter.id`. Time ranges are intersected with the
+constraints-derived available range; the tighter of the two wins. Regular dimensions
+mark matching code IDs as `isSelectedValue: true`.
+
+For multi-dataset: `getFiltersPreselectedByDataQueries()` additionally handles the
+implicit wildcard case — if Dataset A saved an explicit COUNTRY filter and Dataset B
+saved none, Dataset B's filter values are all marked selected so the shared picker
+shows a consistent state. See `02-single-dataset-filters.md` section 2 (Multi-dataset
+variant).
+
+The `isPreselectedFromDataQuery` ref gate fires the same way as during cold open:
+exactly once.
+
+---
+
+## State vs. Ref vs. Cache
+
+| Data | Storage | Lifetime |
+|---|---|---|
+| `DataQuery[]` (saved selections) | Conversation message (backend) | Survives reload |
+| `Filter[]` (UI model) | React state | Component lifetime |
+| `constraintsRef` | `useRef` | Component lifetime; updated async |
+| `isPreselectedFromDataQuery` | `useRef` | Component lifetime; write-once |
+| `structureDataMaps` | React context | Component lifetime |
+| Request cache (`resolvedRequests`) | Module-level `Map` | Page session (never evicted) |
+| `DatasetDimensionsMetadataMap` | React context (server-injected) | Page session |
+
+The module-level request cache means that changing a filter, navigating away, and
+returning to the same conversation will serve constraint responses from cache —
+the SDMX server is not re-queried even if the underlying data changed.
+
+---
+
+## Timing Summary
+
+```
+Server Component renders
+  → DatasetDimensionsMetadataMap injected (synchronous)
+
+Conversation message list parsed
+  → DataQuery[] extracted from latest Role.System message (synchronous)
+
+React tree mounts
+  → Phase 2a: dimension schemes loaded
+  → Phase 2b: initial constraints loaded (parallel, one per dataset)
+  → Phase 2c wave 1: structure data loaded (parallel)
+  → Phase 2c callback: implicit wildcard check (synchronous calculation)
+  → Phase 2c wave 2: data loaded with expanded filters (if wildcard detected)
+  → Phase 3: fill values + preselect (synchronous once data is ready)
+
+Filter UI interactive
+```
+
+Between Phase 2b and Phase 3 the filter panel shows a loading state. The rest of
+the conversation (messages, other attachments) renders immediately; the filter panel
+is the only part gated on async data.

--- a/specs/filters/08-python-attachment.md
+++ b/specs/filters/08-python-attachment.md
@@ -1,0 +1,133 @@
+# Python Attachment
+
+When the user changes filters, the app re-invokes the LLM's Python code generation
+to produce an updated data-fetch script reflecting the new selections. The result
+is stored as a special attachment on the conversation's system message so that
+refreshing the page re-renders the same code.
+
+All logic lives in:
+- `libs/conversation-view/src/utils/attachments/python-attachment.ts`
+- `libs/conversation-view/src/utils/attachments/replace-python-attachment.ts`
+- `libs/conversation-view/src/utils/query-filters.ts` (`buildDataQueryWithMergedFilters`)
+- `libs/conversation-view/src/context/AttachmentsData.tsx` (single-dataset trigger)
+- `libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx` (multi-dataset trigger)
+
+---
+
+## When It Is Invoked
+
+Both `AttachmentsData` and `AttachmentsDataMultipleQueries` expose an
+`onFiltersChange` / `onMultipleDataFiltersChange` callback to the filter components.
+When the user clicks Apply in the filter modal, that callback fires. Inside it,
+alongside the system-message update described in `05-system-message-persistence.md`,
+the context calls `invokePythonAttachment()`.
+
+There is no debounce — every Apply click fires a new request. Stale-request
+protection (see below) handles rapid successive changes.
+
+---
+
+## Filter Merge: `buildDataQueryWithMergedFilters()`
+
+`query-filters.ts:160`. Before invoking the Python backend, each `DataQuery` is
+rebuilt by merging the UI's current selections into the stored query:
+
+1. **UI-controlled dimensions** — calls `buildQueryFiltersForPythonAttachment()`
+   which serialises `timeRange` as ISO `YYYY-MM-DD` (not `MM-DD-YYYY` as used for
+   the SDMX data API — see spec 99). Non-time selections become
+   `{ operator: 'in', values: [selectedIds...] }`.
+
+2. **Wildcard insertion** — for any UI-controlled dimension that ends up with no
+   selection after step 1, a `{ operator: 'in', values: ['*'] }` filter is added.
+   This explicitly tells the Python backend "all values" rather than relying on
+   filter absence.
+
+3. **Hidden filter preservation** — `QueryFilter` entries whose `componentCode` is
+   not in the UI-controlled set are copied through unchanged. These are filters the
+   LLM wrote into the `DataQuery` that the user never touched.
+
+The returned `DataQuery[]` is what gets sent to the Python API.
+
+---
+
+## API Call and Dual Attachment Output
+
+`invokePythonAttachment()` in `python-attachment.ts`:
+
+1. Calls `getPythonAttachment(dataQueries)` — an async action that hits the backend
+   and returns `{ python_code: string }`.
+
+2. Produces **two attachments** from the single response:
+
+   | Attachment | Type | Purpose |
+   |---|---|---|
+   | `CUSTOM_CODE_SAMPLE` | UI only | Rendered in the in-chat code editor with `language: 'python'` |
+   | Markdown codeblock | Persisted | `` ```python\n${result.python_code}\n``` `` stored on the system message |
+
+   `setCodeAttachments()` updates the UI attachment in React state immediately.
+   `onCodeAttachmentUpdated()` callback delivers the markdown attachment to
+   `ConversationView`, which calls `replacePythonAttachment()` to write it into the
+   message list and then `updateConversation()` to persist to the backend.
+
+---
+
+## Stale-Request Protection
+
+`invokePythonAttachment` takes a `requestIdRef` — a `useRef<number>` counter
+managed by the caller. The current value is captured at call time into
+`currentRequestId`. The counter is incremented immediately. When the response
+arrives, if `requestIdRef.current !== currentRequestId` the response is discarded
+without updating state.
+
+This means only the most recently initiated request takes effect. Earlier in-flight
+responses are silently dropped. No cancellation of the HTTP request itself occurs;
+the network call completes but its result is ignored.
+
+---
+
+## Persistence: `replacePythonAttachment()`
+
+`replace-python-attachment.ts`. Takes the current message list and the new markdown
+attachment. Locates the target message with the following priority:
+
+1. If a `messageId` is provided (AdvancedView path): find the message with that ID
+2. Otherwise: backward scan from the end of the message list to find the most recent
+   `Role.System` message
+
+Once the target is found:
+- All existing `type === 'text/markdown'` attachments whose `data` contains
+  ` ```python` are removed from the target message
+- The new markdown attachment is appended to the remaining attachments
+- The updated messages array is returned (or `null` if the target was not found)
+
+The backward scan for the fallback case is the same logic described in
+`05-system-message-persistence.md` (Invariants). If no system message exists in the
+array, the function returns `null` and the python code is not persisted.
+
+---
+
+## Single vs Multi-Dataset
+
+Both `AttachmentsData.tsx` and `AttachmentsDataMultipleQueries.tsx` implement the
+same pattern independently. The multi-dataset variant passes a `DataQuery[]` (one
+per active dataset) to `buildDataQueryWithMergedFilters` for each dataset, then
+collects the rebuilt queries into an array before calling `invokePythonAttachment`.
+The API call itself is identical; the difference is only how many `DataQuery` objects
+are merged and passed.
+
+---
+
+## Invariants
+
+- The markdown attachment on the system message is the persisted source of truth for
+  the Python code. The UI `CUSTOM_CODE_SAMPLE` attachment is ephemeral — it does not
+  survive a page reload.
+- If `replacePythonAttachment` returns `null` (no system message found), the new
+  code is displayed in the UI but not persisted. The user would see the updated code
+  but a reload would revert to the previous version.
+- Hidden filters (LLM-set, not UI-controlled) are preserved through every filter
+  change. They are never visible in the filter modal and cannot be cleared by the
+  user via the UI.
+- The Python attachment uses ISO dates (`YYYY-MM-DD`). The SDMX data API uses
+  `MM-DD-YYYY`. Both come from the same `timeRange` object serialised by different
+  functions — see spec 99.

--- a/specs/filters/09-applied-filters-display.md
+++ b/specs/filters/09-applied-filters-display.md
@@ -1,0 +1,209 @@
+# Applied Filters Display
+
+After the user applies a filter change, the chat view renders a summary beneath the
+system message showing which filters changed and what they were set to. This is the
+"what the user sees" layer — the display pipeline that turns raw `QueryFilter[]`
+stored in the system message into localized, human-readable filter chips.
+
+Key files:
+- `libs/conversation-view/src/components/ChatMessages/Message/Message.tsx`
+- `libs/conversation-view/src/utils/attachments-details.ts`
+- `libs/conversation-view/src/components/Attachments/AttachmentDetails/AttachmentDetails.tsx`
+- `libs/conversation-view/src/components/Attachments/AttachmentDetails/AttachmentDetailsItem.tsx`
+
+---
+
+## Where the Display Appears
+
+The filter summary is rendered only for messages where `message.role === Role.System`
+and a `previousMessage` exists. It does not render:
+
+- On user or assistant messages
+- On system messages that have no preceding message (first message in a conversation)
+- When the conversation is in AdvancedView mode (`isOpenedAdvancedView` flag) — the
+  summary is hidden there since the full filter panel is open
+
+`Message.tsx` passes the system message and its predecessor to `getAttachmentInfoList()`,
+which does the comparison and returns `AttachmentInfo[]` for rendering.
+
+---
+
+## What Is Compared
+
+The comparison is between the **previous message's DataQuery** and the **current
+system message's DataQuery**. Both are parsed from their respective `custom_content.attachments`
+via the same `getDataQueries()` path described in `05-system-message-persistence.md`.
+
+```
+previousMessage.attachments → DataQuery[]   (what filters looked like before the change)
+systemMessage.attachments   → DataQuery[]   (what filters look like after the change)
+```
+
+`getAttachmentInfoList()` in `attachments-details.ts` iterates the current
+DataQuery array and for each dataset looks up the corresponding previous DataQuery
+by URN. `getUpdatedQueryFiltersDetails()` then compares the two filter lists
+to find only the dimensions that changed:
+
+- A filter is considered **changed** if its value set differs from the previous set.
+  Comparison uses `isEqual()` on sorted `values` arrays — order of selection does
+  not matter.
+- Filters absent from the previous DataQuery (new selections) are treated as
+  changed.
+- Filters absent from the current DataQuery (cleared selections) are treated as
+  changed — the cleared state is still shown.
+- Filters identical in both are excluded from the summary entirely.
+
+The result is a list of only the dimensions the user actually touched in this filter
+session.
+
+---
+
+## Structural Hydration
+
+Raw `QueryFilter[]` contains component codes and value ID arrays (e.g.
+`componentCode: "REF_AREA"`, `values: ["FRA", "DEU"]`). These must be resolved to
+human-readable strings for display.
+
+`getQueryFiltersDetails()` in `attachments-details.ts` performs this hydration for
+each changed filter. It requires `datasetStructuresMap` — a map from dataset URN to
+the full SDMX structural response — to be populated before it runs.
+
+For each `QueryFilter`:
+
+1. **Dimension title** — the `componentCode` is looked up in the dataset's
+   `Dimension[]` to find the associated concept. The concept's localised `name` in
+   the current locale becomes the filter's display title. Falls back to the
+   `componentCode` ID if the concept is not found.
+
+2. **Value labels** — for `operator: 'in'`, each value ID is looked up in the
+   codelist associated with that dimension. The localised `name` of the matching
+   code becomes the display label. Falls back to the raw ID.
+
+3. **Time range** — for `operator: 'between'`, the two date strings are passed
+   through `getTimePeriod()` and formatted with `getDateString()` to produce a
+   locale-aware range label (e.g. `"Jan 2020 – Dec 2023"`).
+
+4. **Excluded** — for `operator: 'excluded'`, a fixed label is shown (no values to
+   resolve).
+
+5. **Shared filter ID resolution** — `getSharedFilterIdForDatasetDimension()` checks
+   whether this dimension maps to one of the three shared filter IDs (`COUNTRY`,
+   `FREQUENCY`, `TIME_PERIOD`). If it does, the `AttachmentInfo` entry is tagged
+   with the shared filter ID so the renderer can group it correctly.
+
+---
+
+## Data Model
+
+```ts
+// models/attachments.ts
+interface AttachmentInfo {
+  datasetName?: string;
+  queryFiltersDetails?: QueryFilterDetails[];
+}
+
+// QueryFilterDetails (from @epam/statgpt-shared-toolkit)
+interface QueryFilterDetails {
+  id: string;          // dimension ID or shared filter ID
+  title: string;       // localized dimension name
+  valuesTitles: string[];  // localized value names (or formatted date range)
+}
+```
+
+`getAttachmentInfoList()` returns `AttachmentInfo[]` — one entry per dataset that
+has at least one changed filter.
+
+---
+
+## Shared vs Per-Dataset Rendering
+
+`AttachmentDetails.tsx` splits the `AttachmentInfo[]` into two groups before
+rendering:
+
+- **Shared filters** (`sharedFilterDetails`): entries whose `id` is in
+  `SHARED_FILTER_IDS` (`COUNTRY`, `FREQUENCY`, `TIME_PERIOD`). These represent
+  dimensions that are shown as a single merged picker in the UI and should be
+  displayed once at the top of the summary, not repeated per dataset.
+
+- **Per-dataset filters** (`perDatasetInfoList`): entries that belong to a specific
+  dataset — dataset-specific dimensions not shared across datasets.
+
+The render order is: shared filters first (no dataset name prefix), then per-dataset
+filters (each preceded by an optional dataset icon and name).
+
+In **single-dataset mode** there are no shared filters — all entries are per-dataset
+and the dataset name header is typically omitted. The mode switch is a runtime check
+on whether `sharedFilterDetails` has any entries.
+
+---
+
+## Cross-Dataset Filter Fusion
+
+When multiple datasets contribute to the same shared filter (e.g. both Dataset A's
+`REF_AREA` and Dataset B's `GEO` map to `COUNTRY`), `getAttachmentInfoList()` merges
+their changed values into a single `AttachmentInfo` entry. It does not produce two
+separate "Country changed in Dataset A" and "Country changed in Dataset B" entries.
+
+The fusion uses the value labels (not the native code IDs) as the merge key — the
+same name-based matching described in `03-shared-filters-merging.md`. If Dataset A's
+`FRA` and Dataset B's `FR` both resolve to the label `"France"`, the fused entry
+shows `"France"` once. If the labels differ, they appear as separate entries in the
+fused list.
+
+This means the user sees "Country set to France, Germany" rather than "Dataset A:
+France, Germany / Dataset B: France, Germany", consistent with the merged picker
+they used to make the selection.
+
+---
+
+## Rendering
+
+`AttachmentDetailsItem.tsx` renders one filter as:
+
+> **"{Title}"** set to **"{Value1}, {Value2}, ..."**
+
+For time range:
+
+> **"Time Period"** set to **"Jan 2020 – Dec 2023"**
+
+Multiple values are joined with `", "`. The component receives a `QueryFilterDetails`
+object and has no knowledge of datasets or shared/per-dataset logic — that split
+happens in `AttachmentDetails.tsx` before it reaches here.
+
+---
+
+## Data Dependencies and Ordering
+
+`getAttachmentInfoList()` requires:
+- `datasetStructuresMap` populated (for codelist and concept lookup)
+- `DatasetDimensionsMetadataMap` available from context (for shared filter ID resolution)
+- Both the system message and its preceding message present in the rendered message
+  list
+
+If `datasetStructuresMap` is empty or the target dataset's structures haven't loaded,
+dimension titles and value labels degrade to their raw IDs. There is no loading state
+— the summary renders with whatever data is available at render time.
+
+The previous-message dependency means the filter summary is inherently tied to the
+message pair pattern: system message immediately following an assistant message. If
+the previous message is a user message (unusual but possible), the diff compares
+against that message's attachments, which typically have no `DataQuery` — the result
+is all filters shown as "new" rather than "changed."
+
+---
+
+## Invariants
+
+- Only changed filters appear. Unchanged dimensions are omitted regardless of how
+  many selections they have.
+- The summary reads from the **previous message's** DataQuery for the before-state,
+  not from any React state. This makes it purely derived from the stored conversation
+  and stable across reloads.
+- Shared filter entries in the display do not carry a `datasetUrn`. They are
+  assembled from the matching entries across all datasets and tagged by shared filter
+  ID only.
+- The display layer never modifies filter state. It is read-only with respect to
+  `DataQuery`, `Filter[]`, and `QueryFilter[]`.
+- If `replacePythonAttachment` failed to persist (see spec 08) and the system
+  message has no attachments, both DataQuery arrays are empty and the summary renders
+  nothing.

--- a/specs/filters/10-chart-attachments.md
+++ b/specs/filters/10-chart-attachments.md
@@ -1,0 +1,297 @@
+# Chart Attachments
+
+The `CUSTOM_CHART` attachment type renders time-series data as an ECharts line chart.
+Unlike the grid attachments it is **lazily evaluated**: the chart data object is not
+built until the component renders. This spec covers the build pipeline, unit-splitting
+logic, the lazy resolver, how filter changes invalidate the cache, and the cross-dataset
+variant.
+
+Key files:
+- `libs/conversation-view/src/utils/attachments/charting/chart-data.ts`
+- `libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts`
+- `libs/conversation-view/src/utils/attachments/charting/data-uniqueness.ts`
+- `libs/conversation-view/src/utils/attachments/charting/split-for-units.ts`
+- `libs/conversation-view/src/utils/attachments/charting/chart-config-building.ts`
+- `libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx`
+- `libs/conversation-view/src/components/Attachments/CustomAttachments/ResponsiveChart.tsx`
+- `libs/conversation-view/src/models/charting.ts`
+
+---
+
+## Pipeline Overview
+
+```
+Filter change → new DataMessage
+  ↓
+createChartDataResolver(structures, dataMessage, dataQuery, locale)
+  → attachment.getChartingData (lazy closure)
+  ↓
+CustomChartAttachment renders
+  → scheduleDeferredWork(() => getChartingData())  [first call]
+  ↓
+buildChartData():
+  getRowsData()
+  → getDimensionsUniquenessByValues()
+  → splitForUnits()
+  → buildUnit() × N
+      → buildChartSeries()
+      → filterTimePeriodsByFrequency()
+      → buildChartConfig()
+  ↓
+ChartingData { units[], groups? }
+  → ResponsiveEChart renders selected unit
+```
+
+---
+
+## Lazy Resolver Pattern
+
+`createChartDataResolver()` (`chart-data.ts`) does not build chart data when called.
+It returns a closure that builds on demand and caches the result:
+
+```ts
+export function createChartDataResolver(...args): () => ChartingData {
+  let cached: ChartingData | undefined;
+  return () => (cached ??= buildChartData(...args));
+}
+```
+
+The `??=` operator ensures `buildChartData` runs exactly once per resolver instance.
+Subsequent calls to the returned function return the same `ChartingData` object.
+
+The attachment object stored in React state holds this function:
+
+```ts
+{
+  charting_data: undefined,      // not pre-built
+  getChartingData: resolver,     // lazy closure
+}
+```
+
+`CustomChartAttachment` calls `getChartingData()` inside `scheduleDeferredWork()`,
+deferring the build past the current render. `charting_data` (the pre-built form) is
+used when chart data arrives serialized from the backend; `getChartingData` is used
+for the live in-session path.
+
+`createCrossDatasetChartingDataResolver()` follows the same closure pattern for the
+multi-dataset case.
+
+---
+
+## Unit Splitting
+
+A single dataset response can contain multiple logically distinct charts — for
+example, one chart per indicator. `buildChartData()` determines the split
+automatically using dimension uniqueness analysis.
+
+### Step 1 — Dimension uniqueness analysis
+
+`getDimensionsUniquenessByValues()` (`data-uniqueness.ts`) scans all rows and, for
+each non-time dimension, checks whether its value varies across rows. Dimensions
+where every row has the same value are **unique** (constant for this slice).
+Dimensions where values differ are **non-unique**.
+
+```
+Rows: [{INDICATOR: 'GDP'}, {INDICATOR: 'GDP'}, {INDICATOR: 'GNP'}]
+INDICATOR → non-unique  (values vary)
+
+Rows: [{FREQ: 'A'}, {FREQ: 'A'}, {FREQ: 'A'}]
+FREQ → unique  (all same value)
+```
+
+### Step 2 — Group rows into units
+
+`splitForUnits()` groups rows by their combination of non-unique dimension values.
+Each distinct combination becomes a separate `ChartUnit` — rendered as a separate
+chart tab in the UI.
+
+```
+Non-unique: [INDICATOR]
+Row A: INDICATOR=GDP  → unit "GDP"
+Row B: INDICATOR=GDP  → unit "GDP"   (same unit, different country series)
+Row C: INDICATOR=GNP  → unit "GNP"  (separate unit)
+```
+
+A dataset with a single unique indicator combination produces exactly one unit.
+
+### Step 3 — Series within a unit
+
+Within each unit, rows become ECharts series. Series are named using the country
+dimension (via `buildSerieKeyTitle()`). Time period values from the row become the
+`data` array on each series, one point per period.
+
+---
+
+## MAX_LINES_PER_UNIT Cap
+
+```ts
+const MAX_LINES_PER_UNIT = 10;  // chart-data.ts:34
+```
+
+`buildUnit()` enforces this limit before building series: if a unit has more than 10
+rows, only the first 10 are used for `buildChartSeries()`. The full row set is still
+stored in `unit.rows`. The unit carries a `limitedByRowsAmountTo: number | undefined`
+flag — set to `10` when the cap is applied, `undefined` otherwise.
+
+`CustomChartAttachment` renders a `ChartLimitationInfo` tooltip when
+`limitedByRowsAmountTo` is set, prompting the user to refine their filter selection.
+
+---
+
+## Frequency-Based Time Period Filtering
+
+`filterTimePeriodsByFrequency()` (`chart-data.ts`) checks the frequency dimension
+value of the first row in a unit and filters the `timePeriods` array accordingly:
+
+| Row frequency | Periods kept |
+|---|---|
+| Monthly (`M`) | Monthly periods only |
+| Quarterly (`Q`) | Quarterly periods only |
+| Annual (`A`) | Annual periods only |
+| Missing / other | All periods |
+
+This prevents mismatched x-axis ticks when a unit contains data at a single
+frequency. The filtered periods become the x-axis categories in `buildChartConfig()`.
+
+---
+
+## Cross-Dataset Variant
+
+`buildCrossDatasetChartingData()` (`cross-dataset-chart-data.ts`) iterates
+`dataQueries` and calls `buildChartData()` per dataset. Each dataset's units are
+wrapped in a `ChartUnitGroup`:
+
+```ts
+interface ChartUnitGroup {
+  title?: string;   // localized dataset name
+  units: ChartUnit[];
+}
+```
+
+The returned `ChartingData` carries both `units[]` (flat list of all units across all
+datasets) and `groups?: ChartUnitGroup[]` (per-dataset grouping for the UI).
+
+`CustomChartAttachment` flattens groups into `FlatChartUnit[]` for the chart
+navigation slider, with each entry tagged by group title for the dataset label
+displayed above the chart.
+
+---
+
+## ECharts Config
+
+`buildChartConfig()` (`chart-config-building.ts`) assembles the final ECharts option
+object from time periods (x-axis) and series. Fixed properties:
+
+- `animation: false`
+- `tooltip.trigger: 'axis'`
+- `legend` at the bottom with dynamic `grid.bottom`
+- `xAxis.type: 'category'` with `boundaryGap: false`
+
+`ResponsiveEChart` (`ResponsiveChart.tsx`) wraps `echarts-for-react`. On mount and
+window resize it measures the legend items using canvas text width estimation, computes
+how many rows the legend needs, then adjusts `grid.bottom` to prevent the series lines
+from overlapping the legend. This adjustment is imperative (direct resize call) and
+runs outside the ECharts option lifecycle.
+
+---
+
+## Sidebar
+
+`ChartSidebar` renders the fixed-dimension context for the currently selected unit.
+`getDimensionsInfo()` builds `DimensionInfo[]` from all dimensions **except** the
+country dimension. Each entry carries:
+
+- `id` — dimension key
+- `title` — localized dimension name
+- `value` — that dimension's value in the first row of the unit (what this chart slice
+  is fixed at — e.g. `"Indicator: GDP"`)
+
+The country dimension is excluded from the sidebar because it drives series
+differentiation within the chart (the legend), not the fixed slice identity. It is
+still used by `buildSerieKeyTitle()` for series names.
+
+---
+
+## Filter Response and Cache Invalidation
+
+Both `AttachmentsData.tsx` (single-dataset) and `AttachmentsDataMultipleQueries.tsx`
+(multi-dataset) run a `useEffect` on `[structures, dataMessage, dataQuery, locale,
+chartStyles]`. When any of these change, a new resolver is created:
+
+```ts
+setCustomChartAttachment(prev => ({
+  ...prev,
+  charting_data: undefined,
+  getChartingData: createChartDataResolver(structures, dataMessage, dataQuery, locale, chartStyles),
+}));
+```
+
+Because the cache lives inside the closure, creating a new resolver discards the old
+cache automatically — no explicit invalidation is needed. The GC reclaims the old
+closure once the component state update replaces it.
+
+`dataMessage` is the primary trigger: when filters change, new SDMX data is fetched
+and the resulting new `DataMessage` lands in state, firing the effect and replacing
+the resolver.
+
+---
+
+## Data Model
+
+```ts
+// charting.ts
+interface ChartingData {
+  units: ChartUnit[];
+  groups?: ChartUnitGroup[];  // populated in cross-dataset mode only
+}
+
+interface ChartUnit {
+  config: EChartsOption;                 // ready-to-pass to echarts-for-react
+  dimensions: DimensionInfo[];           // sidebar display data
+  rows: RowData[];                       // full row set (may exceed MAX_LINES_PER_UNIT)
+  limitedByRowsAmountTo: number | undefined;
+}
+
+interface ChartUnitGroup {
+  title?: string;
+  units: ChartUnit[];
+}
+
+interface DimensionInfo {
+  id: string;
+  title: string;   // localized
+  value: string;   // localized
+}
+```
+
+The attachment object in React state:
+
+```ts
+{
+  charting_data?: ChartingData;      // pre-built (serialized / restored)
+  getChartingData?: () => ChartingData;  // lazy resolver (live session)
+}
+```
+
+Exactly one of these is set at any given time.
+
+---
+
+## Invariants
+
+- `buildChartData` is never called at the point the resolver is created — only at
+  first render. If the component is unmounted before it renders, the build never runs.
+- The resolver cache is per-instance. Two resolver closures for the same inputs do not
+  share a cache. Filter change → new resolver → fresh build on next render.
+- `unit.rows` always holds the full dataset rows. `MAX_LINES_PER_UNIT` only limits
+  the rows passed to `buildChartSeries()` — the full set is available for future use.
+- Country dimension is **excluded** from `DimensionInfo[]` (sidebar) but **included**
+  in series naming. These serve different UI purposes: the sidebar shows the fixed
+  slice, the series legend shows what varies.
+- `groups` in `ChartingData` is `undefined` in single-dataset mode. Code that reads
+  `groups` must handle absence.
+- Frequency filtering is per-unit, derived from the first row's frequency value. If
+  rows in a unit have mixed frequencies (unusual but possible), the first row governs.
+- `ResponsiveEChart`'s legend sizing runs outside the ECharts option object. Passing
+  `grid.bottom` in the ECharts config has no effect — it is overwritten by the resize
+  logic on every mount and window resize event.

--- a/specs/filters/99-gotchas.md
+++ b/specs/filters/99-gotchas.md
@@ -1,0 +1,162 @@
+# Gotchas
+
+This document is for developers who have already read specs 01–10 and are about to
+touch the filter system. Everything here is either absent from the other specs or
+only briefly mentioned. If a behavior is fully explained elsewhere, it is not
+repeated here.
+
+---
+
+## Preselection runs exactly once — even if structural data changes
+
+`Filters.tsx` and `MultiDatasetFilters.tsx` guard the initial preselection step
+with a `useRef(false)` flag:
+
+```ts
+const isPreselectedFromDataQuery = useRef(false);
+
+useEffect(() => {
+  if (!isPreselectedFromDataQuery.current) {
+    // ... call getFiltersPreselectedByDataQuery / getFiltersPreselectedByDataQueries
+    isPreselectedFromDataQuery.current = true;
+  }
+}, [dimensions, structures, structureDimensions, attachmentsDataQuery, ...]);
+```
+
+The flag prevents structural data changes — dimensions reloading, a dataset swap —
+from overwriting user edits in the modal. The consequence is that if datasets are
+swapped after the first render, the old preselection stays. This is intentional; the
+gate is load-bearing.
+
+If you add a new trigger that should re-run preselection, you must reset the ref
+explicitly. Removing the guard entirely causes user edits to be discarded on every
+re-render that touches the dependency list.
+
+---
+
+## Two date formats for the same time range
+
+`QueryFilter` time ranges use `MM-DD-YYYY`:
+
+```ts
+{ operator: 'between', values: ['01-01-2020', '12-31-2023'] }
+```
+
+`buildQueryFiltersForPythonAttachment()` uses ISO `YYYY-MM-DD`:
+
+```ts
+{ operator: 'between', values: ['2020-01-01', '2023-12-31'] }
+```
+
+Both serialize the same `timeRange`. The difference is consumer: the SDMX data API
+expects `MM-DD-YYYY`; the Python code execution environment expects ISO. If you add
+a third consumer, check which format it expects before reusing either function.
+`buildDataQueryWithMergedFilters()` calls the Python variant — it is not generic.
+
+---
+
+## `expandSharedFilter` has a vestigial parameter
+
+`expandSharedFilter` in `multiple-filters.ts` accepts a second parameter
+`_propagateSharedFiltersToAllDatasets` (default `false`). It is prefixed with `_`
+and is never read inside the function body. It does nothing. Do not write code that
+passes `true` expecting different behavior — there is none.
+
+---
+
+## Modal close restores constraints to open-time snapshot, not live state
+
+When the filter modal opens, the current `constraintsRef.current` value is captured
+into `initialModalConstraints` state. When the modal closes without applying, the
+ref is restored to that snapshot:
+
+```ts
+const onCloseModal = useCallback(() => {
+  constraintsRef.current = initialModalConstraints; // restored to open-time value
+  setModalState(PopUpState.Closed);
+}, [initialModalConstraints]);
+```
+
+This means: if the user opens the modal, changes a filter (triggering a new
+constraint fetch), then closes without applying — the next time they open the modal
+they see the constraints from the previous open, not the latest fetch. Constraint
+state does not persist across modal sessions unless the user clicks Apply.
+
+---
+
+## Constraint requests are not cancelled on rapid filter changes
+
+`handleFiltersWithConstraints()` fires an async constraint request on every filter
+change. There is no request cancellation or debounce. If the user makes three quick
+selections, three requests are in flight simultaneously. The constraint ref is
+written by whichever resolves last — not necessarily the one matching the current
+selection. This is partially mitigated by the request cache: if selections revert to
+a previously requested combination, the cached result is returned instantly and no
+race is possible.
+
+---
+
+## `structureDataMaps` is partial until both load waves complete
+
+`getStructureDataMaps` runs two `Promise.allSettled` rounds (wave 1: dataset
+structures; wave 2: data). The maps object is updated after each wave. Components
+that read from `structureDataMaps` before wave 2 completes will see populated
+`dimensionsMap` and `structuresMap` but possibly empty or absent `dataMessagesMap`.
+
+`isStructureDataMapsReady()` checks for the presence of all four required maps
+(`dimensionsMap`, `structuresMap`, `structureDimensionsMap`, `constraintsMap`). The
+filter UI is gated on this check. However, code that reads `dataMessagesMap` (e.g.
+to build the cross-dataset grid) must separately check that the data messages for
+the relevant dataset are present, since they arrive in wave 2.
+
+---
+
+## Incompatible datasets are marked, not removed
+
+When `onApply()` in `MultiDatasetFilters.tsx` finds that some datasets are
+incompatible with the current shared filter selections, it does not remove those
+datasets from the filters map. Instead, it marks their dimension-level filters as
+`isExcluded: true`:
+
+```ts
+if (!filter.dimensionValues?.some((v) => v.isSelectedValue)) {
+  return { ...filter, isExcluded: true };
+}
+```
+
+The `isExcluded` flag is then serialized as `operator: 'excluded'` in the
+`QueryFilter`. Grid and chart components must check this flag and treat excluded
+datasets as inactive. The dataset URN remains in the `dataQueries` list; only the
+per-dimension filter signals exclusion. See `01-domain-model.md` for the
+`QueryFilterType.excluded` operator.
+
+---
+
+## Hierarchy state is keyed by filter identity, not by dataset + dimension
+
+The hierarchy state map (`hierarchyStateMap`) uses `getFilterIdentity(filter)` as
+its key:
+
+- `SharedFilter` → `"shared:COUNTRY"`, `"shared:FREQUENCY"`, etc.
+- `DatasetFilter` → `"${datasetUrn}:${filterId}"`
+
+For shared filters, both datasets contribute to the same hierarchy state entry. If
+Dataset A's `REF_AREA` hierarchy differs from Dataset B's `GEO` hierarchy, only one
+hierarchy tree is stored for the shared COUNTRY filter. The hierarchy loaded last
+(whichever dataset's lazy-load completes last) wins. This is intentional — the
+merged picker shows a unified tree — but it means you cannot retrieve per-dataset
+hierarchy state for a shared dimension.
+
+---
+
+## The request cache survives filter changes but not page reloads
+
+The module-level `resolvedRequests` map in `request-cache.ts` is never cleared
+during a session. Once a constraint response is cached for a given (urn, filters)
+combination, it is served from cache for the rest of the page session even if the
+underlying data changed on the SDMX server.
+
+The practical effect: if a user opens a conversation, sets filters, then changes
+filters back to a previous combination, the constraint response from the first visit
+is returned instantly from cache. A browser refresh is the only way to force fresh
+constraint data.

--- a/specs/filters/README.md
+++ b/specs/filters/README.md
@@ -1,0 +1,114 @@
+# Filters & Dataset Merging — Spec Index
+
+> **Scope is broader than "filters."** This folder documents the full lifecycle
+> of how users select data dimensions, how those selections are reconciled across
+> multiple datasets, how the available values are constrained by the SDMX API,
+> how all state is persisted in the conversation, and how the resulting data is
+> rendered as grids and charts.
+
+---
+
+## Mental Model
+
+The application lets a user query one or more statistical datasets (SDMX dataflows)
+and see the results as charts or tables. Each dataset has its own set of dimensions
+— think "axes" of the data: Country, Frequency, Time Period, and various indicator
+dimensions. Users filter along those axes to narrow down what they want to see.
+
+When a single dataset is active, this is straightforward: the user picks values
+from each dimension and a query is built. The complexity begins when **multiple
+datasets** are active at the same time. Dataset A might have a dimension called
+`REF_AREA` while Dataset B calls the same concept `GEO`. Both represent
+"Country/Region", but they use different dimension IDs and different code values
+(`FRA` vs `FR`). The system must present a **single shared Country picker** to the
+user while keeping track of which code in each dataset corresponds to the selected
+value.
+
+This is solved by the **shared filter** layer: three "universal" filters (Country,
+Frequency, Time Period) are recognised across datasets by their _semantic subtype_
+from deployment metadata, merged into one UI control, and then expanded back to
+dataset-specific filters when a query is built.
+
+The shape of data that can actually be returned by each dataset is further narrowed
+by fetching **SDMX constraints** — server-side lists of which dimension-value
+combinations actually exist in the data. These constraints drive which checkboxes
+are enabled, and they are cached by a normalised request key to avoid redundant
+round-trips.
+
+All filter state (which values are selected, what time range is chosen) is
+serialised into a **system message** appended to the conversation history. This
+means filter state survives page reloads and can be replayed when an existing
+conversation is reopened.
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **DataQuery** | Core persistence unit. One per dataset: URN + metadata + `QueryFilter[]`. Stored in the system message. |
+| **QueryFilter** | A single dimension selection within a DataQuery. Has `componentCode` (dimension ID), `operator` (`in` / `between` / `excluded`), and `values[]`. |
+| **Filter** | UI-layer representation of a dimension. Union of `DatasetFilter` and `SharedFilter`. Lives in React state, not in the system message. |
+| **DatasetFilter** | A `Filter` tied to one dataset URN and one dimension ID. |
+| **SharedFilter** | A `Filter` that spans multiple datasets (Country, Frequency, or Time Period). Holds merged values and a `sourceFilterIdsByDataset` map for re-expansion. |
+| **FilterValue** | One selectable item within a Filter. Carries `id`, `name`, `isSelectedValue`, and — for shared filters — a `sourceValues[]` list that records which dataset-native code this represents in each dataset. |
+| **Dimension** | SDMX structural metadata describing one axis of a dataset. Has an `id`, a `type` (regular vs. time), and a reference to a codelist. |
+| **DatasetDimensionsMetadataMap** | Deployment-time config (from the server) that tags each dimension in each dataset with a `dimensionType` (`INDICATOR`, `NON_INDICATOR`, `TIME_PERIOD`) and optional `subtype` (`REGION`, `FREQUENCY`). Used to recognise which dimensions are "the country one" or "the frequency one" regardless of their actual ID. |
+| **DatasetDimensionsScheme** | Per-dataset summary: `{ timePeriod, frequency, region, indicators[], other[] }` — the actual dimension IDs bucketed by role. |
+| **DataConstraints** | SDMX constraint response: which values actually exist for each dimension, optionally for a given filter combination. Limits which checkboxes are enabled. |
+| **CubeRegion** | SDMX concept inside a constraint. An `isIncluded` flag + `MemberSelection[]` per dimension. |
+| **StructureDataMaps** | Aggregated in-memory maps (dimensions, structures, constraints, data messages) for all active datasets. The central "working state" during attachment rendering. |
+| **System message** | A `Role.System` message appended to the conversation. Its `custom_content.attachments` holds one JSON-serialised `DataQuery` per active dataset. |
+
+---
+
+## A note on line numbers
+
+Line numbers cited in specs (e.g. `multiple-filters.ts:295`) are approximate starting
+points — use the function or symbol name to navigate, not the number. Refactors move
+lines; names are greppable. Update numbers when convenient, but do not block a spec
+update because you cannot verify every line number.
+
+---
+
+## Spec Files
+
+| File | What it covers |
+|---|---|
+| [01-domain-model.md](./01-domain-model.md) | Core types — DataQuery, Filter, Dimension, Constraint — and how they relate |
+| [02-single-dataset-filters.md](./02-single-dataset-filters.md) | Filter construction, preselection from saved state, and serialisation for one dataset |
+| [03-shared-filters-merging.md](./03-shared-filters-merging.md) | How Country/Frequency/Time Period filters are merged across datasets and expanded back |
+| [04-constraints-fetching.md](./04-constraints-fetching.md) | When constraints are fetched, what they exclude from requests, caching and normalisation |
+| [05-system-message-persistence.md](./05-system-message-persistence.md) | How filter state survives across messages — write path and read (restore) path |
+| [06-cross-dataset-grid.md](./06-cross-dataset-grid.md) | Row concatenation, per-row dataset dispatch, value-getter pattern, and view modes for multi-dataset grids |
+| [07-data-flow.md](./07-data-flow.md) | Three end-to-end sequences (cold open, filter change, reload) — async ordering and state lifetime |
+| [08-python-attachment.md](./08-python-attachment.md) | Python code generation on filter change — dual attachment output, stale request protection, hidden filter preservation |
+| [09-applied-filters-display.md](./09-applied-filters-display.md) | How changed filters appear in the chat view — structural hydration and shared vs per-dataset rendering |
+| [10-chart-attachments.md](./10-chart-attachments.md) | Lazy resolver, unit splitting by dimension uniqueness, series grouping, and filter-driven chart rebuild |
+| [99-gotchas.md](./99-gotchas.md) | Sharp edges and non-obvious behaviours across the filter system |
+
+---
+
+## Key Source Files (quick reference)
+
+| Path | Purpose |
+|---|---|
+| `libs/shared-toolkit/src/models/data-query.ts` | `DataQuery`, `QueryFilter` types |
+| `libs/conversation-view/src/models/filters.ts` | `Filter`, `SharedFilter`, `FilterValue` types |
+| `libs/sdmx-toolkit/src/models/structural-metadata/constraints.ts` | `DataConstraints`, `CubeRegion` types |
+| `libs/sdmx-toolkit/src/models/datasets-metadata.ts` | `DatasetDimensionsMetadataMap`, `DimensionConfig` |
+| `libs/sdmx-toolkit/src/models/dataset-dimensions-scheme.ts` | `DatasetDimensionsScheme` |
+| `libs/conversation-view/src/utils/filters.ts` | Single-dataset filter utilities |
+| `libs/conversation-view/src/utils/multiple-filters.ts` | Multi-dataset merging, constraint fetching (1500+ lines — the core) |
+| `libs/conversation-view/src/utils/query-filters.ts` | Filter → QueryFilter serialisation |
+| `libs/conversation-view/src/utils/system-message.ts` | System message write path |
+| `libs/conversation-view/src/utils/normalize-constraint-filters.ts` | Constraint request cache key normalisation |
+| `libs/conversation-view/src/utils/attachments/python-attachment.ts` | Python code generation and dual attachment output |
+| `libs/conversation-view/src/utils/attachments/replace-python-attachment.ts` | Replacing stored Python code on the system message |
+| `libs/conversation-view/src/utils/attachments-details.ts` | Applied filters display — diff, hydration, fusion |
+| `libs/conversation-view/src/utils/attachments/charting/chart-data.ts` | Single-dataset chart builder and lazy resolver |
+| `libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts` | Cross-dataset chart builder |
+| `libs/conversation-view/src/utils/attachments/charting/data-uniqueness.ts` | Dimension uniqueness analysis for unit splitting |
+| `libs/conversation-view/src/utils/attachments/charting/split-for-units.ts` | Row grouping into `ChartUnit[]` |
+| `libs/conversation-view/src/utils/attachments/charting/chart-config-building.ts` | ECharts option assembly |
+| `libs/conversation-view/src/models/charting.ts` | `ChartingData`, `ChartUnit`, `ChartUnitGroup` types |


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

### Description of changes

Adds `specs/filters/` — 11 markdown specs covering the filter/dataset-merging/chart system end-to-end (domain model through chart attachments), plus a gotchas reference.

Also adds `.claude/rules/spec-conventions.md` (auto-loaded by Claude Code) to enforce keeping specs in sync with source changes, and a pointer in `CLAUDE.md`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
