### PR TITLE
feat: convert attachment components to named exports and expand conversation-view public API

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/AdvancedAttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/AdvancedAttachmentRenderer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FC, useCallback } from 'react';
-import AttachmentRenderer from '../Attachments/AttachmentRenderer';
+import { AttachmentRenderer } from '../Attachments/AttachmentRenderer';
 import type { ComponentProps } from 'react';
 import { useTableSettingsContext } from './TableSettings/TableSettingsContext';
 import { useConversationViewSidePanelOptional } from '../ConversationView/SidePanel/ConversationViewSidePanelContext';

--- a/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
@@ -43,6 +43,7 @@ import AttachmentsViewModePanel from './AttachmentsViewModePanel';
 import AttachmentsContentRenderer from './AttachmentsContentRenderer';
 import { DownloadAlert } from './DownloadAlert/DownloadAlert';
 import { useAttachmentDownloadFlow } from './useAttachmentDownloadFlow';
+import { mergeClasses } from '../../utils/mergeClasses';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 interface Props {
@@ -67,13 +68,15 @@ interface Props {
   filters?: DatasetQueryFilters;
   selectDataset?: (datasetUrn?: string) => void;
   onAdvancedViewOpen?: () => void;
+  hideDownloadButton?: boolean;
+  containerClassName?: string;
   isTableSettingsOpen?: boolean;
   onTableSettingsOpen?: () => void;
   onTableSettingsClose?: () => void;
   onGridApiReady?: (api: GridApi) => void;
 }
 
-const AttachmentRenderer: FC<Props> = ({
+export const AttachmentRenderer: FC<Props> = ({
   attachments,
   actions,
   isSystemAttachments,
@@ -91,6 +94,8 @@ const AttachmentRenderer: FC<Props> = ({
   filters,
   selectDataset,
   onAdvancedViewOpen,
+  hideDownloadButton,
+  containerClassName,
   isTableSettingsOpen,
   onTableSettingsOpen,
   onTableSettingsClose,
@@ -259,10 +264,11 @@ const AttachmentRenderer: FC<Props> = ({
         />
       ) : (
         <div
-          className={classNames(
+          className={mergeClasses(
             `space-y-3 max-w-full max-h-full h-full`,
             !isOpenedAdvancedView && !isSystemAttachments ? 'pt-5' : 'pt-0',
             `flex flex-col pb-1`,
+            containerClassName,
           )}
         >
           {!isOpenedAdvancedView &&
@@ -322,6 +328,7 @@ const AttachmentRenderer: FC<Props> = ({
                     limitMessages={limitMessages}
                     onSelectedAttachmentChange={selectAttachment}
                     onDownloadClick={() => setModalState(PopUpState.Opened)}
+                    hideDownloadButton={hideDownloadButton}
                     showAdvancedView={showAdvancedView}
                     onOpenAdvancedView={onOpenAdvancedView}
                     isTableSettingsOpen={isTableSettingsOpen}
@@ -374,5 +381,3 @@ const AttachmentRenderer: FC<Props> = ({
     </>
   );
 };
-
-export default AttachmentRenderer;

--- a/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
@@ -18,8 +18,8 @@ import {
 } from '../../utils/attachments/attachment-parser';
 import { AttachmentsStyles } from '../../models/attachments-styles';
 import GridAttachment from './BaseAttachments/GridAttachment';
-import CustomDataGridAttachment from './CustomAttachments/CustomGridAttachment';
-import CustomChartAttachment from './CustomAttachments/CustomChartAttachment';
+import { CustomDataGridAttachment } from './CustomAttachments/CustomGridAttachment';
+import { CustomChartAttachment } from './CustomAttachments/CustomChartAttachment';
 import { CodeAttachment } from './CustomAttachments/CodeAttachment';
 import { AttachmentsActions } from '../../models/actions';
 import CrossDatasetGridAttachment from './CustomAttachments/CrossDatasetGridAttachment';

--- a/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
@@ -38,6 +38,7 @@ interface Props {
   limitMessages?: LimitMessages;
   onSelectedAttachmentChange: (index: number) => void;
   onDownloadClick: () => void;
+  hideDownloadButton?: boolean;
   showAdvancedView?: boolean;
   onOpenAdvancedView?: () => void;
   isTableSettingsOpen?: boolean;
@@ -54,6 +55,7 @@ const AttachmentsViewModePanel: FC<Props> = ({
   limitMessages,
   onSelectedAttachmentChange,
   onDownloadClick,
+  hideDownloadButton,
   showAdvancedView,
   onOpenAdvancedView,
   isTableSettingsOpen,
@@ -107,6 +109,7 @@ const AttachmentsViewModePanel: FC<Props> = ({
     );
 
   const shouldShowDownloadButton =
+    !hideDownloadButton &&
     !!selectedAttachment &&
     (isCustomGridAttachment(selectedAttachment) ||
       isCrossDatasetGrid(selectedAttachment));

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -35,7 +35,7 @@ interface FlatChartUnit {
   groupTitle?: string;
 }
 
-const CustomChartAttachment: FC<Props> = ({
+export const CustomChartAttachment: FC<Props> = ({
   attachment,
   icons,
   isDataLoading,
@@ -226,5 +226,3 @@ const CustomChartAttachment: FC<Props> = ({
     </div>
   );
 };
-
-export default CustomChartAttachment;

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
@@ -36,7 +36,7 @@ interface Props {
   onApiReady?: (api: GridApi) => void;
 }
 
-const CustomDataGridAttachment: FC<Props> = ({
+export const CustomDataGridAttachment: FC<Props> = ({
   attachment,
   isDataLoading,
   isChartColumnVisible,
@@ -192,5 +192,3 @@ const CustomDataGridAttachment: FC<Props> = ({
     </div>
   );
 };
-
-export default CustomDataGridAttachment;

--- a/libs/conversation-view/src/components/Attachments/__tests__/AttachmentRenderer.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/__tests__/AttachmentRenderer.spec.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import AttachmentRenderer from '../AttachmentRenderer';
+import { AttachmentRenderer } from '../AttachmentRenderer';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
 import type { DataQuery } from '@epam/statgpt-shared-toolkit';
 

--- a/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/Message/Message.tsx
@@ -19,7 +19,7 @@ import { useConversationViewStyles } from '../../../context/ConversationViewStyl
 import classNames from 'classnames';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
-import AttachmentRenderer from '../../Attachments/AttachmentRenderer';
+import { AttachmentRenderer } from '../../Attachments/AttachmentRenderer';
 import MessageContent from '../MessageContent';
 import { useAttachmentsData } from '../../../context/AttachmentsData';
 import { useDatasets } from '../../../context/Datasets';

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -60,3 +60,11 @@ export {
   CrossDatasetAttachmentsProvider,
   useCrossDatasetAttachments,
 } from './context/CrossDatasetAttachmentsContext';
+
+export { AttachmentRenderer } from './components/Attachments/AttachmentRenderer';
+export type {
+  ChartingData,
+  ChartUnit,
+  ChartUnitGroup,
+} from './models/charting';
+export type { GridData } from './types/data-grid/grid-data';

--- a/libs/conversation-view/src/models/attachments-styles.ts
+++ b/libs/conversation-view/src/models/attachments-styles.ts
@@ -9,7 +9,7 @@ export interface AttachmentsStyles {
   openAdvancedViewIcon?: ReactNode;
   advancedViewTitle?: string;
   chartingStyles?: ChartingStyles;
-  chartingIcons: Record<ChartingIcon, ReactNode>;
+  chartingIcons?: Record<ChartingIcon, ReactNode>;
   downloadIcon?: ReactNode;
   downloadChevronIcon?: ReactNode;
   openLinkTitle?: string;


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Converts `AttachmentRenderer`, `CustomChartAttachment`, and `CustomDataGridAttachment` from default exports to named exports and updates all internal import sites. Adds these components plus the `ChartingData`, `ChartUnit`, `ChartUnitGroup`, and `GridData` types to the library's public index.

Also makes `chartingIcons` optional in `AttachmentsStyles` and adds a `hideDownloadButton` prop to `AttachmentsViewModePanel` to allow consumers to suppress the download button without overriding styles.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.