### PR TITLE
fix: copy styles-tailwind.scss to dist root via inline Vite plugin

### DIFF
--- a/libs/ui-components/vite.config.ts
+++ b/libs/ui-components/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig, UserConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
+import * as fs from 'fs';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import svgr from 'vite-plugin-svgr';
@@ -49,12 +50,18 @@ export default defineConfig({
           src: '../../LICENSE',
           dest: '',
         },
-        {
-          src: path.resolve(__dirname, 'src/scss/styles-tailwind.scss'),
-          dest: '',
-        },
       ],
     }),
+    {
+      name: 'copy-styles-tailwind',
+      apply: 'build',
+      closeBundle() {
+        fs.copyFileSync(
+          path.resolve(__dirname, 'src/scss/styles-tailwind.scss'),
+          path.resolve(__dirname, '../../dist/libs/ui-components/styles-tailwind.scss'),
+        );
+      },
+    },
   ],
 
   // Uncomment this if you are using workers.

--- a/libs/ui-components/vite.config.ts
+++ b/libs/ui-components/vite.config.ts
@@ -58,7 +58,10 @@ export default defineConfig({
       closeBundle() {
         fs.copyFileSync(
           path.resolve(__dirname, 'src/scss/styles-tailwind.scss'),
-          path.resolve(__dirname, '../../dist/libs/ui-components/styles-tailwind.scss'),
+          path.resolve(
+            __dirname,
+            '../../dist/libs/ui-components/styles-tailwind.scss',
+          ),
         );
       },
     },


### PR DESCRIPTION
### Applicable issues

- follows up on #423

### Description of changes

PR #423 attempted to fix the missing `styles-tailwind.scss` in the published package by using an absolute path in `viteStaticCopy`. That didn't work because the real breaking change in `vite-plugin-static-copy` v4 is behavioral: v4 **always preserves the source directory structure** in the destination. So `src: 'src/scss/styles-tailwind.scss'` with `dest: ''` now copies to `dist/libs/ui-components/src/scss/styles-tailwind.scss` instead of the root — regardless of whether the path is relative or absolute.

`README.md` and `../../LICENSE` still work because their `dir` component is either empty or pure `../` sequences, which the plugin strips.

**Fix:** remove `styles-tailwind.scss` from the `viteStaticCopy` targets and replace it with a minimal inline Vite `closeBundle` plugin that copies the file directly to the dist root with no ambiguity.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.