### PR TITLE
chore: register minimal ag-grid modules per grid and drop AllCommunityModule

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnGridListeners.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnGridListeners.spec.ts
@@ -15,6 +15,7 @@ function mockApi() {
   return {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
+    isDestroyed: jest.fn(() => false),
   } as unknown as GridApi;
 }
 

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnPreferences.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnPreferences.spec.ts
@@ -16,6 +16,7 @@ function mockApi(overrides: Partial<Record<string, jest.Mock>> = {}) {
     setColumnGroupState: jest.fn(),
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
+    isDestroyed: jest.fn(() => false),
     ...overrides,
   } as unknown as GridApi;
 }

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnsPanel.spec.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/__tests__/useAgGridColumnsPanel.spec.ts
@@ -25,6 +25,7 @@ function mockApi(
     applyColumnState: jest.fn(),
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
+    isDestroyed: jest.fn(() => false),
     ...overrides,
   } as unknown as GridApi;
 }

--- a/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/useAgGridColumnGridListeners.ts
+++ b/libs/conversation-view/src/components/AdvancedView/TableSettings/AgGridColumnPanel/hooks/useAgGridColumnGridListeners.ts
@@ -30,6 +30,9 @@ export function useAgGridColumnGridListeners(
     }
 
     return () => {
+      if (api.isDestroyed()) {
+        return;
+      }
       for (const eventName of COLUMN_SYNC_EVENTS) {
         api.removeEventListener(eventName, listener);
       }

--- a/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
@@ -32,7 +32,7 @@ import AttachmentDetails from './AttachmentDetails/AttachmentDetails';
 import { useAdvancedView } from '../../context/AdvancedViewContext';
 import AttachmentCollapsed from './AttachmentCollapsed';
 import { AttachmentsActions } from '../../models/actions';
-import { AllCommunityModule, GridApi, ModuleRegistry } from 'ag-grid-community';
+import type { GridApi } from 'ag-grid-community';
 import DownloadSettings from '@statgpt/download-panel/src/components/DownloadSettings/DownloadSettings';
 import { DownloadDatasetItem } from '@statgpt/download-panel/src/models/download-dataset-item';
 import { useConversationViewStyles } from '../../context/ConversationViewStylesContext';
@@ -45,7 +45,6 @@ import { DownloadAlert } from './DownloadAlert/DownloadAlert';
 import { useAttachmentDownloadFlow } from './useAttachmentDownloadFlow';
 import { mergeClasses } from '../../utils/mergeClasses';
 
-ModuleRegistry.registerModules([AllCommunityModule]);
 interface Props {
   attachments: (
     | Attachment

--- a/libs/conversation-view/src/components/Attachments/BaseAttachments/GridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/BaseAttachments/GridAttachment.tsx
@@ -5,11 +5,27 @@ import { FC, useEffect, useMemo, useState } from 'react';
 import { Loader, SERIES_LIMIT } from '@epam/statgpt-ui-components';
 import { convertToGridData } from '../../../utils/attachments/convert-to-grid-data';
 import type { ColDef } from 'ag-grid-community';
+import {
+  ModuleRegistry,
+  ClientSideRowModelModule,
+  TooltipModule,
+  ColumnAutoSizeModule,
+  CellStyleModule,
+} from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { AttachmentsActions } from '../../../models/actions';
 import { GridData } from '../../../types/data-grid/grid-data';
 import { GRID_HEADER_HEIGHT, GRID_ROW_HEIGHT } from '../../../constants/grid';
 import { getGridHeight } from '../../../utils/attachments/data-grid/grid-height';
+
+ModuleRegistry.registerModules([
+  ClientSideRowModelModule,
+  TooltipModule,
+  ColumnAutoSizeModule,
+  CellStyleModule,
+]);
+
+const DEFAULT_COL_DEF: ColDef = { cellDataType: false };
 
 interface Props {
   attachment: Attachment;
@@ -64,6 +80,7 @@ const GridAttachment: FC<Props> = ({
         rowHeight={GRID_ROW_HEIGHT}
         rowData={rowData}
         columnDefs={columnDefs}
+        defaultColDef={DEFAULT_COL_DEF}
         enableCellTextSelection
         domLayout="normal"
         tooltipShowDelay={0}

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
@@ -9,6 +9,16 @@ import {
   useIsMobile,
 } from '@epam/statgpt-ui-components';
 import type { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
+import {
+  ModuleRegistry,
+  ClientSideRowModelModule,
+  TooltipModule,
+  ValueCacheModule,
+  ColumnApiModule,
+  CellStyleModule,
+  EventApiModule,
+  RenderApiModule,
+} from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { GridData } from '../../../types/data-grid/grid-data';
 import { getGridHeight } from '../../../utils/attachments/data-grid/grid-height';
@@ -29,6 +39,18 @@ import ChartCellRenderer from '../GridCellRenderers/ChartCellRenderer';
 import MergedDimensionCellRenderer from '../GridCellRenderers/MergedDimensionCellRenderer';
 import DatasetDetailCellRenderer from '../GridCellRenderers/DatasetDetailCellRenderer';
 import GridContainer from './GridContainer';
+
+ModuleRegistry.registerModules([
+  ClientSideRowModelModule,
+  TooltipModule,
+  ValueCacheModule,
+  ColumnApiModule,
+  CellStyleModule,
+  EventApiModule,
+  RenderApiModule,
+]);
+
+const DEFAULT_COL_DEF: ColDef = { cellDataType: false };
 
 interface Props {
   attachment: CrossDatasetGridAttachmentType;
@@ -69,6 +91,7 @@ const CrossDatasetGridAttachment: FC<Props> = ({
         }
         return applyMobileColumnWidth(col, isMobile);
       });
+
       setRowData(attachment.gridContent.data);
       setColumnDefs(columns);
       setIsLoading(false);
@@ -130,6 +153,7 @@ const CrossDatasetGridAttachment: FC<Props> = ({
   const memoizedGrid = useMemo(
     () => (
       <AgGridReact
+        defaultColDef={DEFAULT_COL_DEF}
         headerHeight={GRID_HEADER_HEIGHT}
         rowHeight={GRID_ROW_HEIGHT}
         rowData={rowData}

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
@@ -9,6 +9,16 @@ import {
   useIsMobile,
 } from '@epam/statgpt-ui-components';
 import type { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
+import {
+  ModuleRegistry,
+  ClientSideRowModelModule,
+  TooltipModule,
+  ValueCacheModule,
+  ColumnApiModule,
+  CellStyleModule,
+  EventApiModule,
+  RenderApiModule,
+} from 'ag-grid-community';
 import { AgGridReact } from 'ag-grid-react';
 import { GridData } from '../../../types/data-grid/grid-data';
 import { getGridHeight } from '../../../utils/attachments/data-grid/grid-height';
@@ -31,6 +41,18 @@ import { OnboardingElements } from '../../../constants/onboarding-elements';
 import { useOnboarding } from '../../../context/OnboardingContext';
 import { OnboardingFileSchema } from '@epam/statgpt-shared-toolkit';
 import GridContainer from './GridContainer';
+
+ModuleRegistry.registerModules([
+  ClientSideRowModelModule,
+  TooltipModule,
+  ValueCacheModule,
+  ColumnApiModule,
+  CellStyleModule,
+  EventApiModule,
+  RenderApiModule,
+]);
+
+const DEFAULT_COL_DEF: ColDef = { cellDataType: false };
 
 interface Props {
   attachment: CustomGridAttachment;
@@ -161,6 +183,7 @@ export const CustomDataGridAttachment: FC<Props> = ({
     () => (
       <AgGridReact
         onGridReady={handleGridReady}
+        defaultColDef={DEFAULT_COL_DEF}
         headerHeight={GRID_HEADER_HEIGHT}
         rowHeight={GRID_ROW_HEIGHT}
         rowData={rowData}

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomGrid.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomGrid.stories.tsx
@@ -1,11 +1,8 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
-import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
 import { CustomDataGridAttachment } from '../CustomGridAttachment';
 import { CustomGridAttachment } from '../../../../models/attachments';
 import { ConversationViewStylesProvider } from '../../../../context/ConversationViewStylesContext';
 import { OnboardingProvider } from '../../../../context/OnboardingContext';
-
-ModuleRegistry.registerModules([AllCommunityModule]);
 
 const withProviders: Decorator = (Story) => (
   <ConversationViewStylesProvider>

--- a/libs/sdmx-toolkit/package.json
+++ b/libs/sdmx-toolkit/package.json
@@ -2,6 +2,7 @@
   "name": "@epam/statgpt-sdmx-toolkit",
   "version": "0.0.1",
   "license": "MIT",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/libs/shared-toolkit/package.json
+++ b/libs/shared-toolkit/package.json
@@ -2,6 +2,7 @@
   "name": "@epam/statgpt-shared-toolkit",
   "version": "0.0.1",
   "license": "MIT",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/libs/ui-components/package.json
+++ b/libs/ui-components/package.json
@@ -2,6 +2,7 @@
   "name": "@epam/statgpt-ui-components",
   "version": "0.0.1",
   "license": "MIT",
+  "sideEffects": false,
   "dependencies": {
     "@epam/statgpt-shared-toolkit": "*"
   },


### PR DESCRIPTION
### Applicable issues
- N/A

### Description of changes

Replaces the global `AllCommunityModule` registration with per-grid registration of only the AG Grid v33 modules each grid uses, enabling tree-shaking. Sets derived from source (colDefs are built client-side) and verified against runtime exports. Includes minor rolled-in fixes (`cellDataType: false` → error #48; `api.isDestroyed()` guard → error #26) and `"sideEffects": false` on `sdmx-toolkit`/`shared-toolkit`/`ui-components`.

Verified: build OK; grids + Table Settings work; `nx test conversation-view` 677/677; lint clean.

### Checklist
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.