### PR TITLE
feat: disable Apply button in filters modal when state is unchanged

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
@@ -11,6 +11,7 @@ import {
 } from '@epam/statgpt-sdmx-toolkit';
 import { Locale } from '@epam/statgpt-shared-toolkit';
 import { Popup, PopUpSize, PopUpState } from '@epam/statgpt-ui-components';
+import { isEqual } from 'lodash';
 import FilterSettings from './FiltersModal/FiltersSettings';
 import { Filter, FiltersProps } from '../../../models/filters';
 import {

--- a/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
@@ -624,6 +624,9 @@ const Filters: FC<FiltersProps> = ({
     getTimeSeriesCount(constraintsRef?.current?.[0]?.annotations),
   );
 
+  const isApplyDisabled =
+    isConstraintsLoading || isDisableFilterValues || isFiltersUnchanged;
+
   return (
     <div className="filters-container">
       <FilterButton
@@ -681,11 +684,7 @@ const Filters: FC<FiltersProps> = ({
               onClose={onCloseModal}
               onClearAllFilters={onClearAllFilters}
               modalProps={modalProps}
-              applyDisabled={
-                isConstraintsLoading ||
-                isDisableFilterValues ||
-                isFiltersUnchanged
-              }
+              applyDisabled={isApplyDisabled}
               timeseriesLength={timeSeriesCount}
               limitMessages={limitMessages}
             />

--- a/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
@@ -11,7 +11,7 @@ import {
 } from '@epam/statgpt-sdmx-toolkit';
 import { Locale } from '@epam/statgpt-shared-toolkit';
 import { Popup, PopUpSize, PopUpState } from '@epam/statgpt-ui-components';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import FilterSettings from './FiltersModal/FiltersSettings';
 import { Filter, FiltersProps } from '../../../models/filters';
 import {
@@ -493,7 +493,11 @@ const Filters: FC<FiltersProps> = ({
   );
 
   const isFiltersUnchanged = useMemo(
-    () => isEqual(getFiltersChangeParams(modalFilters), getFiltersChangeParams(appliedFilters)),
+    () =>
+      isEqual(
+        getFiltersChangeParams(modalFilters),
+        getFiltersChangeParams(appliedFilters),
+      ),
     [modalFilters, appliedFilters, getFiltersChangeParams],
   );
 
@@ -677,7 +681,11 @@ const Filters: FC<FiltersProps> = ({
               onClose={onCloseModal}
               onClearAllFilters={onClearAllFilters}
               modalProps={modalProps}
-              applyDisabled={isConstraintsLoading || isDisableFilterValues || isFiltersUnchanged}
+              applyDisabled={
+                isConstraintsLoading ||
+                isDisableFilterValues ||
+                isFiltersUnchanged
+              }
               timeseriesLength={timeSeriesCount}
               limitMessages={limitMessages}
             />

--- a/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/Filters.tsx
@@ -40,6 +40,7 @@ import {
   startTransition,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -491,6 +492,11 @@ const Filters: FC<FiltersProps> = ({
     [dimensions],
   );
 
+  const isFiltersUnchanged = useMemo(
+    () => isEqual(getFiltersChangeParams(modalFilters), getFiltersChangeParams(appliedFilters)),
+    [modalFilters, appliedFilters, getFiltersChangeParams],
+  );
+
   const updateViewAfterDelete = useCallback(
     (dataConstraints: DataConstraints[], filtersToUpdate: Filter[]) => {
       const filledFilters = getFilledFilters(
@@ -671,7 +677,7 @@ const Filters: FC<FiltersProps> = ({
               onClose={onCloseModal}
               onClearAllFilters={onClearAllFilters}
               modalProps={modalProps}
-              applyDisabled={isConstraintsLoading || isDisableFilterValues}
+              applyDisabled={isConstraintsLoading || isDisableFilterValues || isFiltersUnchanged}
               timeseriesLength={timeSeriesCount}
               limitMessages={limitMessages}
             />

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -797,6 +797,9 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
     [dataQueries, structureDataMaps?.structuresMap, locale],
   );
 
+  const isApplyDisabled =
+    isConstraintsLoading || isDisableFilterValues || isFiltersUnchanged;
+
   return (
     <div className="filters-container">
       <FilterButton
@@ -852,11 +855,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
               onClose={onCloseModal}
               onClearAllFilters={onClearAllFilters}
               modalProps={modalProps}
-              applyDisabled={
-                isConstraintsLoading ||
-                isDisableFilterValues ||
-                isFiltersUnchanged
-              }
+              applyDisabled={isApplyDisabled}
               limitMessages={limitMessages}
             />
           </Popup>

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -10,7 +10,7 @@ import {
   Locale,
   QueryFilterType,
 } from '@epam/statgpt-shared-toolkit';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { Popup, PopUpSize, PopUpState } from '@epam/statgpt-ui-components';
 import { Filter, FiltersProps } from '../../../models/filters';
 import {
@@ -852,7 +852,11 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
               onClose={onCloseModal}
               onClearAllFilters={onClearAllFilters}
               modalProps={modalProps}
-              applyDisabled={isConstraintsLoading || isDisableFilterValues || isFiltersUnchanged}
+              applyDisabled={
+                isConstraintsLoading ||
+                isDisableFilterValues ||
+                isFiltersUnchanged
+              }
               limitMessages={limitMessages}
             />
           </Popup>

--- a/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/MultiDatasetFilters/MultiDatasetFilters.tsx
@@ -10,6 +10,7 @@ import {
   Locale,
   QueryFilterType,
 } from '@epam/statgpt-shared-toolkit';
+import { isEqual } from 'lodash';
 import { Popup, PopUpSize, PopUpState } from '@epam/statgpt-ui-components';
 import { Filter, FiltersProps } from '../../../models/filters';
 import {
@@ -99,6 +100,9 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
   const [isFilterValuesLoading, setIsFilterValuesLoading] = useState(false);
   const filterValuesLoadingRequestsRef = useRef(0);
   const [disabledDatasetUrns, setDisabledDatasetUrns] = useState<Set<string>>(
+    new Set(),
+  );
+  const [appliedDisabledUrns, setAppliedDisabledUrns] = useState<Set<string>>(
     new Set(),
   );
   const conversationRef = useRef(conversation);
@@ -409,9 +413,11 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
         firstFilter ? { ...firstFilter, isSelectedFilter: true } : void 0,
       );
       setModalFilters(appliedFilters);
-      setDisabledDatasetUrns(
-        new Set(dataQueries?.filter((q) => q.disabled).map((q) => q.urn)),
+      const initialDisabled = new Set(
+        dataQueries?.filter((q) => q.disabled).map((q) => q.urn),
       );
+      setDisabledDatasetUrns(initialDisabled);
+      setAppliedDisabledUrns(initialDisabled);
     }
     if (modalState === PopUpState.Closed) {
       setSelectedFilter(void 0);
@@ -525,6 +531,37 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
       ),
     [dataQueries, structureDataMaps?.dimensionsMap],
   );
+
+  const isFiltersUnchanged = useMemo(() => {
+    const appliedMap = buildFiltersMap(
+      appliedFilters,
+      constraintsMapRef.current,
+      false,
+      datasetDimensionsMetadata.map,
+    );
+    const modalMap = buildFiltersMap(
+      modalFilters,
+      constraintsMapRef.current,
+      false,
+      datasetDimensionsMetadata.map,
+    );
+    const filtersEqual = isEqual(
+      getFiltersChangeParamsMap(appliedMap),
+      getFiltersChangeParamsMap(modalMap),
+    );
+    const disabledEqual = isEqual(
+      [...appliedDisabledUrns].sort(),
+      [...disabledDatasetUrns].sort(),
+    );
+    return filtersEqual && disabledEqual;
+  }, [
+    appliedFilters,
+    modalFilters,
+    appliedDisabledUrns,
+    disabledDatasetUrns,
+    getFiltersChangeParamsMap,
+    datasetDimensionsMetadata.map,
+  ]);
 
   const updateViewAfterDelete = useCallback(
     (
@@ -815,7 +852,7 @@ const MultiDatasetFilters: FC<FiltersProps> = ({
               onClose={onCloseModal}
               onClearAllFilters={onClearAllFilters}
               modalProps={modalProps}
-              applyDisabled={isConstraintsLoading || isDisableFilterValues}
+              applyDisabled={isConstraintsLoading || isDisableFilterValues || isFiltersUnchanged}
               limitMessages={limitMessages}
             />
           </Popup>

--- a/libs/conversation-view/src/utils/__tests__/filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/filters.spec.ts
@@ -853,7 +853,9 @@ describe('getSelectedFilterValues — isSelectedFilter does not affect output', 
       dimensionValues: [{ id: 'A', isSelectedValue: true }],
     };
 
-    const withFlag = getSelectedFilterValues([{ ...base, isSelectedFilter: true }]);
+    const withFlag = getSelectedFilterValues([
+      { ...base, isSelectedFilter: true },
+    ]);
 
     expect(withFlag).toHaveLength(1);
     expect(withFlag[0].id).toBe('FREQ');
@@ -866,7 +868,9 @@ describe('getSelectedFilterValues — isSelectedFilter does not affect output', 
       dimensionValues: [{ id: 'A', isSelectedValue: true }],
     };
 
-    const withFalse = getSelectedFilterValues([{ ...base, isSelectedFilter: false }]);
+    const withFalse = getSelectedFilterValues([
+      { ...base, isSelectedFilter: false },
+    ]);
 
     expect(withFalse).toHaveLength(1);
     expect(withFalse[0].id).toBe('FREQ');
@@ -880,8 +884,12 @@ describe('getSelectedFilterValues — isSelectedFilter does not affect output', 
     };
 
     const resultWithoutFlag = getSelectedFilterValues([{ ...base }]);
-    const resultWithTrue = getSelectedFilterValues([{ ...base, isSelectedFilter: true }]);
-    const resultWithFalse = getSelectedFilterValues([{ ...base, isSelectedFilter: false }]);
+    const resultWithTrue = getSelectedFilterValues([
+      { ...base, isSelectedFilter: true },
+    ]);
+    const resultWithFalse = getSelectedFilterValues([
+      { ...base, isSelectedFilter: false },
+    ]);
 
     expect(resultWithoutFlag).toEqual(resultWithTrue);
     expect(resultWithoutFlag).toEqual(resultWithFalse);

--- a/libs/conversation-view/src/utils/__tests__/filters.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/filters.spec.ts
@@ -842,3 +842,84 @@ describe('getDatasetFilters', () => {
     expect(result[0].displayMode).toBe(FilterDisplayMode.HIERARCHY);
   });
 });
+
+// ─── getSelectedFilterValues — isSelectedFilter does not affect output ────────
+
+describe('getSelectedFilterValues — isSelectedFilter does not affect output', () => {
+  it('does not filter based on isSelectedFilter: true', () => {
+    const base: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'A', isSelectedValue: true }],
+    };
+
+    const withFlag = getSelectedFilterValues([{ ...base, isSelectedFilter: true }]);
+
+    expect(withFlag).toHaveLength(1);
+    expect(withFlag[0].id).toBe('FREQ');
+  });
+
+  it('does not filter based on isSelectedFilter: false', () => {
+    const base: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'A', isSelectedValue: true }],
+    };
+
+    const withFalse = getSelectedFilterValues([{ ...base, isSelectedFilter: false }]);
+
+    expect(withFalse).toHaveLength(1);
+    expect(withFalse[0].id).toBe('FREQ');
+  });
+
+  it('filters consistently regardless of isSelectedFilter value', () => {
+    const base: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'A', isSelectedValue: false }],
+    };
+
+    const resultWithoutFlag = getSelectedFilterValues([{ ...base }]);
+    const resultWithTrue = getSelectedFilterValues([{ ...base, isSelectedFilter: true }]);
+    const resultWithFalse = getSelectedFilterValues([{ ...base, isSelectedFilter: false }]);
+
+    expect(resultWithoutFlag).toEqual(resultWithTrue);
+    expect(resultWithoutFlag).toEqual(resultWithFalse);
+  });
+});
+
+// ─── updateFiltersWithSelectedItem — preserves query-relevant fields ─────────
+
+describe('updateFiltersWithSelectedItem — preserves query-relevant fields', () => {
+  it('only changes isSelectedFilter, leaving dimensionValues and id intact', () => {
+    const filter: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'A', isSelectedValue: true }],
+    };
+
+    const result = updateFiltersWithSelectedItem([filter], filter);
+
+    expect(result[0].id).toBe(filter.id);
+    expect(result[0].dimensionValues).toEqual(filter.dimensionValues);
+    expect(result[0].isSelectedFilter).toBe(true);
+  });
+
+  it('sets isSelectedFilter to false on non-matching filters, leaving their data intact', () => {
+    const selected: Filter = {
+      id: 'FREQ',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'A', isSelectedValue: true }],
+    };
+    const other: Filter = {
+      id: 'GEO',
+      filterType: 'dataset',
+      dimensionValues: [{ id: 'US', isSelectedValue: true }],
+    };
+
+    const result = updateFiltersWithSelectedItem([selected, other], selected);
+
+    expect(result[1].dimensionValues).toEqual(other.dimensionValues);
+    expect(result[1].isSelectedFilter).toBe(false);
+  });
+});

--- a/specs/system/filters/07-data-flow.md
+++ b/specs/system/filters/07-data-flow.md
@@ -120,6 +120,23 @@ full algorithm.
 This sequence covers what happens between the user clicking "Apply" in the filter
 modal and the new state being saved to the backend.
 
+### Apply button disabled state
+
+The Apply button is disabled when the working modal state is identical to the last
+committed state. `Filters.tsx` computes this via
+`isEqual(getFiltersChangeParams(modalFilters), getFiltersChangeParams(appliedFilters))`.
+`MultiDatasetFilters.tsx` additionally compares `disabledDatasetUrns` against
+`appliedDisabledUrns` (a snapshot of the disabled set taken when the modal opened).
+The button is also disabled while constraints are loading (`isConstraintsLoading`) or
+filter values are being refreshed (`isDisableFilterValues`). Steps 1–3 below only
+execute when the button is enabled.
+
+`getFiltersChangeParams` serialises to `{ filterKey, timeFilter }` — query-relevant
+fields only. UI-only state such as `isSelectedFilter` (set by
+`updateFiltersWithSelectedItem` on modal open) is not included, so the comparison
+correctly returns "unchanged" right after the modal opens before the user touches
+anything.
+
 ### Step 1 — Serialise selections to QueryFilter[]
 
 `onApply()` in `Filters.tsx` calls `getQueryFilters()` which internally calls


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/296

### Description of changes

The Apply button is now disabled when the working modal state is identical to the last committed state. This prevents unnecessary data requests and system messages when the user opens the filters modal and clicks Apply without making any changes. The button also re-disables correctly if the user changes a filter and then reverts it. Both single-dataset (`Filters.tsx`) and multi-dataset (`MultiDatasetFilters.tsx`) flows are covered. In multi-dataset mode, toggling a dataset on or off is also treated as a change and enables the Apply button.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
