### PR TITLE
fix: hide chart buttons in special cases

### DIFF
--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ChartCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ChartCellRenderer.tsx
@@ -5,7 +5,7 @@ import { Locale } from '@epam/statgpt-shared-toolkit';
 import { IconButton } from '@epam/statgpt-ui-components';
 import ChartIcon from '../../../assets/icons/chart.svg';
 import { ICellRendererParams } from 'ag-grid-community';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChartUnit, ChartUnitValue } from '../../../models/charting';
 import { Tooltip } from '../../Tooltip/Tooltip';
 import { getTooltipDataByElement } from '../../../utils/get-tooltip-data.by-element';
@@ -33,10 +33,15 @@ const ChartCellRenderer = (params: ChartCellRendererParams) => {
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
   const [isChartClosed, setIsChartClosed] = useState(false);
 
+  const resolvedChart = useMemo(
+    () => getChartUnit(params.value),
+    [params.value],
+  );
+
   const openChart = useCallback(() => {
-    setChart((currentChart) => currentChart ?? getChartUnit(params.value));
+    setChart((currentChart) => currentChart ?? resolvedChart);
     setIsOpenChart(true);
-  }, [params.value]);
+  }, [resolvedChart]);
 
   const closeChart = useCallback(() => {
     setIsOpenChart(false);
@@ -70,6 +75,10 @@ const ChartCellRenderer = (params: ChartCellRendererParams) => {
   useEffect(() => {
     setChart(undefined);
   }, [params.value]);
+
+  if (resolvedChart && !resolvedChart.isPlottable) {
+    return null;
+  }
 
   return (
     <>

--- a/libs/conversation-view/src/context/AttachmentsData.tsx
+++ b/libs/conversation-view/src/context/AttachmentsData.tsx
@@ -36,7 +36,10 @@ import {
   getTimeQueryFilterFromAttachment,
 } from '../utils/query-filters';
 import { AttachmentType } from '@epam/statgpt-dial-toolkit';
-import { createChartDataResolver } from '../utils/attachments/charting/chart-data';
+import {
+  createChartDataResolver,
+  isChartingDataPlottable,
+} from '../utils/attachments/charting/chart-data';
 import { ChartingStyles } from '../models/attachments-styles';
 import { MetadataSettings } from '../models/metadata';
 import { ConversationViewTitles } from '../models/titles';
@@ -87,6 +90,7 @@ export function useAttachmentsData(
     useState<CustomChartAttachmentType>(
       createInitialChartAttachment(titles?.chart),
     );
+  const [isChartPlottable, setIsChartPlottable] = useState(false);
   const [codeAttachments, setCodeAttachments] = useState<
     CustomCodeAttachment[]
   >([]);
@@ -337,19 +341,30 @@ export function useAttachmentsData(
   ]);
 
   useEffect(() => {
-    if (structures != null && dataMessage != null) {
-      setCustomChartAttachment((prev) => ({
-        ...prev,
-        charting_data: undefined,
-        getChartingData: createChartDataResolver(
-          structures,
-          dataMessage,
-          dataQuery,
-          locale,
-          chartStyles,
-        ),
-      }));
+    if (structures == null || dataMessage == null) {
+      return undefined;
     }
+    const resolver = createChartDataResolver(
+      structures,
+      dataMessage,
+      dataQuery,
+      locale,
+      chartStyles,
+    );
+    setCustomChartAttachment((prev) => ({
+      ...prev,
+      charting_data: undefined,
+      getChartingData: resolver,
+    }));
+    setIsChartPlottable(false);
+    return scheduleDeferredWork(() => {
+      try {
+        setIsChartPlottable(isChartingDataPlottable(resolver()));
+      } catch (err) {
+        console.error('Error evaluating chart plottability', err as object);
+        setIsChartPlottable(false);
+      }
+    });
   }, [structures, dataMessage, dataQuery, locale, chartStyles]);
 
   useEffect(() => {
@@ -367,8 +382,17 @@ export function useAttachmentsData(
   }, [rawAttachments, titles, dataQuery]);
 
   const attachments = useMemo(
-    () => [customGridAttachment, customChartAttachment, ...codeAttachments],
-    [customGridAttachment, customChartAttachment, codeAttachments],
+    () => [
+      customGridAttachment,
+      ...(isChartPlottable ? [customChartAttachment] : []),
+      ...codeAttachments,
+    ],
+    [
+      customGridAttachment,
+      customChartAttachment,
+      codeAttachments,
+      isChartPlottable,
+    ],
   );
 
   return {

--- a/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
+++ b/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
@@ -39,6 +39,7 @@ import { MetadataSettings } from '../models/metadata';
 import { CrossDatasetGridViewMode } from '../components/AdvancedView/TableSettings/types';
 import { StructureDataMaps } from '../models/structure-data';
 import { createCrossDatasetChartingDataResolver } from '../utils/attachments/charting/cross-dataset-chart-data';
+import { isChartingDataPlottable } from '../utils/attachments/charting/chart-data';
 import { scheduleDeferredWork } from '../utils/deferred-work';
 import {
   filterDataQueriesByActiveDatasetUrns,
@@ -97,6 +98,8 @@ export function useAttachmentsDataMultipleQueries(
     );
   const [crossDatasetChartAttachment, setCrossDatasetChartAttachment] =
     useState(createInitialChartAttachment(titles?.chart));
+  const [isCrossDatasetChartPlottable, setIsCrossDatasetChartPlottable] =
+    useState(false);
   const [codeAttachments, setCodeAttachments] = useState<
     CustomCodeAttachment[]
   >([]);
@@ -368,18 +371,32 @@ export function useAttachmentsDataMultipleQueries(
         activeDatasetUrns,
       );
 
+      const resolver = createCrossDatasetChartingDataResolver(
+        visibleStructuresMap,
+        visibleDataMessagesMap,
+        visibleDataQueries,
+        locale,
+        chartStyles,
+      );
       setCrossDatasetChartAttachment((prev) => ({
         ...prev,
         charting_data: undefined,
-        getChartingData: createCrossDatasetChartingDataResolver(
-          visibleStructuresMap,
-          visibleDataMessagesMap,
-          visibleDataQueries,
-          locale,
-          chartStyles,
-        ),
+        getChartingData: resolver,
       }));
+      setIsCrossDatasetChartPlottable(false);
+      return scheduleDeferredWork(() => {
+        try {
+          setIsCrossDatasetChartPlottable(isChartingDataPlottable(resolver()));
+        } catch (err) {
+          console.error(
+            'Error evaluating cross-dataset chart plottability',
+            err as object,
+          );
+          setIsCrossDatasetChartPlottable(false);
+        }
+      });
     }
+    return undefined;
   }, [
     structureDataMaps,
     compatibleDataQueries,
@@ -392,10 +409,15 @@ export function useAttachmentsDataMultipleQueries(
   const crossDatasetAttachments = useMemo(
     () => [
       crossDatasetGridAttachment,
-      crossDatasetChartAttachment,
+      ...(isCrossDatasetChartPlottable ? [crossDatasetChartAttachment] : []),
       ...codeAttachments,
     ],
-    [crossDatasetGridAttachment, crossDatasetChartAttachment, codeAttachments],
+    [
+      crossDatasetGridAttachment,
+      crossDatasetChartAttachment,
+      codeAttachments,
+      isCrossDatasetChartPlottable,
+    ],
   );
 
   const onMultipleDataFiltersChange = useCallback(

--- a/libs/conversation-view/src/models/charting.ts
+++ b/libs/conversation-view/src/models/charting.ts
@@ -10,6 +10,7 @@ export interface ChartUnit extends ChartUnitRows {
   config: EChartsOption;
   dimensions: DimensionInfo[];
   limitedByRowsAmountTo: number | undefined;
+  isPlottable: boolean;
 }
 
 export type ChartUnitValue = ChartUnit | (() => ChartUnit);

--- a/libs/conversation-view/src/utils/attachments/charting/__tests__/chart-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/__tests__/chart-data.spec.ts
@@ -14,6 +14,7 @@ import {
   buildSingleLineUnit,
   buildUnit,
   createChartDataResolver,
+  isChartingDataPlottable,
 } from '../chart-data';
 import { getDimensionsUniquenessByValues } from '../data-uniqueness';
 import { buildSerieKeyTitle } from '../serie-title';
@@ -440,5 +441,168 @@ describe('buildUnit', () => {
       expect.any(Array),
       styles,
     );
+  });
+
+  it('marks the unit as plottable when at least one series has two or more non-null points', () => {
+    const row = {
+      '2020': { value: [{ value: 100 }] },
+      '2021': { value: [{ value: 200 }] },
+    } as any;
+
+    const unit = buildUnit(
+      { rows: [row] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021', '2022'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(true);
+  });
+
+  it('marks the unit as not plottable when every series has fewer than two non-null points', () => {
+    const row = { '2020': { value: [{ value: 100 }] } } as any;
+
+    const unit = buildUnit(
+      { rows: [row] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021', '2022'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(false);
+  });
+
+  it('treats non-numeric time-period values as unfilled points', () => {
+    const row = {
+      '2020': { value: [{ value: 'n/a' }] },
+      '2021': { value: [{ value: 'pending' }] },
+      '2022': { value: [{ value: 42 }] },
+    } as any;
+
+    const unit = buildUnit(
+      { rows: [row] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021', '2022'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(false);
+  });
+
+  it('treats numeric string time-period values as filled points', () => {
+    const row = {
+      '2020': { value: [{ value: '42' }] },
+      '2021': { value: [{ value: '3.14' }] },
+    } as any;
+
+    const unit = buildUnit(
+      { rows: [row] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021', '2022'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(true);
+  });
+
+  it('treats empty and whitespace-only strings as unfilled points', () => {
+    const row = {
+      '2020': { value: [{ value: '' }] },
+      '2021': { value: [{ value: '   ' }] },
+      '2022': { value: [{ value: 7 }] },
+    } as any;
+
+    const unit = buildUnit(
+      { rows: [row] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021', '2022'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(false);
+  });
+
+  it('treats Infinity as an unfilled point', () => {
+    const row = {
+      '2020': { value: [{ value: Infinity }] },
+      '2021': { value: [{ value: 1 }] },
+    } as any;
+
+    const unit = buildUnit(
+      { rows: [row] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(false);
+  });
+
+  it('marks the unit as plottable when any series in a multi-row unit has two or more points', () => {
+    const rowWithOne = { '2020': { value: [{ value: 1 }] } } as any;
+    const rowWithTwo = {
+      '2020': { value: [{ value: 10 }] },
+      '2021': { value: [{ value: 20 }] },
+    } as any;
+
+    const unit = buildUnit(
+      { rows: [rowWithOne, rowWithTwo] },
+      makeStructures(),
+      makeDataQuery(),
+      ['2020', '2021'],
+      'en',
+    );
+
+    expect(unit.isPlottable).toBe(true);
+  });
+});
+
+describe('isChartingDataPlottable', () => {
+  const makeUnit = (isPlottable: boolean) =>
+    ({
+      rows: [],
+      config: {},
+      dimensions: [],
+      limitedByRowsAmountTo: undefined,
+      isPlottable,
+    }) as any;
+
+  it('returns true when any unit in the top-level units array is plottable', () => {
+    expect(
+      isChartingDataPlottable({
+        units: [makeUnit(false), makeUnit(true)],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when any unit inside a group is plottable', () => {
+    expect(
+      isChartingDataPlottable({
+        units: [],
+        groups: [
+          { title: 'a', units: [makeUnit(false)] },
+          { title: 'b', units: [makeUnit(true)] },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when no unit is plottable', () => {
+    expect(
+      isChartingDataPlottable({
+        units: [makeUnit(false), makeUnit(false)],
+        groups: [{ title: 'a', units: [makeUnit(false)] }],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for empty charting data', () => {
+    expect(isChartingDataPlottable({ units: [] })).toBe(false);
   });
 });

--- a/libs/conversation-view/src/utils/attachments/charting/__tests__/cross-dataset-chart-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/__tests__/cross-dataset-chart-data.spec.ts
@@ -24,7 +24,13 @@ describe('cross-dataset chart data', () => {
     const dataQuery = { urn: 'urn:1' };
     const structuresMap = new Map([['urn:1', structures]]);
     const dataMessagesMap = new Map([['urn:1', dataMessage]]);
-    const chartUnit = { config: {}, dimensions: [], rows: [] };
+    const chartUnit = {
+      config: {},
+      dimensions: [],
+      rows: [],
+      limitedByRowsAmountTo: undefined,
+      isPlottable: false,
+    };
 
     jest.mocked(getLocalizedName).mockReturnValue('Dataset 1');
     jest.mocked(buildChartData).mockReturnValue({ units: [chartUnit] });
@@ -48,7 +54,13 @@ describe('cross-dataset chart data', () => {
     const dataQuery = { urn: 'urn:1' };
     const structuresMap = new Map([['urn:1', structures]]);
     const dataMessagesMap = new Map([['urn:1', dataMessage]]);
-    const chartUnit = { config: {}, dimensions: [], rows: [] };
+    const chartUnit = {
+      config: {},
+      dimensions: [],
+      rows: [],
+      limitedByRowsAmountTo: undefined,
+      isPlottable: false,
+    };
 
     jest.mocked(getLocalizedName).mockReturnValue('Dataset 1');
     jest.mocked(buildChartData).mockReturnValue({ units: [chartUnit] });

--- a/libs/conversation-view/src/utils/attachments/charting/chart-data.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/chart-data.ts
@@ -32,6 +32,22 @@ import { getDimRelatedStructures } from '../localized-value';
 
 const LINE_TYPE = 'line';
 const MAX_LINES_PER_UNIT = 10;
+const MIN_POINTS_PER_LINE = 2;
+
+function isFilledPoint(value: unknown): boolean {
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    return Number.isFinite(Number(value));
+  }
+  return false;
+}
+
+export function isChartingDataPlottable(data: ChartingData): boolean {
+  const groupUnits = (data.groups ?? []).flatMap((group) => group.units);
+  return [...data.units, ...groupUnits].some((unit) => unit.isPlottable);
+}
 
 export function buildChartData(
   structures: StructuralData,
@@ -121,6 +137,11 @@ export function buildUnit(
   const frequencyDimensionId = dimensions?.find((dimension) =>
     FREQUENCY_DIMENSION_ID.includes(dimension?.id),
   )?.id;
+  const filteredTimePeriods = filterTimePeriodsByFrequency(
+    timePeriods,
+    unit?.rows?.[0],
+    frequencyDimensionId,
+  );
   const series = buildChartSeries(
     unit.rows.length > MAX_LINES_PER_UNIT
       ? unit.rows.slice(0, MAX_LINES_PER_UNIT)
@@ -128,11 +149,7 @@ export function buildUnit(
     structures,
     dataQuery,
     locale,
-    filterTimePeriodsByFrequency(
-      timePeriods,
-      unit?.rows?.[0],
-      frequencyDimensionId,
-    ),
+    filteredTimePeriods,
   );
 
   return {
@@ -140,16 +157,15 @@ export function buildUnit(
     limitedByRowsAmountTo:
       unit.rows.length > MAX_LINES_PER_UNIT ? MAX_LINES_PER_UNIT : undefined,
     dimensions,
-    config: buildChartConfig(
-      filterTimePeriodsByFrequency(
-        timePeriods,
-        unit?.rows?.[0],
-        frequencyDimensionId,
-      ),
-      series,
-      styles,
-    ),
+    config: buildChartConfig(filteredTimePeriods, series, styles),
+    isPlottable: hasPlottableSeries(series),
   };
+}
+
+function hasPlottableSeries(series: { data: unknown[] }[]): boolean {
+  return series.some(
+    (s) => s.data.filter(isFilledPoint).length >= MIN_POINTS_PER_LINE,
+  );
 }
 
 function filterTimePeriodsByFrequency(

--- a/libs/conversation-view/src/utils/attachments/data-grid/__tests__/rows-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/__tests__/rows-data.spec.ts
@@ -36,7 +36,13 @@ describe('getRowsData', () => {
     const chartStyles = {};
     const timeSeries = [{ name: 'A.US' }];
     const rows = [{ FREQ: 'A', REF_AREA: 'US' }];
-    const chartUnit = { config: {}, dimensions: [], rows };
+    const chartUnit = {
+      config: {},
+      dimensions: [],
+      rows,
+      limitedByRowsAmountTo: undefined,
+      isPlottable: false,
+    };
 
     jest.mocked(getParsedResponse).mockReturnValue(timeSeries);
     jest.mocked(getDimensions).mockReturnValue({


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/statgpt-portal-frontend/issues/72

### Description of changes

Hide the chart attachment and the inline grid chart button when the data cannot be plotted (no series has ≥ 2 finite numeric points).

  - Added ChartUnit.isPlottable and isChartingDataPlottable(data) helper.
  - AttachmentsData / AttachmentsDataMultipleQueries evaluate plottability via scheduleDeferredWork and omit the chart attachment when it is not plottable.                                 
  - ChartCellRenderer returns null for non-plottable units.
  - Added tests covering plottability across number, numeric-string, whitespace, and Infinity cases.
  
  
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
