### PR TITLE
fix: show "Last updated" date in the Dataset info panel

### DIFF
--- a/apps/portals-example/src/app/[locale]/layout.tsx
+++ b/apps/portals-example/src/app/[locale]/layout.tsx
@@ -22,7 +22,10 @@ import { ComponentsConfig } from '../../components/configs/ComponentsConfig/Comp
 import { TextsConfig } from '../../components/configs/TextsConfig/TextsConfig';
 import { ClientProvidersWrapper } from '../../components/ClientProvidersWrapper/ClientProvidersWrapper';
 import { getDatasetsMetadata } from '../actions/datasets-metadata';
-import { buildDatasetDimensionsMetadataMap } from '@epam/statgpt-sdmx-toolkit';
+import {
+  buildDatasetDimensionsMetadataMap,
+  buildDatasetLastUpdatedMap,
+} from '@epam/statgpt-sdmx-toolkit';
 import { parseBoolean } from '@epam/statgpt-shared-toolkit';
 
 export default async function LocaleLayout({
@@ -76,6 +79,9 @@ export default async function LocaleLayout({
   const datasetDimensionsMetadataMap = metadata.data
     ? buildDatasetDimensionsMetadataMap(metadata.data)
     : {};
+  const datasetLastUpdatedMap = metadata.data
+    ? buildDatasetLastUpdatedMap(metadata.data)
+    : {};
 
   const getContent = () => {
     if (!configuration.success && !isAnyConversationAvailable) {
@@ -92,6 +98,7 @@ export default async function LocaleLayout({
           <ClientProvidersWrapper
             isAgentAvailable={configuration.success}
             datasetDimensionsMetadataMap={datasetDimensionsMetadataMap}
+            datasetLastUpdatedMap={datasetLastUpdatedMap}
           >
             <OnboardingProvider>
               <AdvancedViewProvider>

--- a/apps/portals-example/src/components/ClientProvidersWrapper/ClientProvidersWrapper.tsx
+++ b/apps/portals-example/src/components/ClientProvidersWrapper/ClientProvidersWrapper.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { DatasetDimensionsMetadataMapProvider } from '@epam/statgpt-conversation-view';
-import { DatasetDimensionsMetadataMap } from '@epam/statgpt-sdmx-toolkit';
+import {
+  DatasetDimensionsMetadataMap,
+  DatasetLastUpdatedMap,
+} from '@epam/statgpt-sdmx-toolkit';
 import { AgentAvailabilityProvider } from '@epam/statgpt-ui-components';
 import { ReactNode } from 'react';
 
@@ -9,14 +12,19 @@ export const ClientProvidersWrapper = ({
   children,
   isAgentAvailable,
   datasetDimensionsMetadataMap,
+  datasetLastUpdatedMap,
 }: {
   children: ReactNode;
   isAgentAvailable: boolean;
   datasetDimensionsMetadataMap: DatasetDimensionsMetadataMap;
+  datasetLastUpdatedMap: DatasetLastUpdatedMap;
 }) => {
   return (
     <AgentAvailabilityProvider isAgentAvailable={isAgentAvailable}>
-      <DatasetDimensionsMetadataMapProvider map={datasetDimensionsMetadataMap}>
+      <DatasetDimensionsMetadataMapProvider
+        map={datasetDimensionsMetadataMap}
+        lastUpdatedMap={datasetLastUpdatedMap}
+      >
         {children}
       </DatasetDimensionsMetadataMapProvider>
     </AgentAvailabilityProvider>

--- a/libs/conversation-view/src/components/AdvancedView/DatasetInfo.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/DatasetInfo.tsx
@@ -4,7 +4,6 @@ import MetadataIcon from '../../assets/icons/metadata.svg';
 import { IconExternalLink } from '@tabler/icons-react';
 import {
   Dataflow,
-  getLastUpdatedTime,
   getLocalizedName,
   StructuralData,
   Data,
@@ -41,6 +40,7 @@ import { mergeClasses } from '../../utils/mergeClasses';
 import { useConversationViewFeatureToggles } from '../../context/ConversationViewFeatureTogglesContext';
 import { useConversationViewSidePanelOptional } from '../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useAdvancedView } from '../../context/AdvancedViewContext';
+import { useDatasetDimensionsMetadataMap } from '../../context/DatasetDimensionsMetadataMapContext';
 
 export interface DatasetInfoOptions {
   isShowAgency?: boolean;
@@ -98,6 +98,7 @@ const DatasetInfo: FC<Props> = ({
   const { isOpenedAdvancedView } = useAdvancedView();
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
+  const { getDatasetLastUpdated } = useDatasetDimensionsMetadataMap();
   const [isMetadataClosed, setIsMetadataClosed] = useState(false);
 
   const datasetDescription = useMemo(
@@ -182,9 +183,15 @@ const DatasetInfo: FC<Props> = ({
       getDatasetUpdatedTime && getDatasetUpdatedTime(datasetMetadata);
     const updatedTime =
       overridenValue ||
-      getDateFormattedValue(getLastUpdatedTime(dataset), locale);
+      getDateFormattedValue(getDatasetLastUpdated(dataset), locale);
     setLastUpdatedDate(updatedTime);
-  }, [dataset, locale, datasetMetadata, getDatasetUpdatedTime]);
+  }, [
+    dataset,
+    locale,
+    datasetMetadata,
+    getDatasetUpdatedTime,
+    getDatasetLastUpdated,
+  ]);
 
   useEffect(() => {
     if (isShowOnboarding) {

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/DatasetDetailCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/DatasetDetailCellRenderer.tsx
@@ -4,7 +4,6 @@ import { FC, useMemo, useCallback } from 'react';
 import { ICellRendererParams } from 'ag-grid-community';
 import {
   Data,
-  getLastUpdatedTime,
   getStructureComponentsMap,
   StructuralData,
 } from '@epam/statgpt-sdmx-toolkit';
@@ -18,6 +17,7 @@ import { useConversationViewFeatureToggles } from '../../../context/Conversation
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useAdvancedView } from '../../../context/AdvancedViewContext';
+import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
 import { getDateFormattedValue } from '../../../utils/date-format';
 import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
 
@@ -36,6 +36,7 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
   const { isOpenedAdvancedView } = useAdvancedView();
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
+  const { getDatasetLastUpdated } = useDatasetDimensionsMetadataMap();
 
   const urn: string | undefined = params?.data?.dataset?.urn;
   const externalLink = getExternalLinkFromContext(params?.context, urn);
@@ -47,11 +48,11 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
     const dataflow = structures?.dataflows?.[0];
     if (!dataflow) return undefined;
     const lastUpdatedDate = getDateFormattedValue(
-      getLastUpdatedTime(dataflow),
+      getDatasetLastUpdated(dataflow),
       params.locale,
     );
     return getDatasetInfoData(dataflow, lastUpdatedDate, params.locale, titles);
-  }, [structures, params.locale, titles]);
+  }, [structures, params.locale, titles, getDatasetLastUpdated]);
 
   const metadata = useMemo(
     () =>

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/MergedDimensionCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/MergedDimensionCellRenderer.tsx
@@ -6,7 +6,6 @@ import {
   DatasetDimensionsScheme,
   StructuralData,
   getStructureComponentsMap,
-  getLastUpdatedTime,
 } from '@epam/statgpt-sdmx-toolkit';
 import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
 import {
@@ -18,6 +17,7 @@ import { ConversationViewTitles } from '../../../models/titles';
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useAdvancedView } from '../../../context/AdvancedViewContext';
+import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
 import { getDateFormattedValue } from '../../../utils/date-format';
 import {
   COUNTRY_COL_ID,
@@ -66,6 +66,7 @@ const MergedDimensionCellRenderer: FC<MergedDimensionCellRendererParams> = (
   const { isOpenedAdvancedView } = useAdvancedView();
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
+  const { getDatasetLastUpdated } = useDatasetDimensionsMetadataMap();
   const tableSettings = useTableSettingsContextOptional();
 
   const urn: string | undefined = params?.data?.dataset?.urn;
@@ -119,11 +120,11 @@ const MergedDimensionCellRenderer: FC<MergedDimensionCellRendererParams> = (
     const dataflow = structures?.dataflows?.[0];
     if (!dataflow) return undefined;
     const lastUpdatedDate = getDateFormattedValue(
-      getLastUpdatedTime(dataflow),
+      getDatasetLastUpdated(dataflow),
       params.locale,
     );
     return getDatasetInfoData(dataflow, lastUpdatedDate, params.locale, titles);
-  }, [structures, params.locale, titles]);
+  }, [structures, params.locale, titles, getDatasetLastUpdated]);
 
   const showTriangle =
     isMetadataInSidePanel &&

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellRenderer.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Data,
-  getLastUpdatedTime,
   getStructureComponentsMap,
   StructuralData,
   TimeSeries,
@@ -34,6 +33,7 @@ import { useOnboarding } from '../../../context/OnboardingContext';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useAdvancedView } from '../../../context/AdvancedViewContext';
+import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
 import { getDateFormattedValue } from '../../../utils/date-format';
 
 interface MetadataCellRendererParams extends ICellRendererParams {
@@ -58,6 +58,7 @@ const MetadataCellRenderer = (params: MetadataCellRendererParams) => {
   const { isOpenedAdvancedView } = useAdvancedView();
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
+  const { getDatasetLastUpdated } = useDatasetDimensionsMetadataMap();
   const [isMetadataClosed, setIsMetadataClosed] = useState(false);
   const rowUrn = params?.data?.dataset?.urn as string | undefined;
   const externalLink = getExternalLinkFromContext(params?.context, rowUrn);
@@ -128,12 +129,12 @@ const MetadataCellRenderer = (params: MetadataCellRendererParams) => {
   const sidePanelDatasetInfo = useMemo(() => {
     const dataset = resolvedDataSetData?.dataflows?.[0];
     const lastUpdatedDate = getDateFormattedValue(
-      getLastUpdatedTime(dataset),
+      getDatasetLastUpdated(dataset),
       params?.locale,
     );
 
     return getDatasetInfoData(dataset, lastUpdatedDate, params?.locale, titles);
-  }, [resolvedDataSetData, params?.locale, titles]);
+  }, [resolvedDataSetData, params?.locale, titles, getDatasetLastUpdated]);
 
   const openMetadata = useCallback(() => {
     if (isMetadataInSidePanel && sidePanel) {

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellWithMetadata.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellWithMetadata.tsx
@@ -8,6 +8,7 @@ import { useConversationViewFeatureToggles } from '../../../context/Conversation
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
 import { useAdvancedView } from '../../../context/AdvancedViewContext';
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
+import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
 import {
   getObservationMetadataContent,
   ObservationMetadataContent,
@@ -30,11 +31,16 @@ const ObservationValueCellWithMetadata: FC<
   const { isOpenedAdvancedView } = useAdvancedView();
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
+  const { getDatasetLastUpdated } = useDatasetDimensionsMetadataMap();
   const rowUrn = params?.data?.dataset?.urn as string | undefined;
   const externalLink = getExternalLinkFromContext(params?.context, rowUrn);
 
   const openMetadata = useCallback(() => {
-    const content = getObservationMetadataContent(params, obsAttributes);
+    const content = getObservationMetadataContent(
+      params,
+      obsAttributes,
+      getDatasetLastUpdated,
+    );
 
     if (isMetadataInSidePanel && sidePanel) {
       sidePanel.openPanel({
@@ -65,6 +71,7 @@ const ObservationValueCellWithMetadata: FC<
     params,
     sidePanel,
     titles,
+    getDatasetLastUpdated,
   ]);
 
   const closeMetadata = useCallback(() => {

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/helpers/get-observation-metadata-content.ts
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/helpers/get-observation-metadata-content.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../utils/attachments/metadata';
 import { ICellRendererParams } from 'ag-grid-community';
 import {
+  Dataflow,
   getLastUpdatedTime,
   getStructureComponentsMap,
   StructuralData,
@@ -33,6 +34,9 @@ export type ObservationMetadataContent = ReturnType<
 export const getObservationMetadataContent = (
   params: ObservationValueCellRendererParams,
   obsAttributes: NonNullable<ReturnType<typeof getObsAttributesFromParams>>,
+  getDatasetLastUpdated: (
+    dataset: Dataflow | null | undefined,
+  ) => string | undefined = getLastUpdatedTime,
 ) => {
   const dataSetData = getDataSetData(params);
   const structureComponentsMap = getStructureComponentsMap(dataSetData);
@@ -73,7 +77,7 @@ export const getObservationMetadataContent = (
     : [];
   const dataset = dataSetData?.dataflows?.[0];
   const lastUpdatedDate = getDateFormattedValue(
-    getLastUpdatedTime(dataset),
+    getDatasetLastUpdated(dataset),
     params?.locale,
   );
   const sidePanelDatasetInfo = getDatasetInfoData(

--- a/libs/conversation-view/src/context/DatasetDimensionsMetadataMapContext.tsx
+++ b/libs/conversation-view/src/context/DatasetDimensionsMetadataMapContext.tsx
@@ -2,9 +2,13 @@
 
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 import {
+  Dataflow,
   DatasetDimensionsScheme,
+  DatasetLastUpdatedMap,
   DimensionConfig,
   DimensionKey,
+  generateShortUrn,
+  getLastUpdatedTime,
   ShortUrn,
   DatasetDimensionsMetadataMap,
 } from '@epam/statgpt-sdmx-toolkit';
@@ -13,6 +17,10 @@ type GetDimensionMetadata = (
   urn: ShortUrn,
   dimensionKey: DimensionKey,
 ) => DimensionConfig | undefined;
+
+type GetDatasetLastUpdated = (
+  dataset: Dataflow | null | undefined,
+) => string | undefined;
 
 interface DatasetDimensionsMetadataMapContextValue {
   map: DatasetDimensionsMetadataMap;
@@ -24,10 +32,13 @@ interface DatasetDimensionsMetadataMapContextValue {
   getFrequencyDimension: (urn: ShortUrn) => DimensionKey | undefined;
   getIndicatorDimensions: (urn: ShortUrn) => DimensionKey[];
   getDimensionsScheme: (urn: ShortUrn) => DatasetDimensionsScheme | undefined;
+  getDatasetLastUpdated: GetDatasetLastUpdated;
 }
 
 const EMPTY_DATASET_DIMENSIONS_METADATA_MAP =
   {} as DatasetDimensionsMetadataMap;
+
+const EMPTY_DATASET_LAST_UPDATED_MAP = {} as DatasetLastUpdatedMap;
 
 const DEFAULT_CONTEXT_VALUE: DatasetDimensionsMetadataMapContextValue = {
   map: EMPTY_DATASET_DIMENSIONS_METADATA_MAP,
@@ -37,6 +48,7 @@ const DEFAULT_CONTEXT_VALUE: DatasetDimensionsMetadataMapContextValue = {
   getFrequencyDimension: () => undefined,
   getIndicatorDimensions: () => [],
   getDimensionsScheme: () => undefined,
+  getDatasetLastUpdated: (dataset) => getLastUpdatedTime(dataset),
 };
 
 const Context = createContext<DatasetDimensionsMetadataMapContextValue>(
@@ -45,9 +57,11 @@ const Context = createContext<DatasetDimensionsMetadataMapContextValue>(
 
 export function DatasetDimensionsMetadataMapProvider({
   map,
+  lastUpdatedMap = EMPTY_DATASET_LAST_UPDATED_MAP,
   children,
 }: {
   map: DatasetDimensionsMetadataMap;
+  lastUpdatedMap?: DatasetLastUpdatedMap;
   children: ReactNode;
 }) {
   const value = useMemo<DatasetDimensionsMetadataMapContextValue>(() => {
@@ -104,8 +118,21 @@ export function DatasetDimensionsMetadataMapProvider({
       getIndicatorDimensions: (urn: ShortUrn) =>
         dimensionsByType[urn]?.['INDICATOR'] ?? [],
       getDimensionsScheme: (urn: ShortUrn) => schemesCache[urn],
+      getDatasetLastUpdated: (dataset) => {
+        if (!dataset) {
+          return undefined;
+        }
+
+        const urn = generateShortUrn(
+          dataset.id,
+          dataset.version,
+          dataset.agencyID,
+        );
+
+        return lastUpdatedMap[urn] || getLastUpdatedTime(dataset);
+      },
     };
-  }, [map]);
+  }, [map, lastUpdatedMap]);
 
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }

--- a/libs/sdmx-toolkit/src/models/datasets-metadata.ts
+++ b/libs/sdmx-toolkit/src/models/datasets-metadata.ts
@@ -4,6 +4,7 @@ export interface DeploymentDatasetsResponseData {
 
 export interface ChannelDataset {
   dataset: Dataset;
+  last_updated_at?: string | null;
 }
 
 export interface Dataset {
@@ -48,3 +49,4 @@ export type DatasetDimensionsMetadataMap = Record<
   ShortUrn,
   Record<DimensionKey, DimensionConfig>
 >;
+export type DatasetLastUpdatedMap = Record<ShortUrn, string>;

--- a/libs/sdmx-toolkit/src/utils/__tests__/annotations.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/annotations.spec.ts
@@ -5,7 +5,7 @@ describe('getLastUpdatedTime', () => {
   it('returns the value of the LAST_UPDATE_AT annotation', () => {
     const dataset = {
       annotations: [
-        { id: Annotations.LAST_UPDATE_AT, value: '2024-07-24T10:00:00Z' },
+        { id: Annotations.LAST_UPDATE_AT, text: '2024-07-24T10:00:00Z' },
         { id: 'OTHER', value: 'something else' },
       ],
     };

--- a/libs/sdmx-toolkit/src/utils/__tests__/build-dataset-dimensions-metadata-map.spec.ts
+++ b/libs/sdmx-toolkit/src/utils/__tests__/build-dataset-dimensions-metadata-map.spec.ts
@@ -1,0 +1,51 @@
+import { buildDatasetLastUpdatedMap } from '../build-dataset-dimensions-metadata-map';
+import { DeploymentDatasetsResponseData } from '../../models';
+
+function channelDataset(
+  resourceId: string,
+  lastUpdatedAt?: string | null,
+): DeploymentDatasetsResponseData['datasets'][number] {
+  return {
+    dataset: {
+      details: {
+        urn: { agencyId: 'ABC', resourceId, version: '1.0.0' },
+        dimensions: {},
+      },
+    },
+    last_updated_at: lastUpdatedAt,
+  };
+}
+
+describe('buildDatasetLastUpdatedMap', () => {
+  it('maps short urns to last_updated_at values', () => {
+    const data: DeploymentDatasetsResponseData = {
+      datasets: [
+        channelDataset('CPI', '2025-07-15T00:00:00'),
+        channelDataset('GDP', '2024-01-02T10:30:00'),
+      ],
+    };
+
+    expect(buildDatasetLastUpdatedMap(data)).toEqual({
+      'ABC:CPI(1.0.0)': '2025-07-15T00:00:00',
+      'ABC:GDP(1.0.0)': '2024-01-02T10:30:00',
+    });
+  });
+
+  it('skips datasets without last_updated_at', () => {
+    const data: DeploymentDatasetsResponseData = {
+      datasets: [
+        channelDataset('CPI', '2025-07-15T00:00:00'),
+        channelDataset('GDP', null),
+        channelDataset('BOP'),
+      ],
+    };
+
+    expect(buildDatasetLastUpdatedMap(data)).toEqual({
+      'ABC:CPI(1.0.0)': '2025-07-15T00:00:00',
+    });
+  });
+
+  it('returns an empty map for an empty dataset list', () => {
+    expect(buildDatasetLastUpdatedMap({ datasets: [] })).toEqual({});
+  });
+});

--- a/libs/sdmx-toolkit/src/utils/annotations.ts
+++ b/libs/sdmx-toolkit/src/utils/annotations.ts
@@ -8,5 +8,5 @@ export function getLastUpdatedTime(
     if (annotation.id === Annotations.LAST_UPDATE_AT) {
       return annotation;
     }
-  })?.value;
+  })?.text;
 }

--- a/libs/sdmx-toolkit/src/utils/build-dataset-dimensions-metadata-map.ts
+++ b/libs/sdmx-toolkit/src/utils/build-dataset-dimensions-metadata-map.ts
@@ -2,6 +2,7 @@ import {
   Dataset,
   DeploymentDatasetsResponseData,
   DatasetDimensionsMetadataMap,
+  DatasetLastUpdatedMap,
 } from '../models';
 import { generateShortUrn } from './urn';
 
@@ -20,6 +21,20 @@ export function buildDatasetDimensionsMetadataMap(
     const urn = datasetToShortUrn(dataset);
 
     map[urn] = dataset.details.dimensions;
+  }
+
+  return map;
+}
+
+export function buildDatasetLastUpdatedMap(
+  data: DeploymentDatasetsResponseData,
+): DatasetLastUpdatedMap {
+  const map: DatasetLastUpdatedMap = {};
+
+  for (const cd of data.datasets) {
+    if (cd.last_updated_at) {
+      map[datasetToShortUrn(cd.dataset)] = cd.last_updated_at;
+    }
   }
 
   return map;

--- a/specs/system/filters/01-domain-model.md
+++ b/specs/system/filters/01-domain-model.md
@@ -168,6 +168,14 @@ interface DimensionConfig {
 This is how the system knows that `REF_AREA` in Dataset A and `GEO` in Dataset B
 are both the "region/country" dimension — they both have `subtype: 'REGION'`.
 
+The same server response also carries a per-dataset `last_updated_at` timestamp
+(snake_case, as serialised by the backend). It is not filter-related: it is
+collected into `DatasetLastUpdatedMap` (`Record<ShortUrn, string>`) by
+`buildDatasetLastUpdatedMap`, exposed via `getDatasetLastUpdated` on
+`DatasetDimensionsMetadataMapContext`, and used to display the "Last updated"
+date in dataset metadata panels (with the SDMX `lastUpdatedAt` annotation as a
+fallback).
+
 ### `DatasetDimensionsScheme`
 
 A lightweight derived summary per dataset (`libs/sdmx-toolkit/src/models/dataset-dimensions-scheme.ts`):

--- a/specs/system/filters/README.md
+++ b/specs/system/filters/README.md
@@ -96,7 +96,7 @@ update because you cannot verify every line number.
 | `libs/shared-toolkit/src/models/data-query.ts` | `DataQuery`, `QueryFilter` types |
 | `libs/conversation-view/src/models/filters.ts` | `Filter`, `SharedFilter`, `FilterValue` types |
 | `libs/sdmx-toolkit/src/models/structural-metadata/constraints.ts` | `DataConstraints`, `CubeRegion` types |
-| `libs/sdmx-toolkit/src/models/datasets-metadata.ts` | `DatasetDimensionsMetadataMap`, `DimensionConfig` |
+| `libs/sdmx-toolkit/src/models/datasets-metadata.ts` | `DatasetDimensionsMetadataMap`, `DimensionConfig`, `DatasetLastUpdatedMap` |
 | `libs/sdmx-toolkit/src/models/dataset-dimensions-scheme.ts` | `DatasetDimensionsScheme` |
 | `libs/conversation-view/src/utils/filters.ts` | Single-dataset filter utilities |
 | `libs/conversation-view/src/utils/multiple-filters.ts` | Multi-dataset merging, constraint fetching (1500+ lines — the core) |


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/321

### Description of changes

**Surface last_updated_at from the datasets-metadata endpoint**

- Added `last_updated_at?: string | null` to `ChannelDataset` model.
- Added `DatasetLastUpdatedMap` type and `buildDatasetLastUpdatedMap` utility that builds a ShortUrn → timestamp map from the endpoint response.
- Extended `DatasetDimensionsMetadataMapProvider` with an optional `lastUpdatedMap` prop and a `getDatasetLastUpdated(dataflow)` getter on the context — deployment metadata is the primary source, SDMX annotation is the fallback.
- All five display sites (`DatasetInfo, MetadataCellRenderer, DatasetDetailCellRenderer, MergedDimensionCellRenderer, ObservationValueCellWithMetadata`) now call `getDatasetLastUpdated` from the context instead of `getLastUpdatedTime` directly.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
