### PR TITLE
fix: respect disabled datasets in Table Settings columns and Dataset tabs

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -81,6 +81,11 @@ export const AdvancedView: FC<Props> = ({
     [attachmentsProps.currentDataQuery?.urn, attachmentsProps.dataQueries],
   );
 
+  const enabledDataQueries = useMemo(
+    () => attachmentsProps?.dataQueries?.filter((q) => !q.disabled),
+    [attachmentsProps?.dataQueries],
+  );
+
   const [gridViewMode, setGridViewMode] = useState(
     CrossDatasetGridViewMode.Compact,
   );
@@ -295,7 +300,7 @@ export const AdvancedView: FC<Props> = ({
         currentUrn={currentUrn}
         structuresMap={structureDataMaps?.structuresMap}
         locale={locale}
-        dataQueries={attachmentsProps?.dataQueries}
+        dataQueries={enabledDataQueries}
         gridViewMode={gridViewMode}
         onGridViewModeChange={setGridViewMode}
         texts={{

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/__tests__/draggableListUtils.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/__tests__/draggableListUtils.spec.ts
@@ -191,9 +191,18 @@ describe('protectLastVisibleLeafInGroups', () => {
       expect(protectLastVisibleLeafInGroups(node)).toBe(node);
     });
 
-    it('returns unchanged when sub-items contain only item nodes (no groups)', () => {
+    it('returns unchanged when flat leaves have two or more visible items', () => {
       const node = item('col', [
         checkedItem('a', true),
+        checkedItem('b', true),
+      ]);
+      const result = protectLastVisibleLeafInGroups(node);
+      expect(result).toBe(node);
+    });
+
+    it('returns unchanged when all flat leaves are hidden', () => {
+      const node = item('col', [
+        checkedItem('a', false),
         checkedItem('b', false),
       ]);
       const result = protectLastVisibleLeafInGroups(node);
@@ -316,6 +325,28 @@ describe('protectLastVisibleLeafInGroups', () => {
       const leaves = (result.items![0] as ReturnType<typeof group>)
         .items as DraggableListItemNode[];
       expect(leaves[0].checkable).toBe(false);
+    });
+
+    it('sets checkable: false on the sole visible leaf in a flat list (single-dataset layout)', () => {
+      const node = item('col', [
+        checkedItem('a', false),
+        checkedItem('b', true),
+      ]);
+      const result = protectLastVisibleLeafInGroups(node);
+      const leaves = result.items as DraggableListItemNode[];
+      expect(leaves.find((l) => l.id === 'b')?.checkable).toBe(false);
+      expect(leaves.find((l) => l.id === 'a')?.checkable).toBeUndefined();
+    });
+
+    it('sets draggable: false on all flat leaves when only one is visible', () => {
+      const node = item('col', [
+        checkedItem('a', false, { draggable: true }),
+        checkedItem('b', true, { draggable: true }),
+      ]);
+      const result = protectLastVisibleLeafInGroups(node);
+      const leaves = result.items as DraggableListItemNode[];
+      expect(leaves.find((l) => l.id === 'a')?.draggable).toBe(false);
+      expect(leaves.find((l) => l.id === 'b')?.draggable).toBe(false);
     });
   });
 

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/draggableListUtils.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/helpers/draggableListUtils.ts
@@ -52,6 +52,24 @@ export function protectLastVisibleLeafInGroups(
 ): DraggableListItemNode {
   if (!item.items?.length) return item;
 
+  // Single-dataset flat layout: leaves are direct children with no group wrapper.
+  // Apply protection across the entire flat list.
+  if (item.items.every((n) => n.type === 'item')) {
+    const leafItems = item.items as DraggableListItemNode[];
+    const visibleLeaves = leafItems.filter((i) => i.isChecked !== false);
+    if (visibleLeaves.length !== 1) return item;
+    const [soleVisibleLeaf] = visibleLeaves;
+    return {
+      ...item,
+      items: leafItems.map((leaf) =>
+        leaf === soleVisibleLeaf
+          ? { ...leaf, checkable: false, draggable: false }
+          : { ...leaf, draggable: false },
+      ),
+    };
+  }
+
+  // Multi-dataset layout: protect the last visible leaf within each group.
   const newGroupItems = item.items.map((node) => {
     if (node.type !== 'group') return node;
 

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/useAgGridColumnsPanel.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/useAgGridColumnsPanel.ts
@@ -208,13 +208,29 @@ export function useAgGridColumnsPanel({
           ) {
             continue;
           }
-          for (const groupNode of topNode.items) {
-            if (groupNode.type !== 'group') continue;
-            const leafItems = groupNode.items.filter(
+
+          if (topNode.items.some((n) => n.type === 'group')) {
+            // Multi-dataset: each group wraps one dataset's leaves.
+            for (const groupNode of topNode.items) {
+              if (groupNode.type !== 'group') continue;
+              const leafItems = groupNode.items.filter(
+                (i): i is DraggableListItemNode => i.type === 'item',
+              );
+              if (leafItems.length <= 1) continue;
+              const urn = groupNode.id;
+              const newOrder = leafItems.map(
+                (i) => parseDimensionSubItemId(i.id).dimensionKey,
+              );
+              onSubItemOrderChange(urn, topNode.id, newOrder);
+            }
+          } else {
+            // Single-dataset: leaves are direct children; derive urn from the leaf id.
+            const leafItems = topNode.items.filter(
               (i): i is DraggableListItemNode => i.type === 'item',
             );
-            if (leafItems.length <= 1) continue;
-            const urn = groupNode.id;
+            if (leafItems.length <= 1 || !isDimensionSubItemId(leafItems[0].id))
+              continue;
+            const { urn } = parseDimensionSubItemId(leafItems[0].id);
             const newOrder = leafItems.map(
               (i) => parseDimensionSubItemId(i.id).dimensionKey,
             );

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/helpers/__tests__/crossDatasetEnrichment.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/helpers/__tests__/crossDatasetEnrichment.spec.ts
@@ -182,24 +182,24 @@ describe('buildCrossDatasetEnrichItem', () => {
     expect(enrich(item)).toBe(item);
   });
 
-  it('builds one group per dataset for INDICATOR_COL_ID', () => {
-    const urn = 'urn:abc';
+  it('builds one group per dataset when there are multiple datasets', () => {
+    const urn1 = 'urn:abc';
+    const urn2 = 'urn:def';
     const enrich = buildCrossDatasetEnrichItem(
       makeInfo({
-        dataQueries: [{ urn }],
+        dataQueries: [{ urn: urn1 }, { urn: urn2 }],
         getDimensionsScheme: () => makeScheme({ indicators: ['IND1', 'IND2'] }),
         getDimensionConfig: (_, dimKey) => aliasConfig(dimKey + '_label'),
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
 
-    expect(result.items).toHaveLength(1);
-    const group = result.items![0];
-    expect(group.type).toBe('group');
-    expect(group.id).toBe(urn);
+    expect(result.items).toHaveLength(2);
+    expect(result.items![0]).toMatchObject({ type: 'group', id: urn1 });
+    expect(result.items![1]).toMatchObject({ type: 'group', id: urn2 });
   });
 
-  it('builds leaf items with encoded ids and alias labels', () => {
+  it('builds leaf items with encoded ids and alias labels (single dataset — flat)', () => {
     const urn = 'urn:abc';
     const enrich = buildCrossDatasetEnrichItem(
       makeInfo({
@@ -209,18 +209,17 @@ describe('buildCrossDatasetEnrichItem', () => {
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
-    const group = result.items![0];
-    if (group.type !== 'group') throw new Error('expected group');
 
-    expect(group.items).toHaveLength(2);
-    expect(group.items[0]).toMatchObject({
+    expect(result.items).toHaveLength(2);
+    expect(result.items![0]).toMatchObject({
       id: buildDimensionSubItemId(urn, 'IND1'),
       label: 'IND1_label',
       type: 'item',
     });
-    expect(group.items[1]).toMatchObject({
+    expect(result.items![1]).toMatchObject({
       id: buildDimensionSubItemId(urn, 'IND2'),
       label: 'IND2_label',
+      type: 'item',
     });
   });
 
@@ -234,10 +233,8 @@ describe('buildCrossDatasetEnrichItem', () => {
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
-    const group = result.items![0];
-    if (group.type !== 'group') throw new Error('expected group');
 
-    for (const leaf of group.items) {
+    for (const leaf of result.items!) {
       if (leaf.type === 'item') {
         expect(leaf.draggable).toBe(true);
         expect(leaf.checkable).toBe(true);
@@ -256,9 +253,7 @@ describe('buildCrossDatasetEnrichItem', () => {
       }),
     );
     const result = enrich(makeItem(COUNTRY_COL_ID));
-    const group = result.items![0];
-    if (group.type !== 'group') throw new Error('expected group');
-    const leaf = group.items[0];
+    const leaf = result.items![0];
     if (leaf.type === 'item') {
       expect(leaf.draggable).toBe(false);
       expect(leaf.checkable).toBe(false);
@@ -282,47 +277,49 @@ describe('buildCrossDatasetEnrichItem', () => {
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
-    const group = result.items![0];
-    if (group.type !== 'group') throw new Error('expected group');
 
-    const ind1 = group.items.find(
+    const ind1 = result.items!.find(
       (i) => i.id === buildDimensionSubItemId(urn, 'IND1'),
     );
-    const ind2 = group.items.find(
+    const ind2 = result.items!.find(
       (i) => i.id === buildDimensionSubItemId(urn, 'IND2'),
     );
     expect(ind1?.type === 'item' && ind1.isChecked).toBe(false);
     expect(ind2?.type === 'item' && ind2.isChecked).toBe(true);
   });
 
-  it('uses getLocalizedName for the group label', () => {
-    const urn = 'urn:abc';
-    mockGetLocalizedName.mockReturnValue('Localized Dataset Name');
+  it('uses getLocalizedName for the group label (multiple datasets)', () => {
+    const urn1 = 'urn:abc';
+    const urn2 = 'urn:def';
+    mockGetLocalizedName
+      .mockReturnValueOnce('Dataset ABC')
+      .mockReturnValueOnce('Dataset DEF');
     const enrich = buildCrossDatasetEnrichItem(
       makeInfo({
-        dataQueries: [{ urn }],
+        dataQueries: [{ urn: urn1 }, { urn: urn2 }],
         getDimensionsScheme: () => makeScheme({ indicators: ['IND1'] }),
         getDimensionConfig: () => aliasConfig('IND1'),
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
-    const group = result.items![0];
-    expect(group.label).toBe('Localized Dataset Name');
+    expect(result.items![0].label).toBe('Dataset ABC');
+    expect(result.items![1].label).toBe('Dataset DEF');
   });
 
-  it('falls back to urn as group label when getLocalizedName returns undefined', () => {
-    const urn = 'urn:abc';
+  it('falls back to urn as group label when getLocalizedName returns undefined (multiple datasets)', () => {
+    const urn1 = 'urn:abc';
+    const urn2 = 'urn:def';
     mockGetLocalizedName.mockReturnValue(undefined);
     const enrich = buildCrossDatasetEnrichItem(
       makeInfo({
-        dataQueries: [{ urn }],
+        dataQueries: [{ urn: urn1 }, { urn: urn2 }],
         getDimensionsScheme: () => makeScheme({ indicators: ['IND1'] }),
         getDimensionConfig: () => aliasConfig('IND1'),
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
-    const group = result.items![0];
-    expect(group.label).toBe(urn);
+    expect(result.items![0].label).toBe(urn1);
+    expect(result.items![1].label).toBe(urn2);
   });
 
   it('handles FREQUENCY_COL_ID by reading scheme.frequency', () => {
@@ -337,9 +334,10 @@ describe('buildCrossDatasetEnrichItem', () => {
     );
     const result = enrich(makeItem(FREQUENCY_COL_ID));
     expect(result.items).toHaveLength(1);
-    const group = result.items![0];
-    if (group.type !== 'group') throw new Error('expected group');
-    expect(group.items[0].id).toBe(buildDimensionSubItemId(urn, 'FREQ'));
+    expect(result.items![0]).toMatchObject({
+      type: 'item',
+      id: buildDimensionSubItemId(urn, 'FREQ'),
+    });
   });
 
   it('resolves label via getDimensionTitle when no alias is configured', () => {
@@ -357,8 +355,6 @@ describe('buildCrossDatasetEnrichItem', () => {
       }),
     );
     const result = enrich(makeItem(INDICATOR_COL_ID));
-    const group = result.items![0];
-    if (group.type !== 'group') throw new Error('expected group');
-    expect(group.items[0]).toMatchObject({ label: 'Title From Scheme' });
+    expect(result.items![0]).toMatchObject({ label: 'Title From Scheme' });
   });
 });

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/helpers/crossDatasetEnrichment.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/helpers/crossDatasetEnrichment.ts
@@ -183,6 +183,10 @@ export function buildCrossDatasetEnrichItem(
       return item;
     }
 
+    if (groups.length === 1) {
+      return { ...item, items: groups[0].items };
+    }
+
     return { ...item, items: groups };
   };
 }

--- a/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
@@ -7,6 +7,7 @@ import {
   DatasetQueryFilters,
   Dimension,
   DownloadType as DownloadTypeOptions,
+  generateShortUrn,
 } from '@epam/statgpt-sdmx-toolkit';
 import { DataQuery } from '@epam/statgpt-shared-toolkit';
 import {
@@ -35,6 +36,7 @@ import { AllCommunityModule, GridApi, ModuleRegistry } from 'ag-grid-community';
 import DownloadSettings from '@statgpt/download-panel/src/components/DownloadSettings/DownloadSettings';
 import { DownloadDatasetItem } from '@statgpt/download-panel/src/models/download-dataset-item';
 import { useConversationViewStyles } from '../../context/ConversationViewStylesContext';
+import { useConversationViewFeatureToggles } from '../../context/ConversationViewFeatureTogglesContext';
 import DatasetTabs from './Tabs/DatasetTabs/DatasetTabs';
 import { getExternalLink } from '../../utils/attachments-details';
 import AttachmentsViewModePanel from './AttachmentsViewModePanel';
@@ -101,6 +103,7 @@ const AttachmentRenderer: FC<Props> = ({
     limitMessages,
     attachmentsConfig,
   } = useConversationViewStyles();
+  const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
   const [selectedAttachmentIndex, setSelectedAttachmentIndex] =
     useState<number>(0);
   const [selectedAttachment, setSelectedAttachment] =
@@ -111,6 +114,23 @@ const AttachmentRenderer: FC<Props> = ({
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const [showLimitMessage, setShowLimitMessage] = useState(false);
   const downloadType = DownloadTypeOptions.DATA_IN_TABLE;
+
+  const enabledDatasets = useMemo(() => {
+    if (!isCrossDatasetModeOn || !dataQueries?.some((q) => q.disabled)) {
+      return datasets;
+    }
+    const enabledUrns = new Set(
+      dataQueries.filter((q) => !q.disabled).map((q) => q.urn),
+    );
+    return datasets?.filter((dataset) => {
+      const urn = generateShortUrn(
+        dataset?.id,
+        dataset?.version,
+        dataset?.agencyID,
+      );
+      return enabledUrns.has(urn);
+    });
+  }, [datasets, dataQueries, isCrossDatasetModeOn]);
 
   const selectAttachment = (index: number) => {
     setSelectedAttachmentIndex(index);
@@ -263,10 +283,10 @@ const AttachmentRenderer: FC<Props> = ({
                 />
               )}
               {!isOpenedAdvancedView &&
-                datasets?.length != null &&
-                datasets?.length > 0 && (
+                enabledDatasets?.length != null &&
+                enabledDatasets?.length > 0 && (
                   <DatasetTabs
-                    datasets={datasets}
+                    datasets={enabledDatasets}
                     initialSelectedDatasetUrn={initialSelectedDatasetUrn}
                     locale={locale}
                     selectDataset={selectDataset}

--- a/libs/conversation-view/src/components/Attachments/__tests__/AttachmentRenderer.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/__tests__/AttachmentRenderer.spec.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AttachmentRenderer from '../AttachmentRenderer';
+import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
+import type { DataQuery } from '@epam/statgpt-shared-toolkit';
+
+jest.mock('ag-grid-community', () => ({
+  AllCommunityModule: {},
+  ModuleRegistry: { registerModules: jest.fn() },
+}));
+
+jest.mock('@epam/statgpt-sdmx-toolkit', () => ({
+  generateShortUrn: (id?: string, version?: string, agencyID?: string) => {
+    const versionStr = version === '' ? '' : `(${version})`;
+    return `${agencyID}:${id}${versionStr}`;
+  },
+  DownloadType: { DATA_IN_TABLE: 'DATA_IN_TABLE' },
+}));
+
+jest.mock('@epam/statgpt-ui-components', () => ({
+  Loader: () => null,
+  PopUpState: { Closed: 'Closed', Opened: 'Opened' },
+  RequestLimitMessage: () => null,
+}));
+
+jest.mock(
+  '@statgpt/download-panel/src/components/DownloadSettings/DownloadSettings',
+  () => ({ __esModule: true, default: () => null }),
+);
+
+jest.mock('../../../context/ConversationViewStylesContext', () => ({
+  useConversationViewStyles: () => ({
+    titles: {},
+    messageStyles: {},
+    attachmentsStyles: {},
+    limitMessages: undefined,
+    attachmentsConfig: undefined,
+  }),
+}));
+
+jest.mock('../../../context/ConversationViewFeatureTogglesContext', () => ({
+  useConversationViewFeatureToggles: jest.fn(),
+}));
+
+jest.mock('../../../context/AdvancedViewContext', () => ({
+  useAdvancedView: () => ({
+    isOpenedAdvancedView: false,
+    setIsOpenedAdvancedView: jest.fn(),
+  }),
+}));
+
+jest.mock('../AttachmentDetails/AttachmentDetails', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../AttachmentCollapsed', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../AttachmentsViewModePanel', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../AttachmentsContentRenderer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../DownloadAlert/DownloadAlert', () => ({
+  DownloadAlert: () => null,
+}));
+jest.mock('../useAttachmentDownloadFlow', () => ({
+  useAttachmentDownloadFlow: () => ({
+    startDownload: jest.fn(),
+    isDownloadRunning: false,
+    downloadAlertProps: {},
+  }),
+}));
+jest.mock('../../../utils/attachments/attachment-parser', () => ({
+  isAnyGridAttachment: jest.fn().mockReturnValue(false),
+  isCrossDatasetGrid: jest.fn().mockReturnValue(false),
+  isCustomGridAttachment: jest.fn().mockReturnValue(false),
+}));
+jest.mock('../../../utils/attachments-details', () => ({
+  getExternalLink: jest.fn().mockReturnValue(undefined),
+}));
+
+jest.mock('../Tabs/DatasetTabs/DatasetTabs', () => ({
+  __esModule: true,
+  default: ({ datasets }: { datasets?: Array<{ id: string }> }) => (
+    <>
+      {datasets?.map((d) => (
+        <span key={d.id} data-testid={`dataset-tab-${d.id}`} />
+      ))}
+    </>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockFeatureToggles = useConversationViewFeatureToggles as jest.Mock;
+
+const DATASET_A = { id: 'DS_A', version: '1.0', agencyID: 'TEST' };
+const DATASET_B = { id: 'DS_B', version: '1.0', agencyID: 'TEST' };
+
+const QUERY_A: DataQuery = { urn: 'TEST:DS_A(1.0)' } as DataQuery;
+const QUERY_B: DataQuery = {
+  urn: 'TEST:DS_B(1.0)',
+  disabled: true,
+} as DataQuery;
+
+const mockActions = {
+  getFile: jest.fn(),
+  putOnboardingFile: jest.fn(),
+  getDataSet: jest.fn(),
+  getDataSetData: jest.fn(),
+  getConstraints: jest.fn(),
+  downloadDataSet: jest.fn(),
+  updateCurrentDataQuery: jest.fn(),
+  updateDataQueries: jest.fn(),
+  updateDatasets: jest.fn(),
+};
+
+const STUB_ATTACHMENT = { title: 'stub' } as any;
+
+function renderComponent(
+  dataQueries: DataQuery[],
+  isCrossDatasetModeOn = true,
+) {
+  mockFeatureToggles.mockReturnValue({ isCrossDatasetModeOn });
+  render(
+    <AttachmentRenderer
+      attachments={[STUB_ATTACHMENT]}
+      actions={mockActions}
+      isDataSetAttachments={true}
+      datasets={[DATASET_A as any, DATASET_B as any]}
+      dataQueries={dataQueries}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AttachmentRenderer — DatasetTabs dataset filtering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes only enabled datasets to DatasetTabs in cross-dataset mode', () => {
+    renderComponent([QUERY_A, QUERY_B], true);
+
+    expect(screen.getByTestId('dataset-tab-DS_A')).toBeInTheDocument();
+    expect(screen.queryByTestId('dataset-tab-DS_B')).not.toBeInTheDocument();
+  });
+
+  it('passes all datasets to DatasetTabs when not in cross-dataset mode', () => {
+    renderComponent([QUERY_A, QUERY_B], false);
+
+    expect(screen.getByTestId('dataset-tab-DS_A')).toBeInTheDocument();
+    expect(screen.getByTestId('dataset-tab-DS_B')).toBeInTheDocument();
+  });
+
+  it('passes all datasets when no dataQueries are disabled', () => {
+    const allEnabled: DataQuery[] = [QUERY_A, { ...QUERY_B, disabled: false }];
+    renderComponent(allEnabled, true);
+
+    expect(screen.getByTestId('dataset-tab-DS_A')).toBeInTheDocument();
+    expect(screen.getByTestId('dataset-tab-DS_B')).toBeInTheDocument();
+  });
+
+  it('hides DatasetTabs entirely when all datasets are disabled', () => {
+    const allDisabled: DataQuery[] = [
+      { ...QUERY_A, disabled: true },
+      { ...QUERY_B, disabled: true },
+    ];
+    renderComponent(allDisabled, true);
+
+    expect(screen.queryByTestId('dataset-tab-DS_A')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dataset-tab-DS_B')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/292
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/293 

### Description of changes

**1. Dataset tabs in the regular chat view**
`AttachmentRenderer` now filters the datasets list against `dataQueries` before passing it to `DatasetTabs`. Disabled datasets are excluded from displaying in `DatasetTabs`.

**2. Column groups in the Table Settings panel**
`AdvancedView` now derives an `enabledDataQueries` list and passes it down to `TableSettingsProvider` instead of the full list. `buildCrossDatasetEnrichItem` then only builds sub-item groups for the datasets that are actually active, so disabled datasets no longer produce column entries in the `Columns panel`.

**3. Correctness fixes for the single-dataset flat layout**
The flattening above exposed two places that assumed the old two-level structure (column → group → leaves):

Last-visible-leaf protection (`protectLastVisibleLeafInGroups`) — previously only walked type: 'group' children, so it silently skipped flat leaves. It now detects the flat layout and applies the same protection (preventing the user from unchecking the last visible indicator) directly across the leaf list.
Sub-item drag reordering (`handleItemsChange`) — previously extracted the dataset **URN** from the group `node's id` field. In the flat layout there is no group node, so it now detects the absence of groups and recovers the **URN** from the encoded leaf item ID instead, ensuring drag-to-reorder is correctly persisted in single-dataset mode.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
