### PR TITLE
fix: resolve suggestion list layout issues

### DIFF
--- a/apps/portals-example/src/scss/buttons.scss
+++ b/apps/portals-example/src/scss/buttons.scss
@@ -67,7 +67,7 @@
 }
 
 .tag {
-  @apply rounded-[10px] border-hues-600 bg-neutrals-100 hover:bg-white border p-2 text-primary h-[32px];
+  @apply rounded-[10px] border-hues-600 bg-neutrals-100 hover:bg-white border p-2 text-primary min-h-[32px];
 }
 
 .tag-container {

--- a/libs/conversation-view/src/components/ConversationWelcome/ConversationWelcome.tsx
+++ b/libs/conversation-view/src/components/ConversationWelcome/ConversationWelcome.tsx
@@ -262,13 +262,13 @@ export const ConversationWelcome: FC<Props> = ({
         />
         <div
           className={classNames(
-            'no-scrollbar max-w-full overflow-x-auto',
+            'no-scrollbar overflow-x-auto',
             suggestionsContainerClass,
           )}
         >
           <div
             className={classNames(
-              'flex flex-wrap justify-center gap-2 sm:flex-nowrap',
+              'flex flex-wrap justify-center gap-2',
               'tags-container',
             )}
           >


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/262

### Description of changes

- Constrain suggestions container to `max-w-[784px]` to align with the welcome heading and input field above it
- Remove `sm:flex-nowrap` so tags wrap onto multiple rows on screens narrower than `720px` instead of overflowing in a single scrollable row
- Replace fixed `h-[32px]` with `min-h-[32px]` on `.tag` so tags with long text can expand beyond one line while retaining vertical padding

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
