### PR TITLE
fix: send availability requests when change items in shared filters

### DIFF
--- a/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/multiple-filters.spec.ts
@@ -1574,7 +1574,7 @@ describe('getCompatibleDatasetUrns', () => {
 });
 
 describe('getConstraintsRequests', () => {
-  it('excludes shared non-time dimension filters from constraint requests in cross-dataset mode', async () => {
+  it('includes shared non-time dimension filters in constraint requests for each dataset', async () => {
     const sharedFrequencyFilter = {
       id: COMMON_FREQUENCY_FILTER_ID,
       filterType: 'shared',
@@ -1610,12 +1610,12 @@ describe('getConstraintsRequests', () => {
     );
 
     expect(mockGetSeriesFilterDto).toHaveBeenCalledWith(
-      [],
+      sourceFilters,
       DATASET_A_URN,
       DATASET_DIMENSIONS_METADATA_MAP,
     );
     expect(mockGetSeriesFilterDto).toHaveBeenCalledWith(
-      [],
+      sourceFilters,
       DATASET_B_URN,
       DATASET_DIMENSIONS_METADATA_MAP,
     );

--- a/libs/conversation-view/src/utils/multiple-filters.ts
+++ b/libs/conversation-view/src/utils/multiple-filters.ts
@@ -1182,22 +1182,9 @@ const getConstraintFilters = (
   sourceFilters: Filter[],
   datasetDimensionsMetadataMap?: DatasetDimensionsMetadataMap,
 ): SeriesFilterDto[] => {
-  const hasMergedSharedFilters = sourceFilters.some(
-    (filter) => filter.filterType === 'shared',
-  );
-  const filtersForConstraint = hasMergedSharedFilters
-    ? sourceFilters.filter((filter) => {
-        const config = getSharedFilterConfigForFilter(
-          filter,
-          datasetDimensionsMetadataMap,
-        );
-        return !config || config.id === COMMON_TIME_PERIOD_FILTER_ID;
-      })
-    : sourceFilters;
-
   return normalizeConstraintFilters(
     getSeriesFilterDto(
-      filtersForConstraint,
+      sourceFilters,
       attachmentUrn,
       datasetDimensionsMetadataMap,
     ).filter((filter) => filter.componentCode !== TIME_PERIOD),


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/267

### Description of changes

**What changed**
Removed the logic in `getConstraintFilters` that stripped shared (non-time) filters from the `/api/constraints/${dataset_name}` request payload. Shared filter selections now flow through to the per-dataset requests, where `expandSharedFilter` maps each value to its native dimension id on the correct dataset(s).

**Why**
Toggling a value on a shared filter (e.g. COUNTRY, FREQUENCY) produced no change in the request payload, so the cache returned a stale result and downstream filter values never refreshed. With the strip removed, every shared-value toggle now triggers real constraints requests for the affected datasets and feeds back into the existing post-response refresh flow — matching how dataset-specific filters already work. Time period shared filter is untouched.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
