### PR TITLE
fix: replace minimist with built-in parseArgs in publish-lib

### DIFF
--- a/tools/publish-lib.mjs
+++ b/tools/publish-lib.mjs
@@ -11,9 +11,9 @@ import mainPackageJson from '../package.json' with { type: 'json' };
 import devkit from '@nx/devkit';
 import { execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import minimist from 'minimist';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { parseArgs } from 'util';
 
 const PREFIX = '@epam/statgpt';
 
@@ -32,11 +32,19 @@ function invariant(condition, message) {
 
 // Executing publish script: node path/to/publish.mjs {name} --version {version} --tag {tag}
 // Default "tag" to "next" so we won't publish the "latest" tag by accident.
-let params = minimist(process.argv);
-let version = params.version;
-const dry = params.dry === 'true';
-const tag = params.tag || 'next';
-const name = params['_'][2];
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    version: { type: 'string' },
+    dry: { type: 'string' },
+    tag: { type: 'string' },
+  },
+  allowPositionals: true,
+});
+let version = values.version;
+const dry = values.dry === 'true';
+const tag = values.tag || 'next';
+const name = positionals[0];
 
 console.info(
   `\nPublish run with next values:\nname=${name}\nversion=${version}\ndry=${dry}\ntag=${tag}\n`,


### PR DESCRIPTION

### Description of changes

Removes the minimist dependency in favor of Node's built-in util.parseArgs, eliminating the process.argv -> minimist taint sink flagged by the security scan (minimist prototype-pollution history, CVE-2020-7598 / CVE-2021-44906). minimist was only a transitive, undeclared dependency, so it was also unpinned.

Also feeds parseArgs process.argv.slice(2) and reads the project name from positionals[0], fixing the off-by-slice that required params['_'][2].

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
