### PR TITLE
fix: retry python-attachment endpoint on transient server errors

### DIFF
--- a/apps/portals-example/src/app/api/python-attachment/__tests__/route.spec.ts
+++ b/apps/portals-example/src/app/api/python-attachment/__tests__/route.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment node
+ */
+/// <reference types="jest" />
+import { NextRequest } from 'next/server';
+
+jest.mock('../../../../utils/auth/withAuth', () => ({
+  withAuth:
+    (
+      handler: (
+        req: NextRequest,
+        authParams: { token: { access_token: string } },
+      ) => Promise<Response>,
+    ) =>
+    (req: NextRequest) =>
+      handler(req, { token: { access_token: 'test-token' } }),
+}));
+
+const mockPostRequest = jest.fn();
+jest.mock('../../api', () => ({
+  dialApiClient: {
+    postRequest: (...args: unknown[]) => mockPostRequest(...args),
+  },
+  DEFAULT_MODEL_ID: 'test-model',
+}));
+
+const mockApiLoggerWarn = jest.fn();
+const mockApiLoggerError = jest.fn();
+jest.mock('../../../../core/logger', () => ({
+  apiLogger: {
+    warn: (...args: unknown[]) => mockApiLoggerWarn(...args),
+    error: (...args: unknown[]) => mockApiLoggerError(...args),
+  },
+}));
+
+import { POST } from '../route';
+
+function makeRequest(body: unknown): NextRequest {
+  return {
+    json: () => Promise.resolve(body),
+  } as unknown as NextRequest;
+}
+
+describe('POST /api/python-attachment', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockPostRequest.mockReset();
+    mockApiLoggerWarn.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the result on first-attempt success without retrying', async () => {
+    mockPostRequest.mockResolvedValue({ python_code: 'print(1)' });
+
+    const response = await POST(makeRequest({ queries: [] }));
+    const json = await response.json();
+
+    expect(json).toEqual({ python_code: 'print(1)' });
+    expect(mockPostRequest).toHaveBeenCalledTimes(1);
+    expect(mockApiLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('retries once on a transient failure and returns the eventual success', async () => {
+    mockPostRequest
+      .mockRejectedValueOnce(
+        new Error('API request failed: 500 Internal Server Error'),
+      )
+      .mockResolvedValueOnce({ python_code: 'print(2)' });
+
+    const responsePromise = POST(makeRequest({ queries: [] }));
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+    const json = await response.json();
+
+    expect(json).toEqual({ python_code: 'print(2)' });
+    expect(mockPostRequest).toHaveBeenCalledTimes(2);
+    expect(mockApiLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockApiLoggerWarn).toHaveBeenCalledWith(
+      '[BFF] python-attachment retry 1',
+      expect.objectContaining({ delayMs: 300 }),
+    );
+  });
+
+  it('returns an error response after exhausting all retries', async () => {
+    mockPostRequest.mockRejectedValue(
+      new Error('API request failed: 500 Internal Server Error'),
+    );
+
+    const responsePromise = POST(makeRequest({ queries: [] }));
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+    const json = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(json.error.operation).toBe('get-python-attachment');
+    expect(mockPostRequest).toHaveBeenCalledTimes(3);
+    expect(mockApiLoggerWarn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/portals-example/src/app/api/python-attachment/route.ts
+++ b/apps/portals-example/src/app/api/python-attachment/route.ts
@@ -3,17 +3,34 @@ import { dialApiClient, DEFAULT_MODEL_ID } from '../api';
 import { withAuth } from '../../../utils/auth/withAuth';
 import { AuthParams } from '../../../models/auth';
 import { DIAL_API_ROUTES } from '@epam/statgpt-dial-toolkit';
+import { retryWithBackoff } from '@epam/statgpt-shared-toolkit';
 import { createErrorResponse } from '../../../utils/api/create-error-response';
+import { apiLogger } from '../../../core/logger';
+
+const RETRY_ATTEMPTS = 2;
+const RETRY_BASE_DELAY_MS = 300;
 
 export const POST = withAuth(
   async (req: NextRequest, { token }: AuthParams) => {
     try {
       const body = await req.json();
 
-      const result = await dialApiClient.postRequest<{ python_code: string }>(
-        DIAL_API_ROUTES.PYTHON_ATTACHMENT(DEFAULT_MODEL_ID),
-        token?.access_token as string,
-        { body },
+      const result = await retryWithBackoff(
+        () =>
+          dialApiClient.postRequest<{ python_code: string }>(
+            DIAL_API_ROUTES.PYTHON_ATTACHMENT(DEFAULT_MODEL_ID),
+            token?.access_token as string,
+            { body },
+          ),
+        {
+          retries: RETRY_ATTEMPTS,
+          baseDelayMs: RETRY_BASE_DELAY_MS,
+          onRetry: (attempt, error, delayMs) =>
+            apiLogger.warn(`[BFF] python-attachment retry ${attempt + 1}`, {
+              delayMs,
+              error: String(error),
+            }),
+        },
       );
 
       return NextResponse.json(result);

--- a/libs/shared-toolkit/src/utils/__tests__/retry-with-backoff.spec.ts
+++ b/libs/shared-toolkit/src/utils/__tests__/retry-with-backoff.spec.ts
@@ -1,0 +1,86 @@
+/// <reference types="jest" />
+import { retryWithBackoff } from '../retry-with-backoff';
+
+describe('retryWithBackoff', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('succeeds on the first attempt without calling onRetry', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const onRetry = jest.fn();
+
+    const result = await retryWithBackoff(fn, { onRetry });
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('succeeds after N failures, calling onRetry once per failed attempt with the correct attempt/delay', async () => {
+    const error1 = new Error('fail 1');
+    const error2 = new Error('fail 2');
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(error1)
+      .mockRejectedValueOnce(error2)
+      .mockResolvedValueOnce('ok');
+    const onRetry = jest.fn();
+
+    const promise = retryWithBackoff(fn, {
+      retries: 2,
+      baseDelayMs: 300,
+      onRetry,
+    });
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenNthCalledWith(1, 0, error1, 300);
+    expect(onRetry).toHaveBeenNthCalledWith(2, 1, error2, 600);
+  });
+
+  it('exhausts retries and rethrows the last error, calling onRetry exactly `retries` times', async () => {
+    const error1 = new Error('fail 1');
+    const error2 = new Error('fail 2');
+    const error3 = new Error('fail 3');
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(error1)
+      .mockRejectedValueOnce(error2)
+      .mockRejectedValueOnce(error3);
+    const onRetry = jest.fn();
+
+    const promise = retryWithBackoff(fn, {
+      retries: 2,
+      baseDelayMs: 300,
+      onRetry,
+    });
+    promise.catch(() => {});
+    await jest.runAllTimersAsync();
+
+    await expect(promise).rejects.toBe(error3);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses default retries (2) and baseDelayMs (300) when no options are passed', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce('ok');
+
+    const promise = retryWithBackoff(fn);
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/shared-toolkit/src/utils/index.ts
+++ b/libs/shared-toolkit/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './send-request';
 export * from './conversation-url';
 export * from './conversation-mapping';
 export * from './linkify/linkify';
+export * from './retry-with-backoff';

--- a/libs/shared-toolkit/src/utils/retry-with-backoff.ts
+++ b/libs/shared-toolkit/src/utils/retry-with-backoff.ts
@@ -1,0 +1,33 @@
+export interface RetryWithBackoffOptions {
+  retries?: number;
+  baseDelayMs?: number;
+  onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+}
+
+/**
+ * Retries an async operation on any thrown error, with exponential backoff
+ * (`baseDelayMs * 2^attempt` between attempts). Retries unconditionally —
+ * callers are responsible for only wrapping operations where retrying a
+ * failed call has no unwanted side effects.
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options?: RetryWithBackoffOptions,
+): Promise<T> {
+  const retries = options?.retries ?? 2;
+  const baseDelayMs = options?.baseDelayMs ?? 300;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === retries) break;
+      const delayMs = baseDelayMs * 2 ** attempt;
+      options?.onRetry?.(attempt, error, delayMs);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}

--- a/specs/changes/2026-07-08-python-attachment-retry-design.md
+++ b/specs/changes/2026-07-08-python-attachment-retry-design.md
@@ -1,0 +1,143 @@
+# Design: Retry for Python Attachment Endpoint
+
+**Date:** 2026-07-08
+**Author:** Mikhail Hahalushka
+**Status:** Approved — ready for implementation
+
+---
+
+## Overview
+
+The python attachment endpoint (called on filters Apply, both single- and multi-dataset flows) intermittently
+returns a 500 from the external service it proxies to. The failure is not consistently reproducible — a retried
+request commonly succeeds. Since the upstream issue cannot be fixed here, this change adds an automatic retry
+with backoff around the server-side call, so a transient failure resolves silently instead of surfacing an error
+to the user.
+
+Client-side code (`invokePythonAttachment`, the browser `fetch` in `client.ts`) is unchanged. The browser still
+sends exactly one request to `/api/python-attachment` and gets exactly one response — retries happen entirely
+inside the Next.js route, on the server-to-DIAL leg.
+
+---
+
+## 1. Retry utility
+
+New file: `libs/shared-toolkit/src/utils/retry-with-backoff.ts`
+
+```ts
+export interface RetryWithBackoffOptions {
+  retries?: number; // default 2 (3 total attempts)
+  baseDelayMs?: number; // default 300
+  onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+}
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options?: RetryWithBackoffOptions,
+): Promise<T>
+```
+
+- Retries unconditionally on any thrown error — no status-code inspection. This is safe specifically for the
+  python-attachment call because it has no side effects (it regenerates code from the current filter state; it
+  is not a mutation with consequences on double-execution). The utility itself stays generic and dependency-free
+  so it can be reused for other calls later; a `shouldRetry` predicate can be added if a future consumer needs
+  status-aware retries.
+- Backoff delay is `baseDelayMs * 2^attempt` between attempts (not after the final attempt).
+- `onRetry`, if provided, is invoked once per failed-but-retryable attempt, before the delay. This keeps the
+  utility logging-agnostic — callers wire it to whatever logger they have (see Section 3).
+- Exported via `libs/shared-toolkit/src/utils/index.ts` → `libs/shared-toolkit/src/index.ts`, same pattern as
+  `send-request.ts`.
+
+---
+
+## 2. Call site
+
+`apps/portals-example/src/app/api/python-attachment/route.ts` — wrap the existing `dialApiClient.postRequest`
+call:
+
+```ts
+const result = await retryWithBackoff(
+  () =>
+    dialApiClient.postRequest<{ python_code: string }>(
+      DIAL_API_ROUTES.PYTHON_ATTACHMENT(DEFAULT_MODEL_ID),
+      token?.access_token as string,
+      { body },
+    ),
+  {
+    onRetry: (attempt, error, delayMs) =>
+      apiLogger.warn(`[BFF] python-attachment retry ${attempt + 1}`, {
+        delayMs,
+        error: String(error),
+      }),
+  },
+);
+```
+
+The surrounding `try/catch` → `createErrorResponse(error, 'get-python-attachment')` is unchanged. If all attempts
+fail, the existing error path runs exactly as it does today (already logs via `apiLogger.error`).
+
+---
+
+## 3. Logging
+
+- Per-attempt failures that still have retries left are logged via `apiLogger.warn` (existing structured logger
+  in `apps/portals-example/src/core/logger.ts`), matching the severity convention already used in
+  `create-error-response.ts` (warn = recoverable/expected-ish, error = terminal failure).
+- The final, fully-exhausted failure needs no new logging — it already goes through `createErrorResponse`, which
+  logs at `error` level.
+- Net effect on log volume: a request that eventually succeeds after 1-2 retries now produces 1-2 `warn` lines
+  instead of what would otherwise have been an immediate `error` (today, with no retry, that failure is currently
+  fatal to the request). A request that exhausts all retries produces 2 `warn` + 1 `error` instead of just 1
+  `error` — slightly more volume in the worst case, but distinguishes "flaky, self-healed" from "sustained
+  outage" in the logs.
+
+---
+
+## 4. Configuration
+
+`retries` and `baseDelayMs` are passed as explicit named constants at the `route.ts` call site (not read from
+environment variables). This is a reliability tuning knob for one specific known-flaky call, not a
+per-deployment value like `DIAL_API_URL` — there is no current need to retune it without a redeploy. Revisit
+only if a concrete operational need for runtime tuning shows up later.
+
+---
+
+## 5. Timing
+
+With defaults (`retries: 2`, `baseDelayMs: 300`), worst case (2 failures then success, or 3 failures then
+terminal error) adds up to roughly `300ms + 600ms` = 900ms of backoff on top of the call latency of each attempt,
+all within the single server-side request the browser is already waiting on.
+
+Existing stale-request protection in `invokePythonAttachment` (the `requestIdRef` counter) is unaffected — if the
+user clicks Apply again while a retry is still in flight, the eventual (slow) response is discarded exactly as it
+is today when a newer request has since started.
+
+---
+
+## 6. Testing
+
+- `libs/shared-toolkit/src/utils/__tests__/retry-with-backoff.spec.ts`: succeeds on first try (no delay, no
+  `onRetry` call); succeeds after N failures (`onRetry` called N times with correct attempt/delay values);
+  exhausts retries and rethrows the last error (`onRetry` called `retries` times, not `retries + 1`).
+- Route-level test for `python-attachment/route.ts`: mock `dialApiClient.postRequest` to fail once then succeed,
+  assert the route still returns a success response and `apiLogger.warn` was called once.
+
+---
+
+## 7. Spec update required
+
+`specs/system/filters/08-python-attachment.md` gets a short note that the server route retries the DIAL call up
+to 2 times with backoff before surfacing an error, per `.claude/rules/spec-conventions.md`.
+
+---
+
+## Out of scope
+
+- Client-side changes of any kind (UI, `invokePythonAttachment`, `api-client.ts`) — retries are fully invisible
+  to the browser.
+- Status-code-aware retry logic (e.g. skip retrying 4xx) — not needed for the one known failure mode; would add
+  fragile parsing of `dialApiClient`'s plain-`Error` message string (it does not carry a typed status code today).
+- Baking retry support into `dialApiClient.postRequest`/`request` itself — kept as an explicit per-call wrapper
+  instead, to avoid changing behavior for other call sites that already use the shared DIAL client.
+- Rolling this same change out to other apps that consume `@epam/statgpt-shared-toolkit` — tracked separately,
+  gated on publishing the updated package.

--- a/specs/system/filters/08-python-attachment.md
+++ b/specs/system/filters/08-python-attachment.md
@@ -11,6 +11,8 @@ All logic lives in:
 - `libs/conversation-view/src/utils/query-filters.ts` (`buildDataQueryWithMergedFilters`)
 - `libs/conversation-view/src/context/AttachmentsData.tsx` (single-dataset trigger)
 - `libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx` (multi-dataset trigger)
+- `apps/portals-example/src/app/api/python-attachment/route.ts` (server route, retry)
+- `libs/shared-toolkit/src/utils/retry-with-backoff.ts` (generic retry utility)
 
 ---
 
@@ -83,6 +85,26 @@ third argument controlling how UI filters are resolved to the dataset:
    `onCodeAttachmentUpdated()` callback delivers the markdown attachment to
    `ConversationView`, which calls `replacePythonAttachment()` to write it into the
    message list and then `updateConversation()` to persist to the backend.
+
+---
+
+## Server-Side Retry
+
+`getPythonAttachment(dataQueries)` calls the Next.js route at
+`apps/portals-example/src/app/api/python-attachment/route.ts`, which proxies to a
+backend endpoint that intermittently fails with a transient error. The route wraps
+the proxied call with `retryWithBackoff` (`@epam/statgpt-shared-toolkit`,
+`libs/shared-toolkit/src/utils/retry-with-backoff.ts`): up to 2 retries, exponential
+backoff starting at 300ms, retrying unconditionally on any thrown error (safe here
+because the call has no side effects). Each retried attempt is logged via
+`apiLogger.warn`; a fully exhausted failure still surfaces through the existing
+`createErrorResponse` path as an `error` log and an error response.
+
+This retry is entirely server-side — the browser sends one request to
+`/api/python-attachment` and receives one (possibly delayed) response. It is
+transparent to `invokePythonAttachment` and the stale-request protection below,
+which is unaffected: a delayed response from a superseded request is discarded the
+same way regardless of whether the delay came from retries or normal latency.
 
 ---
 


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/338

### Description of changes

The `python-attachment` endpoint (called when a user applies filters) intermittently returns a transient server error from the service it proxies to. A retried request typically succeeds, so this adds an automatic retry with backoff on the server side rather than surfacing the failure to the user.

- Added a generic `retryWithBackoff` utility to `@epam/statgpt-shared-toolkit`, retrying unconditionally on any thrown error with exponential backoff (default: 2 retries, 300ms base delay).
- Wrapped the `python-attachment` API route's call to the backend with `retryWithBackoff`. This is fully server-side — the browser sends one request and gets one response; no client-side changes.
- Each retried attempt is logged at `warn` level; a fully exhausted failure still logs at `error` level as before.
- Updated `specs/system/filters/08-python-attachment.md` with the new retry behavior, and added a design doc under `specs/changes/` documenting the approach and alternatives considered.
- Added unit tests for the retry utility and route-level tests covering first-attempt success, success-after-retry, and full exhaustion.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.