### PR TITLE
fix: lost of message selected dataset

### DIFF
--- a/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
@@ -281,10 +281,13 @@ const Message: FC<Props> = ({
   }, [attachmentsDataQueries]);
 
   useEffect(() => {
-    if (dataQuery && dataQuery.urn) {
+    if (
+      dataQuery?.urn &&
+      attachmentsDataQueries?.some((q) => q?.urn === dataQuery.urn)
+    ) {
       setInitialSelectedDatasetUrn(dataQuery.urn);
     }
-  }, [dataQuery]);
+  }, [dataQuery, attachmentsDataQueries]);
 
   useEffect(() => {
     if (message?.role === Role.System && previousMessage) {

--- a/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
+++ b/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
@@ -925,8 +925,8 @@ export const ConversationView: FC<Props> = ({
             rightSlot={headerRightSlot}
           />
         )}
-        <div className="flex min-h-0 w-full flex-1">
-          <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 w-full flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             <div
               className={classNames(
                 'flex-1 min-h-0 flex flex-col items-end scroll-hidden-container',


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/statgpt-global-trusted-data-commons/issues/264

### Description of changes

Contains two fixes:

  1. Per-message dataset selection no longer hijacked by sibling messages (Message.tsx) — the effect that adopts the global dataQuery.urn into initialSelectedDatasetUrn now first checks that the urn actually belongs to this 
  message's attachmentsDataQueries. Foreign urns leaked in by other messages' useDatasets calls are ignored, so dataset tabs stay selected and code samples stay filtered to the active query.
  2. Chat column no longer overflows with wide dataset lists (ConversationView.tsx) — added min-w-0 to the two flex containers wrapping ChatMessages, so the chat area can shrink instead of being pushed wide by a long        
  horizontal dataset tab strip.