### PR TITLE
fix: filter modal sometimes closes itself

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -33,6 +33,7 @@ import { useAdvancedView } from '../../context/AdvancedViewContext';
 import { ConversationViewSidePanelOutlet } from '../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useConversationViewFeatureToggles } from '../../context/ConversationViewFeatureTogglesContext';
 import { ConversationViewStylesProvider } from '../../context/ConversationViewStylesContext';
+import { FiltersModalStateProvider } from '../../context/FiltersModalStateContext';
 import { useCrossDatasetAttachments } from '../../context/CrossDatasetAttachmentsContext';
 import { useDatasetDimensionsMetadataMap } from '../../context/DatasetDimensionsMetadataMapContext';
 import {
@@ -311,92 +312,96 @@ export const AdvancedView: FC<Props> = ({
         }}
         resetIcon={attachmentsProps.styles?.tableSettingsResetIcon}
       >
-        <div className="advanced-view flex h-full min-w-0 flex-1 flex-col">
-          <Header
-            locale={locale}
-            shareConversationProps={shareConversationProps}
-            isShowShare={advanceViewStyles?.isShowShare}
-            conversation={props.filtersProps.conversation}
-          />
-          {!datasets.length ? (
-            <Loader />
-          ) : (
-            <>
-              {showDatasetTabs && (
-                <DatasetTabs
-                  datasets={datasets}
-                  initialSelectedDatasetUrn={
-                    attachmentsProps?.currentDataQuery?.urn
-                  }
-                  locale={locale}
-                  selectDataset={onSelectDataset}
-                />
-              )}
-              {isDataLoading && !isFiltering ? (
-                <Loader />
-              ) : (
-                <>
-                  {shouldShowDatasetInfo && (
-                    <DatasetInfo
-                      {...datasetInfoOptions}
-                      locale={locale}
-                      dataset={dataset}
-                      data={dataMessage?.data}
-                      structures={structures}
-                      metadataSettings={metadataSettings}
-                      getDatasetUpdatedTime={getDatasetUpdatedTime}
-                      externalLink={externalLink}
-                    />
-                  )}
-                  <div
-                    className={classNames(
-                      'flex flex-1 min-h-0 overflow-auto',
-                      shouldShowDatasetInfo && 'border-t border-neutrals-500',
+        <FiltersModalStateProvider>
+          <div className="advanced-view flex h-full min-w-0 flex-1 flex-col">
+            <Header
+              locale={locale}
+              shareConversationProps={shareConversationProps}
+              isShowShare={advanceViewStyles?.isShowShare}
+              conversation={props.filtersProps.conversation}
+            />
+            {!datasets.length ? (
+              <Loader />
+            ) : (
+              <>
+                {showDatasetTabs && (
+                  <DatasetTabs
+                    datasets={datasets}
+                    initialSelectedDatasetUrn={
+                      attachmentsProps?.currentDataQuery?.urn
+                    }
+                    locale={locale}
+                    selectDataset={onSelectDataset}
+                  />
+                )}
+                {isDataLoading && !isFiltering ? (
+                  <Loader />
+                ) : (
+                  <>
+                    {shouldShowDatasetInfo && (
+                      <DatasetInfo
+                        {...datasetInfoOptions}
+                        locale={locale}
+                        dataset={dataset}
+                        data={dataMessage?.data}
+                        structures={structures}
+                        metadataSettings={metadataSettings}
+                        getDatasetUpdatedTime={getDatasetUpdatedTime}
+                        externalLink={externalLink}
+                      />
                     )}
-                  >
                     <div
                       className={classNames(
-                        'flex-1 min-h-0 overflow-auto',
-                        'advanced-view-filters',
+                        'flex flex-1 min-h-0 overflow-auto',
+                        shouldShowDatasetInfo && 'border-t border-neutrals-500',
                       )}
                     >
-                      <DataDetails
-                        {...props}
-                        actions={actions}
-                        attachments={
-                          isCrossDatasetModeOn
-                            ? crossDatasetAttachments
-                            : dataSetAttachments
-                        }
-                        attachmentsDataQuery={attachmentsProps.currentDataQuery}
-                        dataQueries={attachmentsProps?.dataQueries}
-                        dimensions={dimensions}
-                        isDataLoading={isDataLoading}
-                        locale={locale}
-                        filtersProps={{
-                          ...props?.filtersProps,
-                          structureDimensions,
-                          structures,
-                          structureDataMaps,
-                          onFiltersChange,
-                          onMultipleDataFiltersChange:
-                            handleMultipleDataFiltersChange,
-                          initialConstraints: constraints,
-                        }}
-                        setIsFiltering={setIsFiltering}
-                        filters={filters}
-                        onFiltersChange={handleFiltersChange}
-                      />
+                      <div
+                        className={classNames(
+                          'flex-1 min-h-0 overflow-auto',
+                          'advanced-view-filters',
+                        )}
+                      >
+                        <DataDetails
+                          {...props}
+                          actions={actions}
+                          attachments={
+                            isCrossDatasetModeOn
+                              ? crossDatasetAttachments
+                              : dataSetAttachments
+                          }
+                          attachmentsDataQuery={
+                            attachmentsProps.currentDataQuery
+                          }
+                          dataQueries={attachmentsProps?.dataQueries}
+                          dimensions={dimensions}
+                          isDataLoading={isDataLoading}
+                          locale={locale}
+                          filtersProps={{
+                            ...props?.filtersProps,
+                            structureDimensions,
+                            structures,
+                            structureDataMaps,
+                            onFiltersChange,
+                            onMultipleDataFiltersChange:
+                              handleMultipleDataFiltersChange,
+                            initialConstraints: constraints,
+                          }}
+                          setIsFiltering={setIsFiltering}
+                          filters={filters}
+                          onFiltersChange={handleFiltersChange}
+                        />
+                      </div>
+                      {isOpenedAdvancedView && (
+                        <ConversationViewSidePanelOutlet scope="advanced" />
+                      )}
                     </div>
-                    {isOpenedAdvancedView && (
-                      <ConversationViewSidePanelOutlet scope="advanced" />
-                    )}
-                  </div>
-                </>
-              )}
-            </>
-          )}
-        </div>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </FiltersModalStateProvider>
       </TableSettingsProvider>
     </ConversationViewStylesProvider>
   );

--- a/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
@@ -45,6 +45,7 @@ import {
 import ModalFooter from './FiltersModal/ModalFooter';
 import FilterButton from './FilterButton/FilterButton';
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
+import { useFiltersModalState } from '../../../context/FiltersModalStateContext';
 import { updateMessagesWithSystemMessage } from '../../../utils/system-message';
 import { getUpdatedDataQueries } from '../../../utils/get-updated-data-queries';
 import { useHierarchyState } from '../../../utils/use-hierarchy-state';
@@ -79,7 +80,8 @@ const Filters: FC<FiltersProps> = ({
   filterIconClassName,
 }) => {
   const { titles } = useConversationViewStyles();
-  const [modalState, setModalState] = useState(PopUpState.Closed);
+  const { modalState, setModalState, isModalClosed, setIsModalClosed } =
+    useFiltersModalState();
   const [modalFilters, setModalFilters] = useState<Filter[]>([]);
   const [appliedFilters, setAppliedFilters] = useState<Filter[]>([]);
   const [selectedFilter, setSelectedFilter] = useState<Filter>();
@@ -98,7 +100,6 @@ const Filters: FC<FiltersProps> = ({
   const [isFilterValuesLoading, setIsFilterValuesLoading] = useState(false);
   const filterValuesLoadingRequestsRef = useRef(0);
   const isPreselectedFromDataQuery = useRef(false);
-  const [isModalClosed, setIsModalClosed] = useState(false);
 
   const startFilterValuesLoading = useCallback(() => {
     filterValuesLoadingRequestsRef.current += 1;
@@ -576,7 +577,7 @@ const Filters: FC<FiltersProps> = ({
     constraintsRef.current = initialModalConstraints;
     setModalState(PopUpState.Closed);
     setIsModalClosed(true);
-  }, [initialModalConstraints]);
+  }, [initialModalConstraints, setModalState, setIsModalClosed]);
 
   const onClearAllFilters = useCallback(() => {
     const filtersAfterClear = getFiltersAfterClear(modalFilters);
@@ -601,6 +602,8 @@ const Filters: FC<FiltersProps> = ({
     onFiltersChange,
     addSystemMessage,
     constraintsRef,
+    setModalState,
+    setIsModalClosed,
   ]);
   const onTimePeriodChange = (value: string | number) => {
     setSelectedTimeOption(value);

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -56,6 +56,7 @@ import { StructureDataMaps } from '../../../models/structure-data';
 import { useHierarchyState } from '../../../utils/use-hierarchy-state';
 import { useDatasetDimensionsMetadataMapOptional } from '../../../context/DatasetDimensionsMetadataMapContext';
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
+import { useFiltersModalState } from '../../../context/FiltersModalStateContext';
 
 const MultiDatasetFilters: FC<FiltersProps> = ({
   actions,
@@ -77,7 +78,8 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
 }) => {
   const { titles } = useConversationViewStyles();
   const datasetDimensionsMetadata = useDatasetDimensionsMetadataMapOptional();
-  const [modalState, setModalState] = useState(PopUpState.Closed);
+  const { modalState, setModalState, isModalClosed, setIsModalClosed } =
+    useFiltersModalState();
   const [modalFilters, setModalFilters] = useState<Filter[]>([]);
   const [appliedFilters, setAppliedFilters] = useState<Filter[]>([]);
   const [selectedFilter, setSelectedFilter] = useState<Filter>();
@@ -96,7 +98,6 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
   const [isDisableFilterValues, setIsDisableFilterValues] = useState<boolean>();
   const [isFilterValuesLoading, setIsFilterValuesLoading] = useState(false);
   const filterValuesLoadingRequestsRef = useRef(0);
-  const [isModalClosed, setIsModalClosed] = useState(false);
   const [disabledDatasetUrns, setDisabledDatasetUrns] = useState<Set<string>>(
     new Set(),
   );
@@ -652,7 +653,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     constraintsMapRef.current = initialModalConstraintsMap;
     setModalState(PopUpState.Closed);
     setIsModalClosed(true);
-  }, [initialModalConstraintsMap]);
+  }, [initialModalConstraintsMap, setModalState, setIsModalClosed]);
 
   const onClearAllFilters = useCallback(() => {
     const filtersAfterClear = getFiltersAfterClear(modalFilters);
@@ -737,6 +738,8 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     dataQueries,
     disabledDatasetUrns,
     addSystemMessage,
+    setModalState,
+    setIsModalClosed,
   ]);
 
   const onTimePeriodChange = (value: string | number) => {

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/__tests__/MultiDatasetFilters.spec.ts
@@ -218,6 +218,18 @@ jest.mock('../../../../context/ConversationViewStylesContext', () => ({
   useConversationViewStyles: jest.fn(() => ({})),
 }));
 
+jest.mock('../../../../context/FiltersModalStateContext', () => {
+  const R = require('react');
+  return {
+    FiltersModalStateProvider: ({ children }: any) => children,
+    useFiltersModalState: () => {
+      const [modalState, setModalState] = R.useState('closed');
+      const [isModalClosed, setIsModalClosed] = R.useState(false);
+      return { modalState, setModalState, isModalClosed, setIsModalClosed };
+    },
+  };
+});
+
 jest.mock('../../../../utils/hierarchy-view', () => ({
   hierarchyNodesToFilterTreeProps: jest.fn(() => []),
 }));

--- a/libs/conversation-view/src/context/FiltersModalStateContext.tsx
+++ b/libs/conversation-view/src/context/FiltersModalStateContext.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { PopUpState } from '@epam/statgpt-ui-components';
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+
+export interface FiltersModalStateContextValue {
+  modalState: PopUpState;
+  setModalState: (modalState: PopUpState) => void;
+  isModalClosed: boolean;
+  setIsModalClosed: (isModalClosed: boolean) => void;
+}
+
+const FiltersModalStateContext =
+  createContext<FiltersModalStateContextValue | null>(null);
+
+export function FiltersModalStateProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [modalState, setModalState] = useState(PopUpState.Closed);
+  const [isModalClosed, setIsModalClosed] = useState(false);
+
+  const value = useMemo(
+    () => ({ modalState, setModalState, isModalClosed, setIsModalClosed }),
+    [modalState, isModalClosed],
+  );
+
+  return (
+    <FiltersModalStateContext.Provider value={value}>
+      {children}
+    </FiltersModalStateContext.Provider>
+  );
+}
+
+export function useFiltersModalState(): FiltersModalStateContextValue {
+  const context = useContext(FiltersModalStateContext);
+  if (!context) {
+    throw new Error(
+      'useFiltersModalState must be used within FiltersModalStateProvider',
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-portal-frontend/issues/388

### Description of changes

The modal's open state lived in local `useState` inside `Filters / MultiDatasetFilters` components. Those components are unmounted when `AdvancedView` swaps in a `<Loader/>` during grid reloads. The unmount silently reset the modal state, making it close with no dismiss event or error.

Solution
Lift the modal open-state into a dedicated context `FiltersModalStateContext`, provided above the `Loader/DataDetails` swap in `AdvancedView`. This ensures the modal stays open across reloads and reappears with refreshed data.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
