### PR TITLE
feat: dimension group attributes

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Metadata/ExpandToggleButton.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/ExpandToggleButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { FC } from 'react';
+import classNames from 'classnames';
+import { IconButton } from '@epam/statgpt-ui-components';
+import ChevronSolidDownIcon from '../../../assets/icons/chevron-solid-down.svg';
+
+interface Props {
+  isExpanded: boolean;
+  onToggle: () => void;
+  title?: string;
+}
+
+export const ExpandToggleButton: FC<Props> = ({
+  isExpanded,
+  onToggle,
+  title,
+}) => (
+  <IconButton
+    title={title}
+    buttonClassName={classNames(
+      'border-none p-0 w-6 h-6 shrink-0',
+      isExpanded && 'rotate-[180deg]',
+    )}
+    isBaseIconStyles={false}
+    icon={<ChevronSolidDownIcon width={24} height={24} />}
+    onClick={onToggle}
+  />
+);

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/MetadataContent.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/MetadataContent.tsx
@@ -40,6 +40,7 @@ const MetadataContent: FC<Props> = ({
               value={metadataItem?.value}
               locale={locale}
               attachedKeysTitles={metadataItem?.attachedKeysTitles}
+              isDimensionGroup={metadataItem?.isDimensionGroup}
             />
           ))
         ) : (

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/MetadataItem.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/MetadataItem.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FC, useMemo } from 'react';
 import classNames from 'classnames';
-import { IconButton } from '@epam/statgpt-ui-components';
-import ChevronSolidDownIcon from '../../../assets/icons/chevron-solid-down.svg';
 import { StructureComponentValue } from '../../../models/structure-component';
+import { useClampToggle } from './hooks/useClampToggle';
+import { ExpandToggleButton } from './ExpandToggleButton';
 
 interface Props extends StructureComponentValue {
   locale: string;
@@ -16,17 +16,7 @@ const MetadataItem: FC<Props> = ({
   attachedKeysTitles,
   locale,
 }) => {
-  const [isItemOpen, setIsItemOpen] = useState(false);
-  const [isShowIcon, setShowIcon] = useState<boolean>(false);
-  const valueContainerRef = useRef<HTMLDivElement>(null);
-
-  const onIconClick = useCallback(() => {
-    if (isShowIcon) {
-      setIsItemOpen((prev) => !prev);
-    }
-  }, [setIsItemOpen, isShowIcon]);
-
-  const getMetadataItemValue = useCallback(
+  const displayValue = useMemo(
     () =>
       Array.isArray(value)
         ? value
@@ -38,14 +28,8 @@ const MetadataItem: FC<Props> = ({
     [locale, value],
   );
 
-  useEffect(() => {
-    if (valueContainerRef?.current) {
-      setShowIcon(
-        valueContainerRef?.current?.scrollHeight >
-          valueContainerRef?.current?.offsetHeight,
-      );
-    }
-  }, [valueContainerRef]);
+  const { valueRef, isExpanded, canToggle, toggle } =
+    useClampToggle<HTMLParagraphElement>(displayValue);
 
   return (
     <div className="metadata-item">
@@ -61,33 +45,25 @@ const MetadataItem: FC<Props> = ({
       <div
         className={classNames(
           'flex items-center',
-          isShowIcon && 'justify-between',
+          canToggle && 'justify-between',
         )}
       >
         <h2 title={title} className="metadata-item-title">
           {title}
         </h2>
-        {isShowIcon && (
-          <IconButton
-            buttonClassName={classNames(
-              'border-none p-0 w-6 h-6',
-              isItemOpen ? 'rotate-[180deg]' : '',
-            )}
-            isBaseIconStyles={false}
-            icon={<ChevronSolidDownIcon width={24} height={24} />}
-            onClick={onIconClick}
-          />
+        {canToggle && (
+          <ExpandToggleButton isExpanded={isExpanded} onToggle={toggle} />
         )}
       </div>
       <p
-        title={getMetadataItemValue()}
+        title={displayValue}
         className={classNames(
           'metadata-item-value pr-3',
-          !isItemOpen && 'line-clamp-4',
+          !isExpanded && 'line-clamp-4',
         )}
-        ref={valueContainerRef}
+        ref={valueRef}
       >
-        {getMetadataItemValue()}
+        {displayValue}
       </p>
     </div>
   );

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/MetadataItem.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/MetadataItem.tsx
@@ -14,6 +14,7 @@ const MetadataItem: FC<Props> = ({
   title,
   value,
   attachedKeysTitles,
+  isDimensionGroup,
   locale,
 }) => {
   const displayValue = useMemo(
@@ -33,15 +34,16 @@ const MetadataItem: FC<Props> = ({
 
   return (
     <div className="metadata-item">
-      {attachedKeysTitles?.map((attachedKeyTitle) => (
-        <div
-          title={attachedKeyTitle}
-          key={attachedKeyTitle}
-          className="metadata-item-key mb-1 pr-3 text-neutrals-800"
-        >
-          {attachedKeyTitle}
-        </div>
-      ))}
+      {!isDimensionGroup &&
+        attachedKeysTitles?.map((attachedKeyTitle) => (
+          <div
+            title={attachedKeyTitle}
+            key={attachedKeyTitle}
+            className="metadata-item-key mb-1 pr-3 text-neutrals-800"
+          >
+            {attachedKeyTitle}
+          </div>
+        ))}
       <div
         className={classNames(
           'flex items-center',

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataContent.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataContent.tsx
@@ -134,6 +134,7 @@ const SidePanelMetadataContent: FC<Props> = ({
                   title={metadataItem?.title || metadataItem?.id}
                   value={formatValue(metadataItem?.value)}
                   attachedKeysTitles={metadataItem?.attachedKeysTitles}
+                  isDimensionGroup={metadataItem?.isDimensionGroup}
                 />
               ))}
             </div>

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataContent.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataContent.tsx
@@ -5,6 +5,7 @@ import { StructureComponentValue } from '../../../../models/structure-component'
 import { useConversationViewStyles } from '../../../../context/ConversationViewStylesContext';
 import { DATASET_DESCRIPTION_ITEM_IDS } from '../../../../constants/metadata';
 import DatasetInfoDetails from './DatasetInfoDetails';
+import { SidePanelMetadataItem } from './SidePanelMetadataItem';
 import { DatasetInfoData } from '../../../../models/metadata';
 
 interface Props {
@@ -128,34 +129,12 @@ const SidePanelMetadataContent: FC<Props> = ({
           <div className="min-h-0 flex-1 overflow-y-auto">
             <div className="flex flex-col gap-4">
               {metadata?.map((metadataItem) => (
-                <div
+                <SidePanelMetadataItem
                   key={metadataItem?.id || metadataItem?.title}
-                  className="flex flex-col gap-1"
-                >
-                  {metadataItem?.attachedKeysTitles?.map(
-                    (attachedKeyTitle, index) => (
-                      <div
-                        key={`${attachedKeyTitle}-${index}`}
-                        title={attachedKeyTitle}
-                        className="body-3 text-neutrals-800"
-                      >
-                        {attachedKeyTitle}
-                      </div>
-                    ),
-                  )}
-                  <p
-                    title={metadataItem?.title}
-                    className="body-3 text-neutrals-800"
-                  >
-                    {metadataItem?.title || metadataItem?.id}
-                  </p>
-                  <p
-                    title={formatValue(metadataItem?.value)}
-                    className="body-2 break-words text-neutrals-1000"
-                  >
-                    {formatValue(metadataItem?.value)}
-                  </p>
-                </div>
+                  title={metadataItem?.title || metadataItem?.id}
+                  value={formatValue(metadataItem?.value)}
+                  attachedKeysTitles={metadataItem?.attachedKeysTitles}
+                />
               ))}
             </div>
           </div>

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataItem.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataItem.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { FC } from 'react';
+import classNames from 'classnames';
+import { useClampToggle } from '../hooks/useClampToggle';
+import { ExpandToggleButton } from '../ExpandToggleButton';
+
+interface Props {
+  title?: string;
+  value: string;
+  attachedKeysTitles?: string[];
+}
+
+export const SidePanelMetadataItem: FC<Props> = ({
+  title,
+  value,
+  attachedKeysTitles,
+}) => {
+  const { valueRef, isExpanded, canToggle, toggle } =
+    useClampToggle<HTMLParagraphElement>(value);
+
+  return (
+    <div className="flex flex-col gap-1">
+      {attachedKeysTitles?.map((attachedKeyTitle, index) => (
+        <div
+          key={`${attachedKeyTitle}-${index}`}
+          title={attachedKeyTitle}
+          className="body-3 text-neutrals-800"
+        >
+          {attachedKeyTitle}
+        </div>
+      ))}
+      <div className="flex items-center justify-between gap-2 pr-2">
+        <p title={title} className="body-3 text-neutrals-800">
+          {title}
+        </p>
+        {canToggle && (
+          <ExpandToggleButton isExpanded={isExpanded} onToggle={toggle} />
+        )}
+      </div>
+      <p
+        ref={valueRef}
+        title={value}
+        className={classNames(
+          'body-2 break-words text-neutrals-1000',
+          !isExpanded && 'line-clamp-4',
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+};

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataItem.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/SidePanelMetadataItem.tsx
@@ -9,27 +9,30 @@ interface Props {
   title?: string;
   value: string;
   attachedKeysTitles?: string[];
+  isDimensionGroup?: boolean;
 }
 
 export const SidePanelMetadataItem: FC<Props> = ({
   title,
   value,
   attachedKeysTitles,
+  isDimensionGroup,
 }) => {
   const { valueRef, isExpanded, canToggle, toggle } =
     useClampToggle<HTMLParagraphElement>(value);
 
   return (
     <div className="flex flex-col gap-1">
-      {attachedKeysTitles?.map((attachedKeyTitle, index) => (
-        <div
-          key={`${attachedKeyTitle}-${index}`}
-          title={attachedKeyTitle}
-          className="body-3 text-neutrals-800"
-        >
-          {attachedKeyTitle}
-        </div>
-      ))}
+      {!isDimensionGroup &&
+        attachedKeysTitles?.map((attachedKeyTitle, index) => (
+          <div
+            key={`${attachedKeyTitle}-${index}`}
+            title={attachedKeyTitle}
+            className="body-3 text-neutrals-800"
+          >
+            {attachedKeyTitle}
+          </div>
+        ))}
       <div className="flex items-center justify-between gap-2 pr-2">
         <p title={title} className="body-3 text-neutrals-800">
           {title}

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/SidePanelMetadataItem.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/SidePanelMetadataItem.spec.tsx
@@ -41,6 +41,20 @@ describe('SidePanelMetadataItem', () => {
     expect(screen.getByText('Country: US')).toBeTruthy();
   });
 
+  it('hides attached key titles for dimensionGroup attributes', () => {
+    setMeasurements(0, 0);
+    render(
+      <SidePanelMetadataItem
+        title="Attr"
+        value="v"
+        attachedKeysTitles={['Country: US']}
+        isDimensionGroup
+      />,
+    );
+
+    expect(screen.queryByText('Country: US')).toBeNull();
+  });
+
   it('clamps and expands long values', () => {
     setMeasurements(200, 80);
     render(

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/SidePanelMetadataItem.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/SidePanelMetadataItem.spec.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SidePanelMetadataItem } from '../SidePanelMetadataItem';
+
+jest.mock('../../../../../assets/icons/chevron-solid-down.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="chevron" />,
+}));
+
+function setMeasurements(scrollHeight: number, offsetHeight: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => offsetHeight,
+  });
+}
+
+describe('SidePanelMetadataItem', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders title and value', () => {
+    setMeasurements(0, 0);
+    render(<SidePanelMetadataItem title="Full Description" value="A note" />);
+
+    expect(screen.getByText('Full Description')).toBeTruthy();
+    expect(screen.getByText('A note')).toBeTruthy();
+  });
+
+  it('renders attached key titles', () => {
+    setMeasurements(0, 0);
+    render(
+      <SidePanelMetadataItem
+        title="Attr"
+        value="v"
+        attachedKeysTitles={['Country: US']}
+      />,
+    );
+
+    expect(screen.getByText('Country: US')).toBeTruthy();
+  });
+
+  it('clamps and expands long values', () => {
+    setMeasurements(200, 80);
+    render(
+      <SidePanelMetadataItem title="Full Description" value="Very long text" />,
+    );
+
+    const value = screen.getByText('Very long text');
+    expect(value.className).toContain('line-clamp-4');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(value.className).not.toContain('line-clamp-4');
+  });
+
+  it('shows no toggle for short values', () => {
+    setMeasurements(40, 40);
+    render(<SidePanelMetadataItem title="Agency" value="IMF" />);
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/__tests__/ExpandToggleButton.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/__tests__/ExpandToggleButton.spec.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ExpandToggleButton } from '../ExpandToggleButton';
+
+jest.mock('../../../../assets/icons/chevron-solid-down.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="chevron" />,
+}));
+
+describe('ExpandToggleButton', () => {
+  it('calls onToggle when clicked', () => {
+    const onToggle = jest.fn();
+    render(<ExpandToggleButton isExpanded={false} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('rotates the chevron when expanded', () => {
+    render(<ExpandToggleButton isExpanded onToggle={jest.fn()} />);
+
+    expect(screen.getByRole('button').className).toContain('rotate-[180deg]');
+  });
+
+  it('does not rotate the chevron when collapsed', () => {
+    render(<ExpandToggleButton isExpanded={false} onToggle={jest.fn()} />);
+
+    expect(screen.getByRole('button').className).not.toContain(
+      'rotate-[180deg]',
+    );
+  });
+});

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/__tests__/MetadataItem.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/__tests__/MetadataItem.spec.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import MetadataItem from '../MetadataItem';
+
+jest.mock('../../../../assets/icons/chevron-solid-down.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="chevron" />,
+}));
+
+function setMeasurements(scrollHeight: number, offsetHeight: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => offsetHeight,
+  });
+}
+
+describe('MetadataItem', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the title and value', () => {
+    setMeasurements(0, 0);
+    render(
+      <MetadataItem title="Full Description" value="A short note" locale="en" />,
+    );
+
+    expect(screen.getByText('Full Description')).toBeTruthy();
+    expect(screen.getByText('A short note')).toBeTruthy();
+  });
+
+  it('shows no toggle when the value fits', () => {
+    setMeasurements(40, 40);
+    render(<MetadataItem title="Full Description" value="Short" locale="en" />);
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('shows a toggle when the value overflows and expands on click', () => {
+    setMeasurements(200, 80);
+    render(
+      <MetadataItem title="Full Description" value="Very long text" locale="en" />,
+    );
+
+    const value = screen.getByText('Very long text');
+    expect(value.className).toContain('line-clamp-4');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(value.className).not.toContain('line-clamp-4');
+  });
+
+  it('joins array values with the locale', () => {
+    setMeasurements(0, 0);
+    render(
+      <MetadataItem
+        title="Keywords"
+        value={[{ en: 'A' }, { en: 'B' }] as unknown as string[]}
+        locale="en"
+      />,
+    );
+
+    expect(screen.getByText('A, B')).toBeTruthy();
+  });
+});

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/__tests__/MetadataItem.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/__tests__/MetadataItem.spec.tsx
@@ -25,7 +25,11 @@ describe('MetadataItem', () => {
   it('renders the title and value', () => {
     setMeasurements(0, 0);
     render(
-      <MetadataItem title="Full Description" value="A short note" locale="en" />,
+      <MetadataItem
+        title="Full Description"
+        value="A short note"
+        locale="en"
+      />,
     );
 
     expect(screen.getByText('Full Description')).toBeTruthy();
@@ -42,7 +46,11 @@ describe('MetadataItem', () => {
   it('shows a toggle when the value overflows and expands on click', () => {
     setMeasurements(200, 80);
     render(
-      <MetadataItem title="Full Description" value="Very long text" locale="en" />,
+      <MetadataItem
+        title="Full Description"
+        value="Very long text"
+        locale="en"
+      />,
     );
 
     const value = screen.getByText('Very long text');
@@ -50,6 +58,35 @@ describe('MetadataItem', () => {
 
     fireEvent.click(screen.getByRole('button'));
     expect(value.className).not.toContain('line-clamp-4');
+  });
+
+  it('renders attached key titles', () => {
+    setMeasurements(0, 0);
+    render(
+      <MetadataItem
+        title="Attr"
+        value="v"
+        locale="en"
+        attachedKeysTitles={['Country: US']}
+      />,
+    );
+
+    expect(screen.getByText('Country: US')).toBeTruthy();
+  });
+
+  it('hides attached key titles for dimensionGroup attributes', () => {
+    setMeasurements(0, 0);
+    render(
+      <MetadataItem
+        title="Attr"
+        value="v"
+        locale="en"
+        attachedKeysTitles={['Country: US']}
+        isDimensionGroup
+      />,
+    );
+
+    expect(screen.queryByText('Country: US')).toBeNull();
   });
 
   it('joins array values with the locale', () => {

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/hooks/__tests__/useClampToggle.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/hooks/__tests__/useClampToggle.spec.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import { useClampToggle } from '../useClampToggle';
+
+describe('useClampToggle', () => {
+  it('starts collapsed and not toggleable', () => {
+    const { result } = renderHook(() => useClampToggle('text'));
+
+    expect(result.current.isExpanded).toBe(false);
+    expect(result.current.canToggle).toBe(false);
+  });
+
+  it('flips isExpanded when toggle is called', () => {
+    const { result } = renderHook(() => useClampToggle('text'));
+
+    act(() => result.current.toggle());
+    expect(result.current.isExpanded).toBe(true);
+
+    act(() => result.current.toggle());
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it('exposes a value ref', () => {
+    const { result } = renderHook(() => useClampToggle('text'));
+
+    expect(result.current.valueRef).toHaveProperty('current');
+  });
+});

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/hooks/useClampToggle.ts
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/hooks/useClampToggle.ts
@@ -1,0 +1,38 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseClampToggleResult<T extends HTMLElement> {
+  valueRef: RefObject<T | null>;
+  isExpanded: boolean;
+  canToggle: boolean;
+  toggle: () => void;
+}
+
+export function useClampToggle<T extends HTMLElement = HTMLElement>(
+  dependency: unknown,
+): UseClampToggleResult<T> {
+  const valueRef = useRef<T>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [canToggle, setCanToggle] = useState(false);
+
+  const measure = useCallback(() => {
+    const node = valueRef.current;
+    if (!node) return;
+    setCanToggle(node.scrollHeight > node.offsetHeight);
+  }, []);
+
+  useEffect(() => {
+    if (isExpanded) return;
+    measure();
+
+    const node = valueRef.current;
+    if (!node || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [isExpanded, dependency, measure]);
+
+  const toggle = useCallback(() => setIsExpanded((prev) => !prev), []);
+
+  return { valueRef, isExpanded, canToggle, toggle };
+}

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/DatasetDetailCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/DatasetDetailCellRenderer.tsx
@@ -2,9 +2,18 @@
 
 import { FC, useMemo, useCallback } from 'react';
 import { ICellRendererParams } from 'ag-grid-community';
-import { StructuralData, getLastUpdatedTime } from '@epam/statgpt-sdmx-toolkit';
+import {
+  Data,
+  getLastUpdatedTime,
+  getStructureComponentsMap,
+  StructuralData,
+} from '@epam/statgpt-sdmx-toolkit';
 import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
-import { getDatasetInfoData } from '../../../utils/attachments/metadata';
+import {
+  getDataSetAttributes,
+  getDatasetInfoData,
+  getStructureAttributes,
+} from '../../../utils/attachments/metadata';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
@@ -14,6 +23,7 @@ import { getExternalLinkFromContext } from './helpers/get-external-link-from-con
 
 interface DatasetDetailCellRendererParams extends ICellRendererParams {
   structuresMap: Map<string, StructuralData | undefined>;
+  attributesDataMap: Map<string, Data | undefined>;
   locale: string;
 }
 
@@ -30,6 +40,8 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
   const urn: string | undefined = params?.data?.dataset?.urn;
   const externalLink = getExternalLinkFromContext(params?.context, urn);
   const structures = urn != null ? params.structuresMap.get(urn) : undefined;
+  const resolvedData =
+    urn != null ? params.attributesDataMap?.get(urn) : undefined;
 
   const datasetInfo = useMemo(() => {
     const dataflow = structures?.dataflows?.[0];
@@ -40,6 +52,16 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
     );
     return getDatasetInfoData(dataflow, lastUpdatedDate, params.locale, titles);
   }, [structures, params.locale, titles]);
+
+  const metadata = useMemo(
+    () =>
+      getDataSetAttributes(
+        getStructureAttributes(resolvedData),
+        getStructureComponentsMap(structures),
+        params.locale,
+      ),
+    [resolvedData, structures, params.locale],
+  );
 
   const showIndicator = isMetadataInSidePanel && !!sidePanel && !!params.value;
 
@@ -53,7 +75,7 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
       content: (
         <SidePanelMetadataContent
           locale={params.locale}
-          metadata={[]}
+          metadata={metadata}
           datasetInfo={datasetInfo}
           externalLink={externalLink}
         />
@@ -62,6 +84,7 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
   }, [
     sidePanel,
     isOpenedAdvancedView,
+    metadata,
     datasetInfo,
     externalLink,
     titles,

--- a/libs/conversation-view/src/models/structure-component.ts
+++ b/libs/conversation-view/src/models/structure-component.ts
@@ -3,4 +3,5 @@ export interface StructureComponentValue {
   title?: string;
   value?: string | string[];
   attachedKeysTitles?: string[];
+  isDimensionGroup?: boolean;
 }

--- a/libs/conversation-view/src/utils/attachments/__tests__/metadata.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/__tests__/metadata.spec.ts
@@ -1,0 +1,195 @@
+import { Codelist, Data, ElementBase } from '@epam/statgpt-sdmx-toolkit';
+import { getDataSetAttributes, getStructureAttributes } from '../metadata';
+
+jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  getLocalizedName: (
+    item: { names?: Record<string, string>; name?: string } | undefined | null,
+    locale: string,
+  ) => (item?.names && item.names[locale]) || item?.name,
+}));
+
+const LOCALE = 'en';
+
+function buildData(
+  structureDataSet: unknown[],
+  dataSetAttributes: unknown[],
+): Data {
+  return {
+    dataSets: [{ attributes: dataSetAttributes as (number | null)[] }],
+    structures: [
+      {
+        attributes: { dataSet: structureDataSet },
+        dimensions: { dataSet: [] },
+        measures: { dataSet: [] },
+      },
+    ],
+  } as unknown as Data;
+}
+
+const emptyComponentsMap = new Map<string, Codelist | ElementBase>();
+
+describe('getStructureAttributes', () => {
+  it('returns structure attributes as-is when there are no dataSet value indices', () => {
+    const structureDataSet = [{ id: 'DOI', values: [] }];
+    const data = buildData(structureDataSet, []);
+
+    expect(getStructureAttributes(data)).toBe(
+      data.structures?.[0]?.attributes?.dataSet,
+    );
+  });
+
+  it('skips attributes whose dataSet value is null', () => {
+    const data = buildData(
+      [
+        { id: 'DOI', values: [] },
+        { id: 'AUTHOR', values: [] },
+      ],
+      [null, null],
+    );
+
+    expect(getStructureAttributes(data)).toEqual([]);
+  });
+
+  it('selects the value by index for coded attributes', () => {
+    const data = buildData([{ id: 'PUBLISHER', values: [{ id: 'IMF' }] }], [0]);
+
+    expect(getStructureAttributes(data)).toEqual([
+      { id: 'PUBLISHER', values: [{ id: 'IMF' }] },
+    ]);
+  });
+
+  it('preserves a raw array value under "values" instead of coercing to a string', () => {
+    const rawValue = [{ en: 'Demographics' }, { en: ' Real sector' }];
+    const data = buildData(
+      [{ id: 'KEYWORDS_DATASET', values: [] }],
+      [rawValue],
+    );
+
+    expect(getStructureAttributes(data)).toEqual([
+      { id: 'KEYWORDS_DATASET', values: [{ values: rawValue }] },
+    ]);
+  });
+
+  it('preserves a non-array raw value under "value" instead of coercing to a string', () => {
+    const rawValue = { en: 'A note' };
+    const data = buildData([{ id: 'NOTE', values: [] }], [rawValue]);
+
+    expect(getStructureAttributes(data)).toEqual([
+      { id: 'NOTE', values: [{ value: rawValue }] },
+    ]);
+  });
+});
+
+describe('getDataSetAttributes', () => {
+  it('resolves a localized free-text array value to a readable string (no [object Object])', () => {
+    const data = buildData(
+      [{ id: 'FULL_DESCRIPTION', values: [] }],
+      [[{ en: 'The World Economic Outlook database.' }]],
+    );
+
+    const result = getDataSetAttributes(
+      getStructureAttributes(data),
+      emptyComponentsMap,
+      LOCALE,
+    );
+
+    expect(result).toEqual([
+      {
+        id: 'FULL_DESCRIPTION',
+        title: 'FULL_DESCRIPTION',
+        value: ['The World Economic Outlook database.'],
+      },
+    ]);
+  });
+
+  it('resolves a multi-value localized array to a list of readable strings', () => {
+    const data = buildData(
+      [{ id: 'KEYWORDS_DATASET', values: [] }],
+      [
+        [
+          { en: 'Demographics' },
+          { en: ' Real sector' },
+          { en: ' Unemployment' },
+        ],
+      ],
+    );
+
+    const result = getDataSetAttributes(
+      getStructureAttributes(data),
+      emptyComponentsMap,
+      LOCALE,
+    );
+
+    expect(result[0]?.value).toEqual([
+      'Demographics',
+      ' Real sector',
+      ' Unemployment',
+    ]);
+  });
+
+  it('passes plain string array values through unchanged', () => {
+    const data = buildData(
+      [{ id: 'CONTACT_POINT', values: [] }],
+      [['datahelp@imf.org']],
+    );
+
+    const result = getDataSetAttributes(
+      getStructureAttributes(data),
+      emptyComponentsMap,
+      LOCALE,
+    );
+
+    expect(result[0]?.value).toEqual(['datahelp@imf.org']);
+  });
+
+  it('resolves coded id values via the structure components map', () => {
+    const componentsMap = new Map<string, Codelist | ElementBase>([
+      [
+        'PUBLISHER',
+        {
+          id: 'PUBLISHER',
+          codes: [{ id: 'IMF', names: { en: 'International Monetary Fund' } }],
+        } as unknown as Codelist,
+      ],
+    ]);
+    const data = buildData([{ id: 'PUBLISHER', values: [{ id: 'IMF' }] }], [0]);
+
+    const result = getDataSetAttributes(
+      getStructureAttributes(data),
+      componentsMap,
+      LOCALE,
+    );
+
+    expect(result[0]?.value).toBe('International Monetary Fund');
+  });
+
+  it('never emits "[object Object]" for the real WEO dataset attributes', () => {
+    const structureDataSet = [
+      { id: 'DOI', values: [] },
+      { id: 'FULL_DESCRIPTION', values: [] },
+      { id: 'CONTACT_POINT', values: [] },
+      { id: 'KEYWORDS_DATASET', values: [] },
+    ];
+    const dataSetAttributes = [
+      null,
+      [{ en: 'WEO database description.' }],
+      ['datahelp@imf.org'],
+      [{ en: 'Demographics' }, { en: ' Real sector' }],
+    ];
+    const data = buildData(structureDataSet, dataSetAttributes);
+
+    const result = getDataSetAttributes(
+      getStructureAttributes(data),
+      emptyComponentsMap,
+      LOCALE,
+    );
+
+    const flattened = result
+      .flatMap((item) =>
+        Array.isArray(item.value) ? item.value : [item.value],
+      )
+      .join(' ');
+
+    expect(flattened).not.toContain('[object Object]');
+  });
+});

--- a/libs/conversation-view/src/utils/attachments/cross-dataset-grid/build-cross-dataset-grid-columns.ts
+++ b/libs/conversation-view/src/utils/attachments/cross-dataset-grid/build-cross-dataset-grid-columns.ts
@@ -25,8 +25,13 @@ export function buildCrossDatasetGridColumns(
   formattingSettings?: FormatNumbersType,
   gridViewMode: CrossDatasetGridViewMode = CrossDatasetGridViewMode.Compact,
 ): ColDef[] {
+  const attributesDataMap = new Map<string, Data | undefined>(
+    [...dataMessagesMap.entries()].map(([urn, msg]) => [urn, msg?.data]),
+  );
+
   const datasetInfoColumns = getCrossDatasetInfoColumns(
     structuresMap,
+    attributesDataMap,
     locale,
     titles,
   );
@@ -43,10 +48,6 @@ export function buildCrossDatasetGridColumns(
     locale,
     formattingSettings,
     titles,
-  );
-
-  const attributesDataMap = new Map<string, Data | undefined>(
-    [...dataMessagesMap.entries()].map(([urn, msg]) => [urn, msg?.data]),
   );
 
   return [

--- a/libs/conversation-view/src/utils/attachments/cross-dataset-grid/dataset-info-columns.ts
+++ b/libs/conversation-view/src/utils/attachments/cross-dataset-grid/dataset-info-columns.ts
@@ -1,4 +1,8 @@
-import { getLocalizedName, StructuralData } from '@epam/statgpt-sdmx-toolkit';
+import {
+  Data,
+  getLocalizedName,
+  StructuralData,
+} from '@epam/statgpt-sdmx-toolkit';
 import { ColDef, ITooltipParams, ValueGetterParams } from 'ag-grid-community';
 import {
   CELL_PADDING_0,
@@ -15,17 +19,19 @@ import {
 
 export function getCrossDatasetInfoColumns(
   structuresMap: Map<string, StructuralData | undefined>,
+  attributesDataMap: Map<string, Data | undefined>,
   locale: string,
   titles?: ConversationViewTitles,
 ): ColDef[] {
   return [
     buildAgencyColDef(structuresMap, titles),
-    buildDatasetColDef(structuresMap, locale, titles),
+    buildDatasetColDef(structuresMap, attributesDataMap, locale, titles),
   ];
 }
 
 function buildDatasetColDef(
   structuresMap: Map<string, StructuralData | undefined>,
+  attributesDataMap: Map<string, Data | undefined>,
   locale: string,
   titles?: ConversationViewTitles,
 ): ColDef {
@@ -50,6 +56,7 @@ function buildDatasetColDef(
     cellRenderer: DATASET_DETAIL_CELL_RENDER,
     cellRendererParams: {
       structuresMap,
+      attributesDataMap,
       locale,
       titles,
     },

--- a/libs/conversation-view/src/utils/attachments/group-attributes.ts
+++ b/libs/conversation-view/src/utils/attachments/group-attributes.ts
@@ -202,6 +202,7 @@ export const getDimensionGroupAttributes = (
             structureComponentsMap,
             dataStructure,
           ),
+          isDimensionGroup: true,
         };
       })
       ?.filter(({ value }) => value?.some((v) => !!v)) || []

--- a/libs/conversation-view/src/utils/attachments/metadata.ts
+++ b/libs/conversation-view/src/utils/attachments/metadata.ts
@@ -183,13 +183,42 @@ export const getStructureAttributes = (data?: Data): StructureAttribute[] => {
     return structuresAttributes;
   }
 
-  return structuresAttributes.map((attr, index) => {
-    if (attr?.values?.length > 0) {
-      return { ...attr };
-    }
+  return structuresAttributes.reduce<StructureAttribute[]>(
+    (result, attr, index) => {
+      const rawValue = attributes[index];
+      if (rawValue == null) return result;
 
-    return { ...attr, values: [{ value: attributes?.[index] }] };
-  }) as StructureAttribute[];
+      if (attr?.values?.length > 0) {
+        const selectedValue = attr.values[rawValue as number];
+        if (selectedValue) result.push({ ...attr, values: [selectedValue] });
+      } else if (Array.isArray(rawValue)) {
+        result.push({
+          ...attr,
+          values: [{ values: rawValue as unknown as string[] }],
+        });
+      } else {
+        result.push({
+          ...attr,
+          values: [{ value: rawValue as unknown as string }],
+        });
+      }
+      return result;
+    },
+    [],
+  );
+};
+
+const resolveLocalizedString = (
+  raw: unknown,
+  locale: string,
+): string | undefined => {
+  if (raw == null) return undefined;
+  if (typeof raw !== 'object') return String(raw);
+  const obj = raw as Record<string, unknown>;
+  const byLocale = obj[locale];
+  if (typeof byLocale === 'string') return byLocale;
+  const first = Object.values(obj).find((v) => typeof v === 'string');
+  return typeof first === 'string' ? first : undefined;
 };
 
 export const getDataSetAttributes = (
@@ -201,10 +230,14 @@ export const getDataSetAttributes = (
     structureAttributes
       ?.map((structureAttribute: StructureAttribute) => {
         const id = structureAttribute?.id;
+        const rawValue = structureAttribute?.values?.[0]?.value;
         const value =
-          structureAttribute?.values?.[0]?.value ||
-          structureAttribute?.values?.[0]?.id;
-        const values = structureAttribute?.values?.[0]?.ids;
+          (typeof rawValue === 'object'
+            ? resolveLocalizedString(rawValue, locale)
+            : rawValue) || structureAttribute?.values?.[0]?.id;
+        const ids =
+          structureAttribute?.values?.[0]?.ids ||
+          structureAttribute?.values?.[0]?.values;
         const attributeData = structureComponentsMap?.get(id);
         const codeList = (attributeData as Codelist)?.codes?.length
           ? (attributeData as Codelist)
@@ -214,21 +247,33 @@ export const getDataSetAttributes = (
           getLocalizedName(
             codeList?.codes?.find((code) => code?.id === value),
             locale,
-          ) || value;
+          ) ||
+          getLocalizedName(
+            structureAttribute?.values?.[0] as unknown as ElementBase,
+            locale,
+          ) ||
+          value;
         const attributeValues =
-          values &&
-          values.map(
-            (value: string) =>
-              getLocalizedName(
-                codeList?.codes?.find((code) => code?.id === value),
-                locale,
-              ) || value,
-          );
+          ids &&
+          ids
+            .map((item: unknown): string | undefined => {
+              const strItem =
+                typeof item === 'object'
+                  ? resolveLocalizedString(item, locale)
+                  : String(item);
+              return (
+                getLocalizedName(
+                  codeList?.codes?.find((code) => code?.id === strItem),
+                  locale,
+                ) || strItem
+              );
+            })
+            .filter((v): v is string => v != null);
 
         return {
           id,
           title: getLocalizedName(attributeData, locale) || id,
-          value: values ? attributeValues : attributeValue,
+          value: attributeValues ? attributeValues : attributeValue,
         };
       })
       .filter(({ value }) => !!value) || []

--- a/libs/conversation-view/src/utils/attachments/metadata.ts
+++ b/libs/conversation-view/src/utils/attachments/metadata.ts
@@ -190,7 +190,9 @@ export const getStructureAttributes = (data?: Data): StructureAttribute[] => {
 
       if (attr?.values?.length > 0) {
         const selectedValue = attr.values[rawValue as number];
-        if (selectedValue) result.push({ ...attr, values: [selectedValue] });
+        result.push(
+          selectedValue ? { ...attr, values: [selectedValue] } : { ...attr },
+        );
       } else if (Array.isArray(rawValue)) {
         result.push({
           ...attr,
@@ -273,7 +275,7 @@ export const getDataSetAttributes = (
         return {
           id,
           title: getLocalizedName(attributeData, locale) || id,
-          value: attributeValues ? attributeValues : attributeValue,
+          value: attributeValues?.length ? attributeValues : attributeValue,
         };
       })
       .filter(({ value }) => !!value) || []


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/280

### Description of changes

- Shows dataset-level attributes in the metadata side panel when clicking a dataset cell in
  cross-dataset mode.
- Extends the metadata side panel and popup to display dimension-group attributes — series-level attributes with relationship dimensions — alongside existing dataset-level attributes, in both cross-dataset and single-dataset modes.
- Adds a `SidePanelMetadataItem` component with an expand/collapse toggle for long values. It uses a shared `useClampToggle` hook, which was also backported to `MetadataItem`.
- Hides relationship dimension labels, such as "Indicator: …" and "Country: …", for dimension-group attributes, so only the title and value are shown. This is controlled via a new `isDimensionGroup` flag on `StructureComponentValue`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
