### PR TITLE
fix: remove orphaned pr-2 padding from conversation view wrapper

### DIFF
--- a/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
+++ b/libs/conversation-view/src/components/ConversationView/ConversationView.tsx
@@ -910,9 +910,7 @@ export const ConversationView: FC<Props> = ({
       <div
         className={classNames(
           'h-full flex flex-col bg-white conversation-view-wrapper',
-          isOpenedAdvancedView && !showConversationHeaderAdvancedView
-            ? 'p-4'
-            : 'pr-2',
+          isOpenedAdvancedView && !showConversationHeaderAdvancedView && 'p-4',
         )}
       >
         {isOpenedAdvancedView && !showConversationHeaderAdvancedView ? null : (


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Removes the pr-2 class from the outer ConversationView wrapper — it was present since the initial commit with no stated reason, survived two scrollbar refactors untouched, and has no effect: the scrollbar lives three levels deeper in scroll hidden-container, and all consuming portals already apply their own right-side spacing via messagesWrapperClass and inputContainerClass.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
