### PR TITLE
feat: expose cross-dataset grid and chart builders via public API

### DIFF
--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ChartCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ChartCellRenderer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import SingleLineChart from '../SingleLineChart';
 import { MetadataSettings } from '../../../models/metadata';
 import { Data, StructuralData } from '@epam/statgpt-sdmx-toolkit';

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -65,9 +65,14 @@ export { AttachmentRenderer } from './components/Attachments/AttachmentRenderer'
 export { CustomChartAttachment } from './components/Attachments/CustomAttachments/CustomChartAttachment';
 export { CustomDataGridAttachment } from './components/Attachments/CustomAttachments/CustomGridAttachment';
 export { CrossDatasetGridAttachment } from './components/Attachments/CustomAttachments/CrossDatasetGridAttachment';
+export { buildCrossDatasetGridContent } from './utils/attachments/cross-dataset-grid/build-cross-dataset-grid-attachment';
+export { CrossDatasetGridViewMode } from './components/AdvancedView/TableSettings/types';
+export { buildCrossDatasetChartingData } from './utils/attachments/charting/cross-dataset-chart-data';
+export { isChartingDataPlottable } from './utils/attachments/charting/chart-data';
 export type {
   ChartingData,
   ChartUnit,
   ChartUnitGroup,
 } from './models/charting';
 export type { GridData } from './types/data-grid/grid-data';
+export type { CrossDatasetGridAttachmentType } from './models/attachments';

--- a/libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts
@@ -30,6 +30,20 @@ export function createCrossDatasetChartingDataResolver(
   };
 }
 
+/**
+ * Builds `ChartingData` for a cross-dataset chart from parsed SDMX structures
+ * and data messages, producing one chart group per dataset.
+ *
+ * All map params are keyed by dataset URN; `dataQueries` selects which datasets
+ * to include and in what order.
+ *
+ * @param structuresMap - Parsed structure metadata per dataset URN.
+ * @param dataMessagesMap - Raw SDMX-JSON data message per dataset URN.
+ * @param dataQueries - Datasets to render, in order; matched to the maps by `urn`.
+ * @param locale - Locale used to resolve localized names.
+ * @param chartStyles - Optional chart styling.
+ * @returns Charting data for `CustomChartAttachment`.
+ */
 export function buildCrossDatasetChartingData(
   structuresMap: Map<string, StructuralData | undefined>,
   dataMessagesMap: Map<string, DataMessage | null>,

--- a/libs/conversation-view/src/utils/attachments/cross-dataset-grid/build-cross-dataset-grid-attachment.ts
+++ b/libs/conversation-view/src/utils/attachments/cross-dataset-grid/build-cross-dataset-grid-attachment.ts
@@ -54,6 +54,25 @@ export function buildCrossDatasetGridAttachment(
   };
 }
 
+/**
+ * Builds the `{ data, columns }` grid content for a cross-dataset grid from
+ * parsed SDMX structures and data messages.
+ *
+ * All map params are keyed by dataset URN; `dataQueries` selects which datasets
+ * to include and in what order. Entries with no matching structure or data
+ * message are skipped.
+ *
+ * @param structuresMap - Parsed structure metadata per dataset URN.
+ * @param dataMessagesMap - Raw SDMX-JSON data message per dataset URN.
+ * @param datasetDimensionsSchemesMap - Dimension-role scheme per URN; drives dimension column grouping (`undefined` entries fall back to degraded labelling).
+ * @param dataQueries - Datasets to render, in order; matched to the maps by `urn`.
+ * @param locale - Locale used to resolve localized names.
+ * @param formattingSettings - Optional number formatting for observation values.
+ * @param chartStyles - Optional styling for the sparkline chart column.
+ * @param titles - Optional column header label overrides.
+ * @param gridViewMode - Dimension display mode; defaults to compact.
+ * @returns AG Grid `columns` and row `data` for `CrossDatasetGridAttachment`.
+ */
 export function buildCrossDatasetGridContent(
   structuresMap: Map<string, StructuralData | undefined>,
   dataMessagesMap: Map<string, DataMessage | null>,


### PR DESCRIPTION
### Description of changes

Surfaces existing internal builders and a type through the `@epam/statgpt-conversation-view` public API so they can be reused by external consumers. Re-exports only — no behavior changes.

Newly public:
- `buildCrossDatasetGridContent` — builds `{ data, columns }` for the cross-dataset grid from parsed SDMX structures and data messages.
- `buildCrossDatasetChartingData` — builds `ChartingData` for a cross-dataset chart (one group per dataset).
- `isChartingDataPlottable` — guard for whether charting data has anything to render.
- `CrossDatasetGridViewMode` — dimension display mode enum.
- `CrossDatasetGridAttachmentType` (type) — the `CrossDatasetGridAttachment` component's attachment prop type.

Also adds concise JSDoc to the two `build*` entry points so the docs flow into the generated `.d.ts`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.