### PR TITLE
fix: prevent redirect when renaming non-active conversation

### DIFF
--- a/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationList/ConversationListWrapper.tsx
@@ -49,6 +49,7 @@ import { useConversationList } from '../../context/ConversationListContext';
 import {
   getConversationNavPath,
   getConversationId,
+  getConversationIdFromResourceUrl,
   ApiResponse,
 } from '@epam/statgpt-shared-toolkit';
 import { getSignInLink } from '../../constants/auth';
@@ -78,6 +79,10 @@ const ConversationListWrapper = ({
   const locale = useCurrentLocale();
   const { data: session } = useSession();
   const { isStreaming } = useChatMessages();
+  const selectedConversationId = useMemo(
+    () => getConversationId(id, locale),
+    [id, locale],
+  );
 
   const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -109,8 +114,14 @@ const ConversationListWrapper = ({
               sourceUrl,
               destinationUrl,
             );
+          const sourceConversationId =
+            getConversationIdFromResourceUrl(sourceUrl);
 
-          if (response.success && navPath) {
+          if (
+            response.success &&
+            navPath &&
+            sourceConversationId === selectedConversationId
+          ) {
             router.replace(
               `/${locale}${ApplicationRoute.Conversations}/${navPath}`,
             );
@@ -120,7 +131,7 @@ const ConversationListWrapper = ({
         },
       ),
     }),
-    [authHandler, locale, router],
+    [authHandler, locale, router, selectedConversationId],
   );
 
   const titles: ConversationListTitles = {
@@ -322,7 +333,7 @@ const ConversationListWrapper = ({
             setConversations={setConversations}
             setSharedConversations={setSharedConversations}
             isCollapsed={isCollapsed}
-            selectedConversationId={getConversationId(id, locale)}
+            selectedConversationId={selectedConversationId}
             conversationStyles={{
               titles,
               isSmallModalButton: true,


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/301

### Description of changes

Fixed unwanted navigation after renaming a conversation.
Now the app updates the route only when the renamed conversation is the currently opened one. Renaming any other conversation from the list or search results keeps the user on the current chat.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
