### PR TITLE
feat: add inline alert to share conversation modal

### DIFF
--- a/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
@@ -216,6 +216,7 @@ const ConversationListWrapper = ({
       chatExpirationDays: t(ChatI18nKeys.CHAT_EXPIRATION_DAYS),
       chatName: t(ChatI18nKeys.CHAT_NAME),
       chatWarning: t(ChatI18nKeys.CHAT_WARNING),
+      shareAlertMessage: t(ChatI18nKeys.SHARE_ALERT_MESSAGE),
     }),
     [t],
   );

--- a/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
@@ -189,6 +189,7 @@ const ConversationViewWrapper: FC<Props> = ({
       chatExpirationDays: t(ChatI18nKeys.CHAT_EXPIRATION_DAYS),
       chatName: t(ChatI18nKeys.CHAT_NAME),
       chatWarning: t(ChatI18nKeys.CHAT_WARNING),
+      shareAlertMessage: t(ChatI18nKeys.SHARE_ALERT_MESSAGE),
     }),
     [id, shareConversationApiProps, t],
   );

--- a/apps/portals-example/src/constants/i18n-keys.ts
+++ b/apps/portals-example/src/constants/i18n-keys.ts
@@ -44,6 +44,7 @@ export enum ChatI18nKeys {
   CHAT_EXPIRATION = 'chat.chatExpiration',
   CHAT_EXPIRATION_DAYS = 'chat.chatExpirationDays',
   CHAT_WARNING = 'chat.chatWarning',
+  SHARE_ALERT_MESSAGE = 'chat.shareAlertMessage',
   DUPLICATE_CHAT = 'chat.duplicateChat',
   EXPLORE_DATA = 'chart.exploreData',
   CONVERSATION_ACCESS_ERROR_TITLE = 'chat.conversationAccessErrorTitle',

--- a/apps/portals-example/src/locales/en/common.json
+++ b/apps/portals-example/src/locales/en/common.json
@@ -39,6 +39,7 @@
     "chatExpiration": "Link expiration date:",
     "chatExpirationDays": "days",
     "chatWarning": "This chat has not been shared with anyone yet.",
+    "shareAlertMessage": "Only users of Global Trusted Data Commons can open this link",
     "conversationAccessErrorTitle": "Access error",
     "conversationAccessErrorText": "The link has expired or the chat has been deleted."
   },

--- a/libs/share-conversation/src/components/ShareConversation/ShareConversationModal.tsx
+++ b/libs/share-conversation/src/components/ShareConversation/ShareConversationModal.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { IconCheck, IconCopy, IconInfoCircle } from '@tabler/icons-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -10,6 +10,8 @@ import {
 } from '@epam/statgpt-dial-toolkit';
 import {
   Button,
+  InlineAlert,
+  InlineAlertType,
   InputWithIcon,
   Loader,
   Popup,
@@ -53,6 +55,7 @@ const ShareConversationModal: FC<Props> = ({
   id,
   clientSharedPage,
   clientSharedProp,
+  shareAlertMessage,
 }) => {
   const [generatedLink, setGeneratedLink] = useState<string | null>(null);
   const [sharedConversation, setSharedConversation] =
@@ -253,6 +256,14 @@ const ShareConversationModal: FC<Props> = ({
         </div>
       ) : (
         <div className="share flex flex-col gap-y-4 overflow-auto px-6 pb-6 sm:p-0">
+          {shareAlertMessage ? (
+            <InlineAlert
+              type={InlineAlertType.Note}
+              icon={<IconInfoCircle width={16} height={16} />}
+            >
+              {shareAlertMessage}
+            </InlineAlert>
+          ) : null}
           {conversation?.name ? (
             <div className="share-info flex w-full">
               <p className="share-info-title body-1 mr-1 text-neutrals-800">

--- a/libs/share-conversation/src/models/share-conversation.ts
+++ b/libs/share-conversation/src/models/share-conversation.ts
@@ -38,4 +38,5 @@ export interface ShareConversationProps {
   id?: string[];
   clientSharedPage?: string;
   clientSharedProp?: string;
+  shareAlertMessage?: string;
 }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/272

### Description of changes

Adds an informational inline alert in Note style to the Share Conversation modal, positioned above the chat name.

The alert text is configurable, wired through the i18n system, and passed from both the conversation list and conversation view wrappers.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
