### PR TITLE
fix: do not allow to open download and advanced view while data is loading

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedView.tsx
@@ -176,6 +176,7 @@ export const AdvancedView: FC<Props> = ({
     handleCodeAttachmentUpdated,
     skipSingleDatasetConstraintsLoading,
   );
+  const shouldRenderDatasetInfo = shouldShowDatasetInfo && !!dataset;
   const {
     structureDataMaps,
     crossDatasetAttachments,
@@ -224,15 +225,17 @@ export const AdvancedView: FC<Props> = ({
     setCrossDatasetAttachmentsState,
     structureDataMaps,
   ]);
-  const [isFiltering, setIsFiltering] = useState<boolean>();
   const [filters, setFilters] = useState<DatasetQueryFilters>({
     filterKey: null,
     timeFilter: null,
   });
-  const isDataLoading = useMemo(
-    () => (isCrossDatasetModeOn ? isLoadingCrossDsGridData : isLoadingGridData),
-    [isCrossDatasetModeOn, isLoadingCrossDsGridData, isLoadingGridData],
-  );
+  const [isFiltering, setIsFiltering] = useState<boolean>();
+  const isDataLoading = isCrossDatasetModeOn
+    ? isLoadingCrossDsGridData
+    : isLoadingGridData;
+  const attachments = isCrossDatasetModeOn
+    ? crossDatasetAttachments
+    : dataSetAttachments;
 
   const handleFiltersChange = useCallback(
     (
@@ -343,7 +346,7 @@ export const AdvancedView: FC<Props> = ({
                   <Loader />
                 ) : (
                   <>
-                    {shouldShowDatasetInfo && (
+                    {shouldRenderDatasetInfo && (
                       <DatasetInfo
                         {...datasetInfoOptions}
                         locale={locale}
@@ -358,7 +361,8 @@ export const AdvancedView: FC<Props> = ({
                     <div
                       className={classNames(
                         'flex flex-1 min-h-0 overflow-auto',
-                        shouldShowDatasetInfo && 'border-t border-neutrals-500',
+                        shouldRenderDatasetInfo &&
+                          'border-t border-neutrals-500',
                       )}
                     >
                       <div
@@ -370,11 +374,7 @@ export const AdvancedView: FC<Props> = ({
                         <DataDetails
                           {...props}
                           actions={actions}
-                          attachments={
-                            isCrossDatasetModeOn
-                              ? crossDatasetAttachments
-                              : dataSetAttachments
-                          }
+                          attachments={attachments}
                           attachmentsDataQuery={
                             attachmentsProps.currentDataQuery
                           }

--- a/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
@@ -106,8 +106,6 @@ const AttachmentRenderer: FC<Props> = ({
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
   const [selectedAttachmentIndex, setSelectedAttachmentIndex] =
     useState<number>(0);
-  const [selectedAttachment, setSelectedAttachment] =
-    useState<Attachment | null>(null);
 
   const { isOpenedAdvancedView, setIsOpenedAdvancedView } = useAdvancedView();
   const [modalState, setModalState] = useState(PopUpState.Closed);
@@ -151,9 +149,7 @@ const AttachmentRenderer: FC<Props> = ({
     onAdvancedViewOpen,
   ]);
 
-  useEffect(() => {
-    setSelectedAttachment(attachments[selectedAttachmentIndex] || null);
-  }, [attachments, selectedAttachmentIndex]);
+  const selectedAttachment = attachments[selectedAttachmentIndex] || null;
 
   useEffect(() => {
     setShowLoading(
@@ -249,6 +245,9 @@ const AttachmentRenderer: FC<Props> = ({
 
   if (!attachments || attachments.length === 0) return null;
 
+  const shouldShowLoader =
+    (!isOpenedAdvancedView && showLoading) || !!isDataLoading;
+
   return (
     <>
       {isOpenedAdvancedView && !isShowAttachments ? (
@@ -266,7 +265,7 @@ const AttachmentRenderer: FC<Props> = ({
             `flex flex-col pb-1`,
           )}
         >
-          {!isOpenedAdvancedView && showLoading ? (
+          {shouldShowLoader ? (
             <Loader />
           ) : (
             <>
@@ -344,32 +343,32 @@ const AttachmentRenderer: FC<Props> = ({
                   )}
                 </div>
               </div>
+              <>
+                {modalState === PopUpState.Opened && (
+                  <DownloadSettings
+                    onCloseModal={onCloseModal}
+                    onDownloadStart={startDownload}
+                    isDownloadInProgress={isDownloadRunning}
+                    dataQuery={currentDataQuery}
+                    datasetName={selectedAttachment?.title || ''}
+                    locale={locale}
+                    type={downloadType}
+                    dimensions={dimensions}
+                    filters={filters}
+                    urn={currentDataQuery?.urn}
+                    titles={attachmentsStyles?.downloadTitles}
+                    rowCount={downloadRowCount}
+                    collapsible={attachmentsStyles?.downloadCollapsible}
+                    downloadDatasets={downloadDatasets}
+                    limitMessages={limitMessages}
+                    showLimitMessage={showLimitMessage}
+                    externalLink={externalLink}
+                  />
+                )}
+                <DownloadAlert {...downloadAlertProps} />
+              </>
             </>
           )}
-          <>
-            {modalState === PopUpState.Opened && (
-              <DownloadSettings
-                onCloseModal={onCloseModal}
-                onDownloadStart={startDownload}
-                isDownloadInProgress={isDownloadRunning}
-                dataQuery={currentDataQuery}
-                datasetName={selectedAttachment?.title || ''}
-                locale={locale}
-                type={downloadType}
-                dimensions={dimensions}
-                filters={filters}
-                urn={currentDataQuery?.urn}
-                titles={attachmentsStyles?.downloadTitles}
-                rowCount={downloadRowCount}
-                collapsible={attachmentsStyles?.downloadCollapsible}
-                downloadDatasets={downloadDatasets}
-                limitMessages={limitMessages}
-                showLimitMessage={showLimitMessage}
-                externalLink={externalLink}
-              />
-            )}
-            <DownloadAlert {...downloadAlertProps} />
-          </>
         </div>
       )}
     </>

--- a/libs/conversation-view/src/utils/attachments/attachment-parser.ts
+++ b/libs/conversation-view/src/utils/attachments/attachment-parser.ts
@@ -1,5 +1,9 @@
 import { Attachment } from '@epam/ai-dial-shared';
 import { AttachmentType, Message } from '@epam/statgpt-dial-toolkit';
+import {
+  CrossDatasetGridAttachmentType,
+  CustomGridAttachment,
+} from '../../models/attachments';
 
 export const parseMessageAttachments = (message: Message): Attachment[] => {
   const attachments: Attachment[] = [];
@@ -39,7 +43,9 @@ export function isGridAttachment(attachment: Attachment): boolean {
   return attachment.type === AttachmentType.TABLE;
 }
 
-export function isCustomGridAttachment(attachment: Attachment): boolean {
+export function isCustomGridAttachment(
+  attachment: Attachment,
+): attachment is CustomGridAttachment {
   return attachment.type === AttachmentType.CUSTOM_DATA_GRID;
 }
 
@@ -55,7 +61,9 @@ export function isCustomCodeSampleAttachment(attachment: Attachment): boolean {
   return attachment.type === AttachmentType.CUSTOM_CODE_SAMPLE;
 }
 
-export function isCrossDatasetGrid(attachment: Attachment): boolean {
+export function isCrossDatasetGrid(
+  attachment: Attachment,
+): attachment is CrossDatasetGridAttachmentType {
   return attachment.type === AttachmentType.CROSS_DATASET_GRID;
 }
 


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/300
### Description of changes

**Problem**

The loader shown above the data table did not extend over the header (dataset tabs + action buttons), so the user is able to open Download modal or Advanced View while data still loading.

**Solution**

Conversation mode: loader covers tabs + buttons + table during data loading.
Advanced view: loader covers the buttons panel + table during filtering and correctly disappears after loading.

### Checklist


- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
