### PR TITLE
fix: reset columns to current mode defaults when initial state is cleared

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnPreferences.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnPreferences.spec.ts
@@ -126,6 +126,25 @@ describe('useAgGridColumnPreferences', () => {
     expect(result.current.initialColumnsState).toBeNull();
   });
 
+  it('clearInitialColumnState resets initialColumnsState to null', () => {
+    const api = mockApi();
+    const { result } = renderHook(() =>
+      useAgGridColumnPreferences({ currentUrn: 'urn:1' }),
+    );
+
+    act(() => {
+      result.current.onGridApiReady(api);
+    });
+
+    expect(result.current.initialColumnsState).not.toBeNull();
+
+    act(() => {
+      result.current.clearInitialColumnState();
+    });
+
+    expect(result.current.initialColumnsState).toBeNull();
+  });
+
   it('restores saved initial state when switching back to a known URN', () => {
     const urn1State = [{ colId: 'x', hide: false }];
     const api1 = mockApi({

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/useAgGridColumnPreferences.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/useAgGridColumnPreferences.ts
@@ -79,6 +79,7 @@ export function useAgGridColumnPreferences({
 
   const clearInitialColumnState = useCallback(() => {
     columnsInitialStateByUrnRef.current.delete(currentUrn);
+    setInitialColumnsState(null);
   }, [currentUrn]);
 
   useAgGridColumnGridListeners(gridApi, persistUserState);

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsPanel.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsPanel.tsx
@@ -69,7 +69,11 @@ export const TableSettingsPanel = () => {
       return;
     }
     clearUserColumnState();
-    restoreInitialColumnsState(gridApi, initialColumnsState);
+    if (initialColumnsState) {
+      restoreInitialColumnsState(gridApi, initialColumnsState);
+    } else {
+      gridApi.resetColumnState();
+    }
     resetDimensionCustomization();
   }, [
     clearUserColumnState,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/266

### Description of changes

Fixes a bug where clicking Reset in Extended view pushed indicator dimension columns to the far right.

Root cause: `clearInitialColumnState` was clearing the ref but not the React state, so a stale Compact-mode snapshot was applied on reset. Now it falls back to `gridApi.resetColumnState()` when no snapshot is available.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
