### PR TITLE
feat: export ConversationViewSidePanelOutlet from conversation-view

### DIFF
--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -43,6 +43,7 @@ export type { ConversationViewStyles } from './context/ConversationViewStylesCon
 
 export {
   ConversationViewSidePanelProvider,
+  ConversationViewSidePanelOutlet,
   useConversationViewSidePanelOptional,
 } from './components/ConversationView/SidePanel/ConversationViewSidePanelContext';
 export type {


### PR DESCRIPTION
### Applicable issues

### Description of changes

Adds `ConversationViewSidePanelOutlet` to `libs/conversation-view/src/index.ts`'s public exports, alongside the already-exported `ConversationViewSidePanelProvider`. This is the component that renders the side-panel UI (title, close button, scrollable body) when a panel is opened via `useConversationViewSidePanelOptional().openPanel(...)` — previously only usable internally within this library, since consumers with just the provider had no way to render it.

Additive export only — no behavior change for existing consumers.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.