### PR TITLE
fix: use absolute path for styles-tailwind.scss in viteStaticCopy

### DIFF
--- a/libs/ui-components/project.json
+++ b/libs/ui-components/project.json
@@ -10,24 +10,7 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/ui-components",
-        "assets": [
-          {
-            "glob": "README.md",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "LICENSE",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "styles-tailwind.scss",
-            "input": "libs/ui-components/src/scss",
-            "output": "."
-          }
-        ]
+        "outputPath": "dist/libs/ui-components"
       },
       "configurations": {
         "development": {

--- a/libs/ui-components/vite.config.ts
+++ b/libs/ui-components/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
           dest: '',
         },
         {
-          src: 'src/scss/styles-tailwind.scss',
+          src: path.resolve(__dirname, 'src/scss/styles-tailwind.scss'),
           dest: '',
         },
       ],


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

After the `vite-plugin-static-copy` upgrade from v3 → v4, `styles-tailwind.scss` stopped being copied to the package root during build. This broke the `@use '@epam/statgpt-ui-components/styles-tailwind.scss'` import used across all consumer projects.

**Root cause:** `vite-plugin-static-copy` v4 requires absolute `src` paths — the previous relative path `src/scss/styles-tailwind.scss` was silently skipped.

- `vite.config.ts` — use `path.resolve(__dirname, 'src/scss/styles-tailwind.scss')` instead of a relative string
- `project.json` — remove redundant `assets` block (same files were already handled by `viteStaticCopy`, consistent with every other lib in this repo)

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.