### PR TITLE
fix: do not show Dataset facet in Single dataset view

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetsList.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/FiltersFacetsList.tsx
@@ -52,6 +52,8 @@ const FiltersFacetsList: FC<Props> = ({
   onClearAllDatasets,
 }) => {
   const { isCrossDatasetModeOn } = useConversationViewFeatureToggles();
+  const shouldShowDatasetSelector =
+    isCrossDatasetModeOn && !!dataQueries?.length;
   const datasetCount = new Set(
     filtersList
       .filter((filter) => filter.filterType === 'dataset')
@@ -64,7 +66,7 @@ const FiltersFacetsList: FC<Props> = ({
         'overflow-y-auto advanced-view-filters-list w-[338px] pr-3 h-full sm:w-full',
       )}
     >
-      {dataQueries && dataQueries.length > 0 && (
+      {shouldShowDatasetSelector && (
         <DatasetSelectorFacet
           dataQueries={dataQueries}
           disabledDatasetUrns={disabledDatasetUrns}

--- a/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/__tests__/FiltersFacetsList.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Filters/FiltersModal/FiltersFacets/__tests__/FiltersFacetsList.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DataQuery } from '@epam/statgpt-shared-toolkit';
+import FiltersFacetsList from '../FiltersFacetsList';
+
+jest.mock('@epam/statgpt-ui-components', () => ({
+  IconButton: ({ onClick, title }: any) => (
+    <button onClick={onClick} aria-label={title}>
+      clear
+    </button>
+  ),
+}));
+
+jest.mock('../../../../../../context/ConversationViewStylesContext', () => ({
+  useConversationViewStyles: () => ({ titles: {} }),
+}));
+
+const mockUseConversationViewFeatureToggles = jest.fn();
+
+jest.mock(
+  '../../../../../../context/ConversationViewFeatureTogglesContext',
+  () => ({
+    useConversationViewFeatureToggles: (...args: any[]) =>
+      mockUseConversationViewFeatureToggles(...args),
+  }),
+);
+
+jest.mock('../../../../../../assets/icons/clear.svg', () => () => null);
+
+const makeQuery = (urn: string): DataQuery => ({
+  urn,
+  title: urn,
+  metadata: { countryDimension: 'REF_AREA', indicatorDimensions: [] },
+});
+
+const renderList = (isCrossDatasetModeOn: boolean) => {
+  mockUseConversationViewFeatureToggles.mockReturnValue({
+    isCrossDatasetModeOn,
+  });
+
+  return render(
+    <FiltersFacetsList
+      filtersList={[]}
+      onSelectFilter={jest.fn()}
+      onSelectDatasetFacet={jest.fn()}
+      onClearAllDatasets={jest.fn()}
+      dataQueries={[makeQuery('A'), makeQuery('B')]}
+    />,
+  );
+};
+
+describe('FiltersFacetsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides Dataset selector facet when cross dataset mode is off', () => {
+    renderList(false);
+
+    expect(screen.queryByText('Dataset')).not.toBeInTheDocument();
+  });
+
+  it('shows Dataset selector facet when cross dataset mode is on', () => {
+    renderList(true);
+
+    expect(screen.getByText('Dataset')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/308

### Description of changes

Do not show Dataset filters when `cross dataset mode` is off.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
