### PR TITLE
fix: update echarts dependency to avoid CVE-2026-45249

### DIFF
--- a/libs/conversation-view/package.json
+++ b/libs/conversation-view/package.json
@@ -18,7 +18,7 @@
     "ag-grid-react": "^33.3.2",
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
-    "echarts": "^5.6.0",
+    "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "flatpickr": "4.6.13",
     "lodash": "^4.17.23",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statgpt-portal-frontend",
-  "version": "0.0.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "statgpt-portal-frontend",
-      "version": "0.0.0",
+      "version": "0.6.1",
       "license": "MIT",
       "workspaces": [
         "libs/*"
@@ -25,7 +25,7 @@
         "classnames": "^2.5.1",
         "compare-versions": "^6.1.1",
         "date-fns": "^4.1.0",
-        "echarts": "^5.6.0",
+        "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.2",
         "flatpickr": "4.6.13",
         "jszip": "3.10.1",
@@ -145,7 +145,7 @@
         "ag-grid-react": "^33.3.2",
         "classnames": "^2.5.1",
         "date-fns": "^4.1.0",
-        "echarts": "^5.6.0",
+        "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.2",
         "flatpickr": "4.6.13",
         "lodash": "^4.17.23",
@@ -13970,11 +13970,13 @@
       "license": "MIT"
     },
     "node_modules/echarts": {
-      "version": "5.6.0",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.1"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/echarts-for-react": {
@@ -29185,7 +29187,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.6.1",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"
@@ -29193,6 +29197,8 @@
     },
     "node_modules/zrender/node_modules/tslib": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "license": "0BSD"
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.5.1",
     "compare-versions": "^6.1.1",
     "date-fns": "^4.1.0",
-    "echarts": "^5.6.0",
+    "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "flatpickr": "4.6.13",
     "jszip": "3.10.1",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
