### PR TITLE
feat: skip min-height in narrow chart when fillHeight is set

### DIFF
--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -200,7 +200,8 @@ export const CustomChartAttachment: FC<Props> = ({
                 <div
                   className={classNames(
                     'flex min-h-0 min-w-0 flex-1 flex-col',
-                    isNarrowChart && 'min-h-[360px] w-full',
+                    isNarrowChart && 'w-full',
+                    isNarrowChart && !fillHeight && 'min-h-[360px]',
                   )}
                 >
                   {selectedGroupTitle && (
@@ -215,7 +216,7 @@ export const CustomChartAttachment: FC<Props> = ({
                     <div
                       className={classNames(
                         'min-h-0 min-w-0 flex-1',
-                        isNarrowChart && 'min-h-[280px]',
+                        isNarrowChart && !fillHeight && 'min-h-[280px]',
                       )}
                     >
                       <ResponsiveEChart

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomChart.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomChart.stories.tsx
@@ -137,3 +137,14 @@ export const FixedHeight: Story = {
     fixHeight: true,
   },
 };
+
+export const NarrowCard: Story = {
+  name: 'Narrow Card (mobile, fixHeight)',
+  args: {
+    attachment: multiUnitAttachment,
+    fixHeight: true,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'mobile2' },
+  },
+};


### PR DESCRIPTION
### Applicable issues

- N/A

### Description of changes

When `fillHeight` is enabled on `CustomChartAttachment`, the fixed `min-h` classes in narrow/mobile layout are now skipped — allowing the chart to fill its container height naturally instead of forcing 360px/280px minimums.

Also adds a `NarrowCard` Storybook story using Storybook's viewport parameter.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.