### PR TITLE
feat: format chart tooltip numbers using grid formatting settings

### DIFF
--- a/libs/conversation-view/src/context/AttachmentsData.tsx
+++ b/libs/conversation-view/src/context/AttachmentsData.tsx
@@ -355,6 +355,7 @@ export function useAttachmentsData(
       dataQuery,
       locale,
       chartStyles,
+      formattingSettings,
     );
     setCustomChartAttachment((prev) => ({
       ...prev,
@@ -370,7 +371,14 @@ export function useAttachmentsData(
         setIsChartPlottable(false);
       }
     });
-  }, [structures, dataMessage, dataQuery, locale, chartStyles]);
+  }, [
+    structures,
+    dataMessage,
+    dataQuery,
+    locale,
+    chartStyles,
+    formattingSettings,
+  ]);
 
   useEffect(() => {
     if (rawAttachments?.length) {

--- a/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
+++ b/libs/conversation-view/src/context/AttachmentsDataMultipleQueries.tsx
@@ -413,6 +413,7 @@ export function useAttachmentsDataMultipleQueries(
         visibleDataQueries,
         locale,
         chartStyles,
+        formattingSettings,
       );
       setCrossDatasetChartAttachment((prev) => ({
         ...prev,
@@ -438,6 +439,7 @@ export function useAttachmentsDataMultipleQueries(
     compatibleDataQueries,
     locale,
     chartStyles,
+    formattingSettings,
     isLoadingGridData,
     activeDatasetUrns,
   ]);

--- a/libs/conversation-view/src/utils/attachments/charting/__tests__/chart-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/__tests__/chart-data.spec.ts
@@ -139,6 +139,7 @@ describe('buildChartData', () => {
       sortedTimePeriods,
       expect.any(Array),
       undefined,
+      undefined,
     );
   });
 });
@@ -357,6 +358,7 @@ describe('buildUnit', () => {
       ['2020-01', '2020-02'],
       expect.any(Array),
       undefined,
+      undefined,
     );
   });
 
@@ -381,6 +383,7 @@ describe('buildUnit', () => {
       ['2020-Q1'],
       expect.any(Array),
       undefined,
+      undefined,
     );
   });
 
@@ -403,6 +406,7 @@ describe('buildUnit', () => {
       ['2020', '2021'],
       expect.any(Array),
       undefined,
+      undefined,
     );
   });
 
@@ -420,6 +424,7 @@ describe('buildUnit', () => {
     expect(buildChartConfig).toHaveBeenCalledWith(
       ['2020', '2021'],
       expect.any(Array),
+      undefined,
       undefined,
     );
   });
@@ -440,6 +445,7 @@ describe('buildUnit', () => {
       ['2020'],
       expect.any(Array),
       styles,
+      undefined,
     );
   });
 

--- a/libs/conversation-view/src/utils/attachments/charting/chart-config-building.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/chart-config-building.ts
@@ -5,11 +5,16 @@ import {
   DEFAULT_TICK_COLOR,
 } from '../../../constants/charting-default-colors';
 import { ChartingTooltipFormatterParams } from '../../../models/charting';
+import {
+  defaultFormatNumbers,
+  formatNumberBySign,
+} from '@epam/statgpt-shared-toolkit';
 
 export function buildChartConfig(
   timePeriods: string[],
   series: Record<string, string | unknown>[],
   styles?: ChartingStyles,
+  formattingSettings = defaultFormatNumbers,
 ): EChartsOption {
   const config: EChartsOption = {
     animation: false,
@@ -21,8 +26,21 @@ export function buildChartConfig(
 
         params.forEach((item: ChartingTooltipFormatterParams) => {
           if (item.value !== null && item.value !== undefined) {
+            const isNumeric =
+              typeof item.value === 'number' ||
+              (typeof item.value === 'string' &&
+                item.value.trim() !== '' &&
+                !Number.isNaN(Number(item.value)));
+            const displayValue = isNumeric
+              ? formatNumberBySign(String(item.value), formattingSettings)
+              : item.value;
             result +=
-              item.marker + ' ' + item.seriesName + ': ' + item.value + '<br/>';
+              item.marker +
+              ' ' +
+              item.seriesName +
+              ': ' +
+              displayValue +
+              '<br/>';
           }
         });
         return result;

--- a/libs/conversation-view/src/utils/attachments/charting/chart-data.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/chart-data.ts
@@ -12,7 +12,7 @@ import {
   FREQUENCY_DIMENSION_ID,
   Periods,
 } from '@epam/statgpt-sdmx-toolkit';
-import { DataQuery } from '@epam/statgpt-shared-toolkit';
+import { DataQuery, FormatNumbersType } from '@epam/statgpt-shared-toolkit';
 
 import { getRowsData } from '../data-grid/rows-data';
 import { ChartingStyles } from '../../../models/attachments-styles';
@@ -55,6 +55,7 @@ export function buildChartData(
   dataQuery: DataQuery | undefined,
   locale: string,
   styles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): ChartingData {
   const rows = getRowsData(data, structures, dataQuery, locale, styles, {
     includeChartData: false,
@@ -75,7 +76,15 @@ export function buildChartData(
 
   return {
     units: units.map((unit) =>
-      buildUnit(unit, structures, dataQuery, sortedTimePeriods, locale, styles),
+      buildUnit(
+        unit,
+        structures,
+        dataQuery,
+        sortedTimePeriods,
+        locale,
+        styles,
+        formattingSettings,
+      ),
     ),
   };
 }
@@ -86,6 +95,7 @@ export function createChartDataResolver(
   dataQuery: DataQuery | undefined,
   locale: string,
   styles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): () => ChartingData {
   let cachedChartingData: ChartingData | undefined;
 
@@ -96,6 +106,7 @@ export function createChartDataResolver(
       dataQuery,
       locale,
       styles,
+      formattingSettings,
     );
 
     return cachedChartingData;
@@ -109,6 +120,7 @@ export function buildSingleLineUnit(
   dataQuery: DataQuery | undefined,
   locale: string,
   styles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): ChartUnit {
   return buildUnit(
     { rows: [row] },
@@ -117,6 +129,7 @@ export function buildSingleLineUnit(
     sortedTimePeriods,
     locale,
     styles,
+    formattingSettings,
   );
 }
 
@@ -127,6 +140,7 @@ export function buildUnit(
   timePeriods: string[],
   locale: string,
   styles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): ChartUnit {
   const dimensions = getDimensionsInfo(
     unit.rows,
@@ -157,7 +171,12 @@ export function buildUnit(
     limitedByRowsAmountTo:
       unit.rows.length > MAX_LINES_PER_UNIT ? MAX_LINES_PER_UNIT : undefined,
     dimensions,
-    config: buildChartConfig(filteredTimePeriods, series, styles),
+    config: buildChartConfig(
+      filteredTimePeriods,
+      series,
+      styles,
+      formattingSettings,
+    ),
     isPlottable: hasPlottableSeries(series),
   };
 }

--- a/libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts
+++ b/libs/conversation-view/src/utils/attachments/charting/cross-dataset-chart-data.ts
@@ -3,7 +3,7 @@ import {
   getLocalizedName,
   StructuralData,
 } from '@epam/statgpt-sdmx-toolkit';
-import { DataQuery } from '@epam/statgpt-shared-toolkit';
+import { DataQuery, FormatNumbersType } from '@epam/statgpt-shared-toolkit';
 import { ChartingData } from '../../../models/charting';
 import { ChartingStyles } from '../../../models/attachments-styles';
 import { buildChartData } from './chart-data';
@@ -14,6 +14,7 @@ export function createCrossDatasetChartingDataResolver(
   dataQueries: DataQuery[],
   locale: string,
   chartStyles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): () => ChartingData {
   let cachedChartingData: ChartingData | undefined;
 
@@ -24,6 +25,7 @@ export function createCrossDatasetChartingDataResolver(
       dataQueries,
       locale,
       chartStyles,
+      formattingSettings,
     );
 
     return cachedChartingData;
@@ -42,6 +44,7 @@ export function createCrossDatasetChartingDataResolver(
  * @param dataQueries - Datasets to render, in order; matched to the maps by `urn`.
  * @param locale - Locale used to resolve localized names.
  * @param chartStyles - Optional chart styling.
+ * @param formattingSettings - Optional number formatting settings for tooltip values.
  * @returns Charting data for `CustomChartAttachment`.
  */
 export function buildCrossDatasetChartingData(
@@ -50,6 +53,7 @@ export function buildCrossDatasetChartingData(
   dataQueries: DataQuery[],
   locale: string,
   chartStyles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): ChartingData {
   const groups = dataQueries
     .filter((q) => !q.disabled)
@@ -72,6 +76,7 @@ export function buildCrossDatasetChartingData(
             dataQuery,
             locale,
             chartStyles,
+            formattingSettings,
           ).units,
         },
       ];

--- a/libs/conversation-view/src/utils/attachments/data-grid/__tests__/rows-data.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/__tests__/rows-data.spec.ts
@@ -68,6 +68,7 @@ describe('getRowsData', () => {
       dataQuery,
       'en',
       chartStyles,
+      undefined,
     );
   });
 });

--- a/libs/conversation-view/src/utils/attachments/data-grid/data-grid.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/data-grid.ts
@@ -42,6 +42,14 @@ export function buildGridData(
       constraints,
       selectedTimePeriod,
     ),
-    data: getRowsData(data, structures, dataQuery, locale, chartStyles),
+    data: getRowsData(
+      data,
+      structures,
+      dataQuery,
+      locale,
+      chartStyles,
+      undefined,
+      formattingSettings,
+    ),
   };
 }

--- a/libs/conversation-view/src/utils/attachments/data-grid/rows-data.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/rows-data.ts
@@ -7,7 +7,7 @@ import {
   StructuralData,
   TimeSeries,
 } from '@epam/statgpt-sdmx-toolkit';
-import { DataQuery } from '@epam/statgpt-shared-toolkit';
+import { DataQuery, FormatNumbersType } from '@epam/statgpt-shared-toolkit';
 
 import { getConvertedData } from './get-converted-data';
 import { GridData } from '../../../types/data-grid/grid-data';
@@ -26,6 +26,7 @@ export function getRowsData(
   locale: string,
   chartStyles?: ChartingStyles,
   options: GetRowsDataOptions = {},
+  formattingSettings?: FormatNumbersType,
 ): GridData[] {
   const timeSeries: TimeSeries[] = data == null ? [] : getParsedResponse(data);
   const dimensions = getDimensions(structures)?.dimensions || [];
@@ -43,6 +44,7 @@ export function getRowsData(
     dataQuery,
     locale,
     chartStyles,
+    formattingSettings,
   );
 }
 
@@ -53,6 +55,7 @@ function extendDataWithChart(
   dataQuery: DataQuery | undefined,
   locale: string,
   chartStyles?: ChartingStyles,
+  formattingSettings?: FormatNumbersType,
 ): GridData[] {
   const timePeriods = getTimePeriods(data);
   const sortedTimePeriods = timePeriods.sort((a, b) => sortPeriods(a, b));
@@ -67,6 +70,7 @@ function extendDataWithChart(
           dataQuery,
           locale,
           chartStyles,
+          formattingSettings,
         ),
     };
   });


### PR DESCRIPTION
### Applicable issues
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/336

### Description of changes

Chart tooltips previously rendered raw numeric values with no formatting (no thousands separators, no decimal handling), inconsistent with the numeric formatting already applied to AG Grid cells.

This threads the existing `formattingSettings` (`FormatNumbersType`) configuration through the chart-building call chain — `buildChartConfig`, `buildChartData`/`buildUnit`/`buildSingleLineUnit`, the cross-dataset chart resolver, and the inline per-row grid chart cell — so tooltip values are formatted with `formatNumberBySign`, the same formatter already used for grid cells.

### Checklist
- [x] Title of the pull request follows Conventional Commits specification

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.