### PR TITLE
feat: add fillHeight prop to CustomChartAttachment and Storybook story

### DIFF
--- a/apps/storybook/.storybook/brand-configs/brand1/chart.scss
+++ b/apps/storybook/.storybook/brand-configs/brand1/chart.scss
@@ -1,0 +1,26 @@
+.chart-attachment {
+  &-title {
+    @apply h4;
+  }
+
+  .chart-area {
+    @apply border border-neutrals-500 rounded mt-4 px-3 py-5;
+  }
+}
+
+.single-chart-popup {
+  @apply pb-5;
+
+  &-heading {
+    @apply text-base font-bold;
+  }
+
+  &-content {
+    @apply p-6;
+    @apply border-t border-t-neutrals-500;
+  }
+
+  .sidebar {
+    @apply w-[320px];
+  }
+}

--- a/apps/storybook/.storybook/brand-configs/brand1/styles.scss
+++ b/apps/storybook/.storybook/brand-configs/brand1/styles.scss
@@ -5,3 +5,4 @@
 @import './calendar';
 @import './input';
 @import './grid';
+@import './chart';

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChart.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChart.stories.tsx
@@ -1,0 +1,139 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { CustomChartAttachment } from './CustomChartAttachment';
+import { CustomChartAttachmentType } from '../../../models/attachments';
+import { ChartUnit } from '../../../models/charting';
+import { ChartingIcon } from '../../../types/charting-icon';
+import { ConversationViewStylesProvider } from '../../../context/ConversationViewStylesContext';
+import { OnboardingProvider } from '../../../context/OnboardingContext';
+
+const withProviders: Decorator = (Story) => (
+  <ConversationViewStylesProvider>
+    <OnboardingProvider>
+      <Story />
+    </OnboardingProvider>
+  </ConversationViewStylesProvider>
+);
+
+const years = ['2019', '2020', '2021', '2022', '2023'];
+
+const ukraineUnit: ChartUnit = {
+  config: {
+    xAxis: { type: 'category', data: years },
+    yAxis: { type: 'value', name: 'USD bn' },
+    series: [
+      {
+        type: 'line',
+        name: 'Ukraine',
+        data: [153.9, 155.6, 200.1, 160.5, 173.4],
+      },
+    ],
+    tooltip: { trigger: 'axis' },
+  },
+  dimensions: [
+    { id: 'REF_AREA', title: 'Country', value: 'Ukraine' },
+    { id: 'INDICATOR', title: 'Indicator', value: 'GDP at current prices' },
+  ],
+  rows: years.map((y, i) => ({
+    year: y,
+    value: [153.9, 155.6, 200.1, 160.5, 173.4][i],
+  })),
+  limitedByRowsAmountTo: undefined,
+  isPlottable: true,
+};
+
+const polandUnit: ChartUnit = {
+  config: {
+    xAxis: { type: 'category', data: years },
+    yAxis: { type: 'value', name: 'USD bn' },
+    series: [
+      {
+        type: 'line',
+        name: 'Poland',
+        data: [596.1, 596.9, 679.4, 688.1, 749.0],
+      },
+    ],
+    tooltip: { trigger: 'axis' },
+  },
+  dimensions: [
+    { id: 'REF_AREA', title: 'Country', value: 'Poland' },
+    { id: 'INDICATOR', title: 'Indicator', value: 'GDP at current prices' },
+  ],
+  rows: years.map((y, i) => ({
+    year: y,
+    value: [596.1, 596.9, 679.4, 688.1, 749.0][i],
+  })),
+  limitedByRowsAmountTo: undefined,
+  isPlottable: true,
+};
+
+const singleUnitAttachment: CustomChartAttachmentType = {
+  type: 'application/json',
+  title: 'GDP by Country',
+  charting_data: { units: [ukraineUnit] },
+};
+
+const multiUnitAttachment: CustomChartAttachmentType = {
+  type: 'application/json',
+  title: 'GDP by Country',
+  charting_data: { units: [ukraineUnit, polandUnit] },
+};
+
+const chartingIcons = {
+  [ChartingIcon.PREVIOUS]: <IconChevronLeft width={20} height={20} />,
+  [ChartingIcon.NEXT]: <IconChevronRight width={20} height={20} />,
+};
+
+const meta: Meta<typeof CustomChartAttachment> = {
+  title: 'Conversation View/Chart/CustomChart',
+  component: CustomChartAttachment,
+  decorators: [withProviders],
+  tags: ['autodocs'],
+  args: {
+    icons: chartingIcons,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomChartAttachment>;
+
+export const WithData: Story = {
+  args: {
+    attachment: singleUnitAttachment,
+  },
+};
+
+export const MultipleCharts: Story = {
+  name: 'Multiple Charts (slider)',
+  args: {
+    attachment: multiUnitAttachment,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    attachment: singleUnitAttachment,
+    isDataLoading: true,
+  },
+};
+
+export const FillHeight: Story = {
+  name: 'Fill Height',
+  render: (args) => (
+    <div style={{ height: 300, maxWidth: 640 }}>
+      <CustomChartAttachment {...args} />
+    </div>
+  ),
+  args: {
+    attachment: singleUnitAttachment,
+    fillHeight: true,
+  },
+};
+
+export const FixedHeight: Story = {
+  name: 'Fixed Height (400px cap)',
+  args: {
+    attachment: singleUnitAttachment,
+    fixHeight: true,
+  },
+};

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -24,12 +24,14 @@ import {
 import { OnboardingElements } from '../../../constants/onboarding-elements';
 import ResponsiveEChart from './ResponsiveChart';
 import DatasetIcon from '../../../assets/icons/dataset.svg';
+
 interface Props {
   attachment: CustomChartAttachmentType;
   icons?: Record<ChartingIcon, ReactNode>;
   openAdvancedView?: () => void;
   isDataLoading?: boolean;
   fixHeight?: boolean;
+  fillHeight?: boolean;
   limitationInfoPrefixIcon?: ReactNode;
   limitationInfoContentClassName?: string;
 }
@@ -45,6 +47,7 @@ export const CustomChartAttachment: FC<Props> = ({
   isDataLoading,
   openAdvancedView,
   fixHeight = true,
+  fillHeight,
   limitationInfoPrefixIcon,
   limitationInfoContentClassName,
 }) => {
@@ -178,13 +181,21 @@ export const CustomChartAttachment: FC<Props> = ({
               </div>
               <div
                 className={classNames(
-                  'chart-area flex gap-4 h-full',
+                  'chart-area flex gap-4',
                   isNarrowChart
                     ? 'flex-col overflow-auto'
                     : 'flex-row overflow-hidden',
+                  fillHeight && 'flex-1 min-h-0',
+                  !fillHeight && 'h-full',
                   isNarrowChart && 'min-h-[500px]',
-                  !isNarrowChart && fixHeight && 'max-h-[400px] min-h-[400px]',
-                  !isNarrowChart && !fixHeight && 'min-h-[300px]',
+                  !isNarrowChart &&
+                    !fillHeight &&
+                    fixHeight &&
+                    'max-h-[400px] min-h-[400px]',
+                  !isNarrowChart &&
+                    !fillHeight &&
+                    !fixHeight &&
+                    'min-h-[300px]',
                 )}
               >
                 <div
@@ -195,7 +206,7 @@ export const CustomChartAttachment: FC<Props> = ({
                 >
                   {selectedGroupTitle && (
                     <div className="mb-1 flex items-center gap-1">
-                      <DatasetIcon className="size-4 shrink-0 text-neutrals-1000" />
+                      <DatasetIcon className="text-neutrals-1000 size-4 shrink-0" />
                       <h4 className="text-neutrals-1000">
                         {selectedGroupTitle}
                       </h4>

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -206,7 +206,7 @@ export const CustomChartAttachment: FC<Props> = ({
                 >
                   {selectedGroupTitle && (
                     <div className="mb-1 flex items-center gap-1">
-                      <DatasetIcon className="text-neutrals-1000 size-4 shrink-0" />
+                      <DatasetIcon className="size-4 shrink-0 text-neutrals-1000" />
                       <h4 className="text-neutrals-1000">
                         {selectedGroupTitle}
                       </h4>

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -159,6 +159,17 @@ export const CustomChartAttachment: FC<Props> = ({
     setChartIndex((prevV) => Math.max(prevV - 1, 0));
   }, []);
 
+  const chartLayoutClass = isNarrowChart
+    ? 'flex-col overflow-auto'
+    : 'flex-row overflow-hidden';
+
+  const chartHeightClass = (() => {
+    if (fillHeight) return 'flex-1 min-h-0';
+    if (isNarrowChart) return 'h-full min-h-[500px]';
+    if (fixHeight) return 'h-full max-h-[400px] min-h-[400px]';
+    return 'h-full min-h-[300px]';
+  })();
+
   if (isLoading || isDataLoading) {
     return <Loader />;
   }
@@ -182,20 +193,8 @@ export const CustomChartAttachment: FC<Props> = ({
               <div
                 className={classNames(
                   'chart-area flex gap-4',
-                  isNarrowChart
-                    ? 'flex-col overflow-auto'
-                    : 'flex-row overflow-hidden',
-                  fillHeight && 'flex-1 min-h-0',
-                  !fillHeight && 'h-full',
-                  isNarrowChart && 'min-h-[500px]',
-                  !isNarrowChart &&
-                    !fillHeight &&
-                    fixHeight &&
-                    'max-h-[400px] min-h-[400px]',
-                  !isNarrowChart &&
-                    !fillHeight &&
-                    !fixHeight &&
-                    'min-h-[300px]',
+                  chartLayoutClass,
+                  chartHeightClass,
                 )}
               >
                 <div

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomChart.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomChart.stories.tsx
@@ -1,11 +1,11 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
-import { CustomChartAttachment } from './CustomChartAttachment';
-import { CustomChartAttachmentType } from '../../../models/attachments';
-import { ChartUnit } from '../../../models/charting';
-import { ChartingIcon } from '../../../types/charting-icon';
-import { ConversationViewStylesProvider } from '../../../context/ConversationViewStylesContext';
-import { OnboardingProvider } from '../../../context/OnboardingContext';
+import { CustomChartAttachment } from '../CustomChartAttachment';
+import { CustomChartAttachmentType } from '../../../../models/attachments';
+import { ChartUnit } from '../../../../models/charting';
+import { ChartingIcon } from '../../../../types/charting-icon';
+import { ConversationViewStylesProvider } from '../../../../context/ConversationViewStylesContext';
+import { OnboardingProvider } from '../../../../context/OnboardingContext';
 
 const withProviders: Decorator = (Story) => (
   <ConversationViewStylesProvider>

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomGrid.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomGrid.stories.tsx
@@ -1,9 +1,9 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
-import { CustomDataGridAttachment } from './CustomGridAttachment';
-import { CustomGridAttachment } from '../../../models/attachments';
-import { ConversationViewStylesProvider } from '../../../context/ConversationViewStylesContext';
-import { OnboardingProvider } from '../../../context/OnboardingContext';
+import { CustomDataGridAttachment } from '../CustomGridAttachment';
+import { CustomGridAttachment } from '../../../../models/attachments';
+import { ConversationViewStylesProvider } from '../../../../context/ConversationViewStylesContext';
+import { OnboardingProvider } from '../../../../context/OnboardingContext';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 


### PR DESCRIPTION
### Applicable issues

### Description of changes

Adds `fillHeight` prop to `CustomChartAttachment` for MCP App display modes (PiP, fullscreen) where the host controls the container height. When `fillHeight=true`, the chart area uses `flex-1 min-h-0` instead of `h-full` + min/max constraints, fixing the overflow scroll caused by `h-full` resolving to 100% of the flex container rather than remaining space.

Also adds a Storybook story (`CustomChart.stories.tsx`) with stories for the standard cases and brand chart styles for brand1.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.