### PR TITLE
fix: filters incompatible frequency and dataset selection produced an empty grid

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -684,7 +684,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     );
     const filtersParamsMap = getFiltersChangeParamsMap(appliedFiltersMap);
     const compatibleUrns = getCompatibleDatasetUrns(
-      modalFilters,
+      appliedFilters,
       dataQueries?.map((q) => q.urn) ?? [],
       dataQueries,
       datasetDimensionsMetadata.map,

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -702,6 +702,88 @@ describe('MultiDatasetFilters', () => {
       );
       expect(disabledDataset?.disabled).toBe(true);
     });
+
+    it('checks dataset compatibility against the rebuilt disabled-aware filters, not the raw modal filters', async () => {
+      const onMultipleDataFiltersChange = jest.fn();
+
+      // Shared FREQUENCY with "Annual" selected, sourced ONLY from DATASET_A.
+      // This mirrors the bug: a frequency available only in a dataset that is
+      // about to be disabled.
+      const sharedFrequencyFilter: Filter = {
+        id: 'FREQUENCY',
+        filterType: 'shared',
+        sourceDatasetUrns: [DATASET_A_URN, DATASET_B_URN],
+        dimensionValues: [
+          {
+            id: 'name:annual',
+            name: 'Annual',
+            isSelectedValue: true,
+            sourceValues: [
+              { datasetUrn: DATASET_A_URN, id: 'A', name: 'Annual' },
+            ],
+          },
+        ],
+      };
+
+      // After DATASET_A is disabled, buildFiltersMap drops it and the rebuilt
+      // merged filters no longer carry the "Annual" selection.
+      const rebuiltFilters: Filter[] = [
+        {
+          id: 'FREQUENCY',
+          filterType: 'shared',
+          sourceDatasetUrns: [DATASET_B_URN],
+          dimensionValues: [],
+        } as Filter,
+      ];
+
+      mockIsStructureDataMapsReady.mockReturnValue(true);
+      mockGetFiltersPreselectedByDataQueries.mockReturnValue([
+        sharedFrequencyFilter,
+      ]);
+      // First call (mount preselect) seeds modalFilters with the selected
+      // frequency; the apply-time rebuild (only DATASET_B in the map) returns
+      // the cleaned filter.
+      mockGetFiltersByConstraints
+        .mockReturnValueOnce([sharedFrequencyFilter])
+        .mockReturnValue(rebuiltFilters);
+      mockBuildFiltersMap.mockReturnValue(
+        new Map<string, Filter[]>([[DATASET_B_URN, []]]),
+      );
+
+      await act(async () => {
+        render(
+          createElement(MultiDatasetFilters, {
+            ...defaultProps,
+            onMultipleDataFiltersChange,
+          }),
+        );
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        mockCallbacks.setModalState?.('opened');
+      });
+
+      await act(async () => {
+        mockCallbacks.onToggleDataset?.(DATASET_A_URN, false);
+      });
+
+      await act(async () => {
+        mockCallbacks.onApply?.();
+        await Promise.resolve();
+      });
+
+      // Regression: compatibility must be evaluated against the rebuilt filters
+      // (no stale selection), NOT the raw modalFilters that still carry "Annual"
+      // sourced from the now-disabled DATASET_A.
+      expect(mockGetCompatibleDatasetUrns).toHaveBeenLastCalledWith(
+        rebuiltFilters,
+        expect.any(Array),
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+      );
+    });
   });
 
   describe('single filter reset', () => {

--- a/specs/system/filters/99-gotchas.md
+++ b/specs/system/filters/99-gotchas.md
@@ -130,6 +130,24 @@ datasets as inactive. The dataset URN remains in the `dataQueries` list; only th
 per-dimension filter signals exclusion. See `01-domain-model.md` for the
 `QueryFilterType.excluded` operator.
 
+### Compatibility must be checked against the disabled-aware filters, not `modalFilters`
+
+`onApply` computes `compatibleUrns` via `getCompatibleDatasetUrns`. It must pass
+`appliedFilters` — the merged set rebuilt by `getFiltersByConstraints` *after*
+`buildFiltersMap` has dropped disabled datasets — **not** the raw `modalFilters`.
+
+`onToggleDataset` only mutates `disabledDatasetUrns`; it does not re-derive
+`modalFilters`. So `modalFilters` can still carry a shared-filter selection whose
+only `sourceValues` come from a now-disabled dataset (e.g. frequency `A` selected
+while the only dataset that has `A` is disabled). Feeding that stale selection to
+`getCompatibleDatasetUrns` makes every *enabled* dataset that lacks `A` look
+incompatible, so they are dropped from the queries handed to
+`onMultipleDataFiltersChange` and the grid renders empty. `appliedFilters` already
+excludes the disabled dataset's contribution, so the selection is gone and the
+remaining datasets are correctly judged compatible. (Symptom before the fix: empty
+grid on first Apply, correct grid after reopening and pressing Apply again — because
+the reopened modal is seeded from the rebuilt `appliedFilters`.)
+
 ---
 
 ## Hierarchy state is keyed by filter identity, not by dataset + dimension


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #https://github.com/epam/statgpt-global-trusted-data-commons/issues/268

### Description of changes

In cross-dataset mode, selecting an incompatible frequency and disabling a dataset produced an empty grid on first Apply (correct only after reopen + re-apply).

   - Fix - In onApply, getCompatibleDatasetUrns now receives appliedFilters (rebuilt without disabled datasets) instead of the stale modalFilters, which still carried a frequency selection sourced only from a now-disabled dataset. 
  
  - Documented that compatibility must be checked against the disabled-aware filters, not modalFilters.
  - Added a regression test asserting getCompatibleDatasetUrns is called with the rebuilt filters. All 14 tests pass.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
