### PR TITLE
fix: pass conversation to share popup in advanced view

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -316,6 +316,7 @@ export const AdvancedView: FC<Props> = ({
             locale={locale}
             shareConversationProps={shareConversationProps}
             isShowShare={advanceViewStyles?.isShowShare}
+            conversation={props.filtersProps.conversation}
           />
           {!datasets.length ? (
             <Loader />

--- a/libs/conversation-view/src/components/AdvancedView/Header.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Header.tsx
@@ -8,6 +8,7 @@ import ShareConversation from '@statgpt/share-conversation/src/components/ShareC
 import { CloseButton } from '@epam/statgpt-ui-components';
 import { ShareConversationProps } from '@statgpt/share-conversation/src/models/share-conversation';
 import { useConversationViewStyles } from '../../context/ConversationViewStylesContext';
+import { ConversationInfo } from '@epam/ai-dial-shared';
 import { getTooltipDataByElement } from '../../utils/get-tooltip-data.by-element';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { OnboardingElements } from '../../constants/onboarding-elements';
@@ -17,9 +18,15 @@ interface Props {
   isShowShare?: boolean;
   locale?: string;
   shareConversationProps?: ShareConversationProps;
+  conversation?: ConversationInfo | null;
 }
 
-const Header: FC<Props> = ({ locale, isShowShare, shareConversationProps }) => {
+const Header: FC<Props> = ({
+  locale,
+  isShowShare,
+  shareConversationProps,
+  conversation,
+}) => {
   const { titles } = useConversationViewStyles();
   const { setIsOpenedAdvancedView } = useAdvancedView();
 
@@ -85,7 +92,11 @@ const Header: FC<Props> = ({ locale, isShowShare, shareConversationProps }) => {
         <h2>{titles?.advanceViewTitle ?? 'Advanced view'}</h2>
       </div>
       {isShowShare && (
-        <ShareConversation locale={locale} {...shareConversationProps} />
+        <ShareConversation
+          locale={locale}
+          conversation={conversation}
+          {...shareConversationProps}
+        />
       )}
     </header>
   );


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

The conversation object was not threaded to `<ShareConversation>` in the advanced view header — only the config props were. Added the `conversation` prop to `Header` and wired it from `filtersProps.conversation`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
