### PR TITLE
fix: derive dataset names from structuresMap in filter modal dataset panel

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { DataConstraints } from '@epam/statgpt-sdmx-toolkit';
+import {
+  DataConstraints,
+  generateShortUrn,
+  getLocalizedName,
+} from '@epam/statgpt-sdmx-toolkit';
 import {
   DataQuery,
   Locale,
@@ -739,6 +743,20 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     setSelectedTimeOption(value);
   };
 
+  const displayDataQueries = useMemo(
+    () =>
+      dataQueries?.map((q) => {
+        const dataflow = structureDataMaps?.structuresMap?.get(q.urn)
+          ?.dataflows?.[0];
+        const localizedName = getLocalizedName(dataflow, locale ?? '');
+        const name = localizedName
+          ? generateShortUrn(localizedName, '', dataflow?.agencyID)
+          : undefined;
+        return name ? { ...q, title: name } : q;
+      }),
+    [dataQueries, structureDataMaps?.structuresMap, locale],
+  );
+
   return (
     <div className="filters-container">
       <FilterButton
@@ -784,7 +802,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
               hierarchyStateMap={hierarchyStateMap}
               onSelectHierarchy={onSelectHierarchy}
               onExpandHierarchyNode={onExpandHierarchyNode}
-              dataQueries={dataQueries}
+              dataQueries={displayDataQueries}
               disabledDatasetUrns={disabledDatasetUrns}
               onToggleDataset={onToggleDataset}
               onClearAllDatasets={onClearAllDatasets}

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -9,7 +9,10 @@ import { COMMON_COUNTRY_FILTER_ID } from '../../../../utils/multiple-filters';
 
 // ─── Module mocks ─────────────────────────────────────────────────────────────
 
-jest.mock('@epam/statgpt-sdmx-toolkit', () => ({}));
+jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  getLocalizedName: jest.fn(),
+  generateShortUrn: jest.fn(),
+}));
 jest.mock('@epam/ai-dial-shared', () => ({}));
 
 // ─── Captured callbacks ────
@@ -356,9 +359,13 @@ describe('MultiDatasetFilters', () => {
       mockGetFiltersPreselectedByDataQueries.mockReturnValue([
         makeSharedCountryFilter(),
       ]);
+      const rejectedConstraint = Promise.reject(
+        new Error('constraints failed'),
+      );
+      void rejectedConstraint.catch(() => {});
       mockGetConstraintsRequests.mockReturnValue([
         Promise.resolve(fulfilledConstraintData),
-        Promise.reject(new Error('constraints failed')),
+        rejectedConstraint,
       ]);
       mockGetConstraintsMapFromSettledResults.mockReturnValue(
         updatedConstraintsMap,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

The Dataset filter panel was showing raw attachment titles, such as `"Query (JSON): BIS:WS_EER(1.0)"`, instead of human-readable dataset names. This happened because `DataQuery.title` was based on the attachment title, which is not always suitable for display in the Dataset filter UI.

The fix derives display names from `structuresMap` in `MultiDatasetFilters` — the same source that already powers the correct group-header labels in the left panel — using `generateShortUrn` to produce the consistent `"AGENCY:Name"` format. The enrichment is display-only; all business logic and persistence continue to use the original `dataQueries`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
