### PR TITLE
fix: restore scroll in Columns display panel when list overflows

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/AgGridColumnsPanel.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/AgGridColumnsPanel.tsx
@@ -107,7 +107,7 @@ export function AgGridColumnsPanel({
   });
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-2 px-5">
+    <div className="flex min-h-0 flex-1 flex-col gap-2 px-5">
       <InputWithIcon
         inputId="columns-search-input"
         containerClasses={'items-center filters-search-input gap-1 !p-2'}

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsPanel.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/TableSettingsPanel.tsx
@@ -111,7 +111,7 @@ export const TableSettingsPanel = () => {
   ]);
 
   return gridApi ? (
-    <>
+    <div className="flex h-full flex-col">
       <GridViewModeSwitcher
         gridViewMode={gridViewMode}
         onModeChange={handleModeChange}
@@ -141,6 +141,6 @@ export const TableSettingsPanel = () => {
         onSubItemVisibilityChange={setDimensionKeyHidden}
         searchPlaceholder={texts?.columnsSearchPlaceholder}
       />
-    </>
+    </div>
   ) : null;
 };


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Fixes a layout bug where the "Columns display" list in the Table Settings panel was clipped instead of scrollable when columns exceeded the panel height.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
