### PR TITLE
fix: disable grid attachment actions until AG Grid finishes rendering

### DIFF
--- a/apps/portals-example/src/scss/advance-view.scss
+++ b/apps/portals-example/src/scss/advance-view.scss
@@ -6,6 +6,14 @@
     svg {
       @apply text-primary;
     }
+
+    &:disabled {
+      @apply border-neutrals-800;
+
+      svg {
+        @apply text-neutrals-800;
+      }
+    }
   }
 
   &-button-divider {

--- a/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentRenderer.tsx
@@ -116,6 +116,7 @@ export const AttachmentRenderer: FC<Props> = ({
   const [modalState, setModalState] = useState(PopUpState.Closed);
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const [showLimitMessage, setShowLimitMessage] = useState(false);
+  const [isGridRendered, setIsGridRendered] = useState(false);
   const downloadType = DownloadTypeOptions.DATA_IN_TABLE;
 
   // Lock the scroll position across a visualization switch so the conversation
@@ -165,6 +166,14 @@ export const AttachmentRenderer: FC<Props> = ({
 
   const selectedAttachment = attachments[selectedAttachmentIndex] || null;
 
+  const isGridTypeAttachmentSelected =
+    !!selectedAttachment &&
+    (isCustomGridAttachment(selectedAttachment) ||
+      isCrossDatasetGrid(selectedAttachment));
+
+  const areActionsDisabled =
+    !!isDataLoading || (isGridTypeAttachmentSelected && !isGridRendered);
+
   useEffect(() => {
     setShowLoading(
       isDataSetAttachments && (datasets == null || datasets?.length == 0),
@@ -185,6 +194,10 @@ export const AttachmentRenderer: FC<Props> = ({
   const onCloseModal = useCallback(() => {
     setModalState(PopUpState.Closed);
   }, [setModalState]);
+
+  const handleGridRenderedChange = useCallback((isRendered: boolean) => {
+    setIsGridRendered(isRendered);
+  }, []);
 
   const isExternalLinkIncludeFilters =
     attachmentsConfig?.isExternaLinkIncludeFilters;
@@ -315,6 +328,7 @@ export const AttachmentRenderer: FC<Props> = ({
                     showAdvancedView
                   }
                   onAdvancedViewClick={onOpenAdvancedView}
+                  advancedViewDisabled={areActionsDisabled}
                   query={externalLink}
                 />
               )}
@@ -345,6 +359,7 @@ export const AttachmentRenderer: FC<Props> = ({
                     onOpenAdvancedView={onOpenAdvancedView}
                     isTableSettingsOpen={isTableSettingsOpen}
                     onTableSettingsOpen={onTableSettingsOpen}
+                    disabled={areActionsDisabled}
                   />
                   {selectedAttachment != null && (
                     <AttachmentsContentRenderer
@@ -356,6 +371,7 @@ export const AttachmentRenderer: FC<Props> = ({
                       onOpenAdvancedView={onOpenAdvancedView}
                       showLimitMessage={setShowLimitMessage}
                       onGridApiReady={onGridApiReady}
+                      onGridRenderedChange={handleGridRenderedChange}
                       externalLink={externalLink}
                       externalLinksMap={externalLinksMap}
                     />

--- a/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
@@ -35,6 +35,7 @@ interface Props {
   onOpenAdvancedView?: () => void;
   showLimitMessage: (p: boolean) => void;
   onGridApiReady?: (api: GridApi) => void;
+  onGridRenderedChange?: (isRendered: boolean) => void;
 }
 
 const AttachmentsContentRenderer: FC<Props> = ({
@@ -48,6 +49,7 @@ const AttachmentsContentRenderer: FC<Props> = ({
   onOpenAdvancedView,
   showLimitMessage,
   onGridApiReady,
+  onGridRenderedChange,
 }) => {
   return (
     <div className="flex min-h-0 w-full flex-1 justify-center">
@@ -73,6 +75,7 @@ const AttachmentsContentRenderer: FC<Props> = ({
           fixHeight={!isOpenedAdvancedView}
           showLimitMessage={showLimitMessage}
           onApiReady={onGridApiReady}
+          onGridRenderedChange={onGridRenderedChange}
           externalLink={externalLink}
         />
       )}
@@ -84,6 +87,7 @@ const AttachmentsContentRenderer: FC<Props> = ({
           fixHeight={!isOpenedAdvancedView}
           showLimitMessage={showLimitMessage}
           onApiReady={onGridApiReady}
+          onGridRenderedChange={onGridRenderedChange}
           externalLink={externalLink}
           externalLinksMap={externalLinksMap}
         />

--- a/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsViewModePanel.tsx
@@ -43,6 +43,7 @@ interface Props {
   onOpenAdvancedView?: () => void;
   isTableSettingsOpen?: boolean;
   onTableSettingsOpen?: () => void;
+  disabled?: boolean;
 }
 
 const AttachmentsViewModePanel: FC<Props> = ({
@@ -60,6 +61,7 @@ const AttachmentsViewModePanel: FC<Props> = ({
   onOpenAdvancedView,
   isTableSettingsOpen,
   onTableSettingsOpen,
+  disabled,
 }) => {
   const { isTableSettingsFeatureEnabled } = useConversationViewFeatureToggles();
   const { isOpenedAdvancedView } = useAdvancedView();
@@ -159,6 +161,7 @@ const AttachmentsViewModePanel: FC<Props> = ({
             )}
             onClick={onDownloadClick}
             iconBefore={downloadIcon}
+            disabled={disabled}
           />
         )}
         {shouldShowDownloadButton && shouldShowAdvancedViewButton && (
@@ -172,12 +175,13 @@ const AttachmentsViewModePanel: FC<Props> = ({
               textClassName="ml-1 h4 md:hidden"
               iconBefore={attachmentsStyles?.openAdvancedViewIcon}
               onClick={onOpenAdvancedView}
+              disabled={disabled}
             />
           </div>
         )}
         {shouldShowColumnsButton && (
           <Button
-            disabled={isTableSettingsOpen}
+            disabled={isTableSettingsOpen || disabled}
             buttonClassName="text-button-tertiary !p-0 !h-6"
             textClassName="ml-1 h4"
             iconBefore={
@@ -211,6 +215,7 @@ const AttachmentsViewModePanel: FC<Props> = ({
           description={tooltipDescription}
           onReferenceClick={onOpenAdvancedView}
           shouldCloseTooltip={isOpenedAdvancedView}
+          disabled={disabled}
         />
       )}
     </div>

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
@@ -62,6 +62,7 @@ interface Props {
   externalLinksMap?: Map<string, string>;
   showLimitMessage?: (p: boolean) => void;
   onApiReady?: (api: GridApi) => void;
+  onGridRenderedChange?: (isRendered: boolean) => void;
 }
 
 const CrossDatasetGridAttachment: FC<Props> = ({
@@ -73,8 +74,10 @@ const CrossDatasetGridAttachment: FC<Props> = ({
   externalLinksMap,
   showLimitMessage,
   onApiReady,
+  onGridRenderedChange,
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isGridRendered, setIsGridRendered] = useState<boolean>(false);
   const [rowData, setRowData] = useState<GridData[]>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>();
   const [gridHeight, setGridHeight] = useState<number>(400);
@@ -83,8 +86,13 @@ const CrossDatasetGridAttachment: FC<Props> = ({
   const prevColIdsRef = useRef<string[]>([]);
 
   useEffect(() => {
+    onGridRenderedChange?.(isGridRendered);
+  }, [isGridRendered, onGridRenderedChange]);
+
+  useEffect(() => {
     if (attachment.gridContent == null) {
       setIsLoading(true);
+      setIsGridRendered(false);
     } else {
       const columns = attachment.gridContent.columns.map((col) => {
         if (col.colId === CHART_COLUMN_ID) {
@@ -135,6 +143,10 @@ const CrossDatasetGridAttachment: FC<Props> = ({
     [onApiReady],
   );
 
+  const handleFirstDataRendered = useCallback(() => {
+    setIsGridRendered(true);
+  }, []);
+
   const gridContext = useMemo(
     () => ({ externalLink, externalLinksMap }),
     [externalLink, externalLinksMap],
@@ -167,9 +179,17 @@ const CrossDatasetGridAttachment: FC<Props> = ({
         components={gridComponents}
         valueCache
         onGridReady={handleGridReady}
+        onFirstDataRendered={handleFirstDataRendered}
       />
     ),
-    [rowData, columnDefs, gridContext, gridComponents, handleGridReady],
+    [
+      rowData,
+      columnDefs,
+      gridContext,
+      gridComponents,
+      handleGridReady,
+      handleFirstDataRendered,
+    ],
   );
 
   if (isLoading || isDataLoading) {

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx
@@ -64,6 +64,7 @@ interface Props {
   externalLink?: string;
   showLimitMessage?: (p: boolean) => void;
   onApiReady?: (api: GridApi) => void;
+  onGridRenderedChange?: (isRendered: boolean) => void;
 }
 
 export const CustomDataGridAttachment: FC<Props> = ({
@@ -75,9 +76,11 @@ export const CustomDataGridAttachment: FC<Props> = ({
   externalLink,
   showLimitMessage,
   onApiReady,
+  onGridRenderedChange,
 }) => {
   const { titles } = useConversationViewStyles();
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isGridRendered, setIsGridRendered] = useState<boolean>(false);
   const [rowData, setRowData] = useState<GridData[]>([]);
   const [columnDefs, setColumnDefs] = useState<ColDef[]>();
   const [gridHeight, setGridHeight] = useState<number>(400);
@@ -91,8 +94,13 @@ export const CustomDataGridAttachment: FC<Props> = ({
     useOnboarding();
 
   useEffect(() => {
+    onGridRenderedChange?.(isGridRendered);
+  }, [isGridRendered, onGridRenderedChange]);
+
+  useEffect(() => {
     if (attachment.grid_data == null) {
       setIsLoading(true);
+      setIsGridRendered(false);
     } else {
       const columns = attachment.grid_data.columns.map((col) => {
         if (col.colId === CHART_COLUMN_ID) {
@@ -170,6 +178,10 @@ export const CustomDataGridAttachment: FC<Props> = ({
     [onApiReady],
   );
 
+  const handleFirstDataRendered = useCallback(() => {
+    setIsGridRendered(true);
+  }, []);
+
   const gridContext = useMemo(() => ({ externalLink }), [externalLink]);
   const gridComponents = useMemo(
     () => ({
@@ -196,9 +208,17 @@ export const CustomDataGridAttachment: FC<Props> = ({
         tooltipShowMode="whenTruncated"
         components={gridComponents}
         valueCache
+        onFirstDataRendered={handleFirstDataRendered}
       />
     ),
-    [rowData, columnDefs, handleGridReady, gridContext, gridComponents],
+    [
+      rowData,
+      columnDefs,
+      handleGridReady,
+      handleFirstDataRendered,
+      gridContext,
+      gridComponents,
+    ],
   );
 
   if (isLoading || isDataLoading) {

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__tests__/CrossDatasetGridAttachment.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__tests__/CrossDatasetGridAttachment.spec.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import type { GridReadyEvent } from 'ag-grid-community';
+import { CrossDatasetGridAttachment } from '../CrossDatasetGridAttachment';
+import { CrossDatasetGridAttachmentType } from '../../../../models/attachments';
+
+jest.mock('ag-grid-community', () => ({
+  ModuleRegistry: { registerModules: jest.fn() },
+  ClientSideRowModelModule: {},
+  TooltipModule: {},
+  ValueCacheModule: {},
+  ColumnApiModule: {},
+  CellStyleModule: {},
+  EventApiModule: {},
+  RenderApiModule: {},
+}));
+
+let capturedGridProps: {
+  onGridReady?: (event: GridReadyEvent) => void;
+  onFirstDataRendered?: () => void;
+} = {};
+
+jest.mock('ag-grid-react', () => ({
+  AgGridReact: (props: {
+    onGridReady?: (event: GridReadyEvent) => void;
+    onFirstDataRendered?: () => void;
+  }) => {
+    capturedGridProps = props;
+    return <div data-testid="ag-grid-stub" />;
+  },
+}));
+
+jest.mock('@epam/statgpt-ui-components', () => ({
+  Loader: () => <div data-testid="loader" />,
+  MOBILE_BREAKPOINT: 768,
+  SERIES_LIMIT: 1000,
+  useIsMobile: () => false,
+}));
+
+const GRID_CONTENT = {
+  data: [{ id: '1' }],
+  columns: [{ colId: 'id', field: 'id' }],
+};
+
+function buildAttachment(
+  overrides: Partial<CrossDatasetGridAttachmentType> = {},
+): CrossDatasetGridAttachmentType {
+  return {
+    type: 'cross_dataset_grid',
+    title: 'Cross dataset grid',
+    gridContent: GRID_CONTENT,
+    ...overrides,
+  } as CrossDatasetGridAttachmentType;
+}
+
+describe('CrossDatasetGridAttachment', () => {
+  beforeEach(() => {
+    capturedGridProps = {};
+  });
+
+  it('reports not-rendered before AG Grid fires onFirstDataRendered', () => {
+    const onGridRenderedChange = jest.fn();
+    render(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment()}
+        onGridRenderedChange={onGridRenderedChange}
+      />,
+    );
+
+    expect(onGridRenderedChange).toHaveBeenCalledWith(false);
+    expect(onGridRenderedChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('reports rendered once AG Grid fires onFirstDataRendered', () => {
+    const onGridRenderedChange = jest.fn();
+    render(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment()}
+        onGridRenderedChange={onGridRenderedChange}
+      />,
+    );
+
+    act(() => {
+      capturedGridProps.onFirstDataRendered?.();
+    });
+
+    expect(onGridRenderedChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('does not mount AG Grid while the attachment has no gridContent yet', () => {
+    const onGridRenderedChange = jest.fn();
+    const { queryByTestId } = render(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment({ gridContent: undefined })}
+        onGridRenderedChange={onGridRenderedChange}
+      />,
+    );
+
+    expect(queryByTestId('ag-grid-stub')).toBeNull();
+    expect(queryByTestId('loader')).not.toBeNull();
+    expect(onGridRenderedChange).toHaveBeenCalledWith(false);
+  });
+
+  it('resets to not-rendered when the attachment starts a new load', () => {
+    const onGridRenderedChange = jest.fn();
+    const { rerender } = render(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment()}
+        onGridRenderedChange={onGridRenderedChange}
+      />,
+    );
+
+    act(() => {
+      capturedGridProps.onFirstDataRendered?.();
+    });
+    expect(onGridRenderedChange).toHaveBeenLastCalledWith(true);
+
+    rerender(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment({ gridContent: undefined })}
+        onGridRenderedChange={onGridRenderedChange}
+      />,
+    );
+
+    expect(onGridRenderedChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/libs/conversation-view/src/components/Attachments/__tests__/AttachmentsViewModePanel.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/__tests__/AttachmentsViewModePanel.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AttachmentsViewModePanel from '../AttachmentsViewModePanel';
+import { Attachment } from '@epam/ai-dial-shared';
+
+jest.mock('../../../context/ConversationViewFeatureTogglesContext', () => ({
+  useConversationViewFeatureToggles: () => ({
+    isTableSettingsFeatureEnabled: true,
+  }),
+}));
+
+jest.mock('../../../context/AdvancedViewContext', () => ({
+  useAdvancedView: () => ({ isOpenedAdvancedView: false }),
+}));
+
+jest.mock('../../../context/ConversationViewStylesContext', () => ({
+  useConversationViewStyles: () => ({ titles: {} }),
+}));
+
+jest.mock('../../../context/OnboardingContext', () => ({
+  useOnboarding: () => ({
+    onboardingFileSchema: undefined,
+    isShowOnboarding: false,
+  }),
+}));
+
+const GRID_ATTACHMENT = {
+  type: 'custom_data_grid',
+  title: 'Data grid',
+} as Attachment;
+
+const commonProps = {
+  attachments: [GRID_ATTACHMENT],
+  selectedAttachmentIndex: 0,
+  selectedAttachment: GRID_ATTACHMENT,
+  onSelectedAttachmentChange: jest.fn(),
+  onDownloadClick: jest.fn(),
+  onOpenAdvancedView: jest.fn(),
+  onTableSettingsOpen: jest.fn(),
+  attachmentsStyles: {
+    downloadTitle: 'Download',
+    advancedViewTitle: 'Advanced view',
+    tableSettings: 'Table settings',
+  },
+};
+
+// `showAdvancedView` gates the Advanced view button; `!showAdvancedView` gates
+// the Table settings button — they are mutually exclusive, so each mode is
+// exercised with its own render.
+function renderWithAdvancedView(disabled?: boolean) {
+  render(
+    <AttachmentsViewModePanel
+      {...commonProps}
+      showAdvancedView
+      disabled={disabled}
+    />,
+  );
+}
+
+function renderWithTableSettings(disabled?: boolean) {
+  render(
+    <AttachmentsViewModePanel
+      {...commonProps}
+      showAdvancedView={false}
+      disabled={disabled}
+    />,
+  );
+}
+
+describe('AttachmentsViewModePanel', () => {
+  it('enables Download and Advanced view buttons when not disabled', () => {
+    renderWithAdvancedView(false);
+
+    expect(screen.getByText('Download').closest('button')).toBeEnabled();
+    expect(screen.getByText('Advanced view').closest('button')).toBeEnabled();
+  });
+
+  it('disables Download and Advanced view buttons when disabled', () => {
+    renderWithAdvancedView(true);
+
+    expect(screen.getByText('Download').closest('button')).toBeDisabled();
+    expect(screen.getByText('Advanced view').closest('button')).toBeDisabled();
+  });
+
+  it('enables the Table settings button when not disabled', () => {
+    renderWithTableSettings(false);
+
+    expect(screen.getByText('Table settings').closest('button')).toBeEnabled();
+  });
+
+  it('disables the Table settings button when disabled', () => {
+    renderWithTableSettings(true);
+
+    expect(screen.getByText('Table settings').closest('button')).toBeDisabled();
+  });
+});

--- a/libs/conversation-view/src/components/Tooltip/Tooltip.tsx
+++ b/libs/conversation-view/src/components/Tooltip/Tooltip.tsx
@@ -26,6 +26,7 @@ interface Props {
   shouldCloseTooltip?: boolean;
   shouldMoveToNextStep?: boolean;
   supressReferenceClick?: boolean;
+  disabled?: boolean;
 }
 
 export const Tooltip: FC<Props> = ({
@@ -36,6 +37,7 @@ export const Tooltip: FC<Props> = ({
   shouldCloseTooltip,
   shouldMoveToNextStep,
   supressReferenceClick,
+  disabled,
 }) => {
   const [open, setOpen] = useState<boolean>(true);
   const [isClosed, setIsClosed] = useState(false);
@@ -96,6 +98,8 @@ export const Tooltip: FC<Props> = ({
   }, [shouldCloseTooltip, close, isClosed]);
 
   const onOverlayItemClick = () => {
+    if (disabled) return;
+
     if (onReferenceClick) {
       onReferenceClick?.();
 

--- a/libs/conversation-view/src/components/Tooltip/__tests__/Tooltip.spec.tsx
+++ b/libs/conversation-view/src/components/Tooltip/__tests__/Tooltip.spec.tsx
@@ -1,0 +1,50 @@
+import React, { useRef } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { Tooltip } from '../Tooltip';
+import { OnboardingProvider } from '../../../context/OnboardingContext';
+
+// FloatingPortal renders into document.body, not the render() container.
+const getOverlay = () =>
+  document.body.querySelector('.outline-block') as HTMLElement;
+
+const TooltipHarness = ({
+  onReferenceClick,
+  disabled,
+}: {
+  onReferenceClick?: () => void;
+  disabled?: boolean;
+}) => {
+  const reference = useRef<HTMLDivElement>(null);
+  return (
+    <OnboardingProvider>
+      <div ref={reference}>Target</div>
+      <Tooltip
+        reference={reference}
+        title="Title"
+        description="Description"
+        onReferenceClick={onReferenceClick}
+        disabled={disabled}
+      />
+    </OnboardingProvider>
+  );
+};
+
+describe('Tooltip', () => {
+  it('calls onReferenceClick when the overlay is clicked', () => {
+    const onReferenceClick = jest.fn();
+    render(<TooltipHarness onReferenceClick={onReferenceClick} />);
+
+    fireEvent.click(getOverlay());
+
+    expect(onReferenceClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onReferenceClick when disabled is true', () => {
+    const onReferenceClick = jest.fn();
+    render(<TooltipHarness onReferenceClick={onReferenceClick} disabled />);
+
+    fireEvent.click(getOverlay());
+
+    expect(onReferenceClick).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ui-components/src/components/RequestLimit/RequestLimit.tsx
+++ b/libs/ui-components/src/components/RequestLimit/RequestLimit.tsx
@@ -27,6 +27,7 @@ interface Props {
   isDownload?: boolean;
   showAdvancedViewButton?: boolean;
   onAdvancedViewClick?: () => void;
+  advancedViewDisabled?: boolean;
   query?: string;
 }
 
@@ -35,6 +36,7 @@ export const RequestLimitMessage: FC<Props> = ({
   isDownload,
   showAdvancedViewButton,
   onAdvancedViewClick,
+  advancedViewDisabled,
   query,
 }) => {
   return (
@@ -82,8 +84,17 @@ export const RequestLimitMessage: FC<Props> = ({
 
       {showAdvancedViewButton && (
         <span
-          onClick={() => onAdvancedViewClick?.()}
-          className="h4 flex cursor-pointer items-center gap-x-[4px] text-primary"
+          onClick={() => {
+            if (advancedViewDisabled) return;
+            onAdvancedViewClick?.();
+          }}
+          aria-disabled={advancedViewDisabled}
+          className={classNames(
+            'h4 flex items-center gap-x-[4px] text-primary',
+            advancedViewDisabled
+              ? 'cursor-not-allowed opacity-50'
+              : 'cursor-pointer',
+          )}
         >
           {limitMessages?.editIcon}
           {limitMessages?.refineInAdvancedView}

--- a/libs/ui-components/src/components/RequestLimit/__tests__/RequestLimit.spec.tsx
+++ b/libs/ui-components/src/components/RequestLimit/__tests__/RequestLimit.spec.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RequestLimitMessage } from '../RequestLimit';
+
+describe('RequestLimitMessage', () => {
+  it('calls onAdvancedViewClick when the refine link is clicked', () => {
+    const onAdvancedViewClick = jest.fn();
+    render(
+      <RequestLimitMessage
+        showAdvancedViewButton
+        onAdvancedViewClick={onAdvancedViewClick}
+        limitMessages={{ refineInAdvancedView: 'Refine in advanced view' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Refine in advanced view'));
+
+    expect(onAdvancedViewClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onAdvancedViewClick when advancedViewDisabled is true', () => {
+    const onAdvancedViewClick = jest.fn();
+    render(
+      <RequestLimitMessage
+        showAdvancedViewButton
+        advancedViewDisabled
+        onAdvancedViewClick={onAdvancedViewClick}
+        limitMessages={{ refineInAdvancedView: 'Refine in advanced view' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Refine in advanced view'));
+
+    expect(onAdvancedViewClick).not.toHaveBeenCalled();
+  });
+
+  it('sets aria-disabled and dims the refine link when advancedViewDisabled is true', () => {
+    render(
+      <RequestLimitMessage
+        showAdvancedViewButton
+        advancedViewDisabled
+        limitMessages={{ refineInAdvancedView: 'Refine in advanced view' }}
+      />,
+    );
+
+    const link = screen.getByText('Refine in advanced view');
+
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+    expect(link.className).toContain('cursor-not-allowed');
+    expect(link.className).toContain('opacity-50');
+  });
+
+  it('does not set aria-disabled when advancedViewDisabled is not set', () => {
+    render(
+      <RequestLimitMessage
+        showAdvancedViewButton
+        limitMessages={{ refineInAdvancedView: 'Refine in advanced view' }}
+      />,
+    );
+
+    const link = screen.getByText('Refine in advanced view');
+
+    expect(link.getAttribute('aria-disabled')).toBeNull();
+    expect(link.className).toContain('cursor-pointer');
+  });
+
+  it('does not render the refine link when showAdvancedViewButton is false', () => {
+    render(
+      <RequestLimitMessage
+        limitMessages={{ refineInAdvancedView: 'Refine in advanced view' }}
+      />,
+    );
+
+    expect(screen.queryByText('Refine in advanced view')).toBeNull();
+  });
+});

--- a/specs/system/filters/11-attachment-view-switching.md
+++ b/specs/system/filters/11-attachment-view-switching.md
@@ -16,6 +16,8 @@ Key files:
 - `libs/conversation-view/src/components/Attachments/CustomAttachments/CustomGridAttachment.tsx`
 - `libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx`
 - `libs/conversation-view/src/components/Attachments/CustomAttachments/GridContainer.tsx`
+- `libs/conversation-view/src/components/Tooltip/Tooltip.tsx`
+- `libs/ui-components/src/components/RequestLimit/RequestLimit.tsx`
 
 ---
 
@@ -117,6 +119,108 @@ reason. See `99-gotchas.md` → "min-height only reserves space on the flex main
 
 ---
 
+## Action-Readiness Gating (Download / Advanced View / Table Settings)
+
+`isDataLoading`/`isLoading` (above) only cover the **upstream** fetch — for
+`CrossDatasetGridAttachment` and `CustomGridAttachment` that means the SDMX data (and,
+in cross-dataset mode, the merge step) arriving. Once that flips to `false`, AG Grid still
+has to do its own first paint of the row model, which is not instantaneous for a large
+grid. Without a separate signal for that, `AttachmentsViewModePanel`'s Download/Advanced
+View buttons — and every other UI entry point that opens Advanced View or Table Settings —
+were clickable during that gap.
+
+### The `isGridRendered` signal
+
+Both grid attachments track a second, local `isGridRendered` boolean, distinct from
+`isLoading`:
+
+```tsx
+// CustomGridAttachment.tsx / CrossDatasetGridAttachment.tsx
+const [isGridRendered, setIsGridRendered] = useState(false);
+
+useEffect(() => {
+  if (attachment.grid_data /* or gridContent */ == null) {
+    setIsLoading(true);
+    setIsGridRendered(false);   // reset alongside isLoading
+  } else {
+    ...
+    setIsLoading(false);
+  }
+}, [...]);
+
+const handleFirstDataRendered = useCallback(() => setIsGridRendered(true), []);
+// <AgGridReact ... onFirstDataRendered={handleFirstDataRendered} />
+```
+
+`isGridRendered` is only ever cleared in the same branch that sets `isLoading = true`,
+which forces the `isLoading || isDataLoading` early return — unmounting `AgGridReact`
+entirely. Because of that coupling, every loading cycle necessarily remounts a fresh
+`AgGridReact` instance, so `onFirstDataRendered` (which AG Grid only fires once per
+instance) reliably refires on each cycle rather than staying permanently `false`.
+
+### Propagation to the toolbar
+
+`isGridRendered` bubbles up via an `onGridRenderedChange` callback prop:
+
+```
+CrossDatasetGridAttachment / CustomGridAttachment
+  → onGridRenderedChange
+    → AttachmentsContentRenderer (passthrough)
+      → AttachmentRenderer: setIsGridRendered(...)
+```
+
+`AttachmentRenderer` combines it with `isDataLoading` and the selected attachment's type:
+
+```tsx
+const isGridTypeAttachmentSelected =
+  !!selectedAttachment &&
+  (isCustomGridAttachment(selectedAttachment) || isCrossDatasetGrid(selectedAttachment));
+
+const areActionsDisabled =
+  !!isDataLoading || (isGridTypeAttachmentSelected && !isGridRendered);
+```
+
+`areActionsDisabled` is passed to `AttachmentsViewModePanel` as `disabled`, which sets the
+native `disabled` attribute (not just a style) on the Download, Advanced View, and Table
+Settings buttons — the buttons stay mounted throughout, so there is no additional
+mount/unmount jump beyond the existing loading placeholder.
+
+### Other entry points into the same actions
+
+Two other UI elements call the same "open Advanced View" handler outside
+`AttachmentsViewModePanel`'s own button, and both needed the same gate wired in
+separately:
+
+- **`RequestLimitMessage`**'s "refine in advanced view" text link (rendered directly by
+  `AttachmentRenderer`, not by `AttachmentsViewModePanel`) takes an `advancedViewDisabled`
+  prop, fed the same `areActionsDisabled`. It no-ops the click and dims the link
+  (`cursor-not-allowed opacity-50`) instead of leaving it fully interactive-looking.
+- **`Tooltip`**'s onboarding overlay (`FloatingPortal`-rendered click-catcher shown over the
+  highlighted Advanced View button during the onboarding walkthrough) calls
+  `onReferenceClick` directly, bypassing the button's own `disabled` attribute since it
+  isn't clicking the button. `Tooltip` takes a `disabled` prop that short-circuits
+  `onOverlayItemClick` before it fires `onReferenceClick`; the tooltip's own close (✕)
+  button is unaffected, so onboarding isn't stuck if the grid is slow to render.
+
+### Known limitation — single grid per message
+
+`isGridRendered` is only reset when `attachment.gridContent`/`grid_data` transitions
+through `null` (a real loading dip). If a message ever renders **two** grid-type
+attachments and the user switches from one to another whose data is already resolved (no
+loading dip in between — e.g. served from a shared cache), `AgGridReact` never
+unmounts/remounts for that switch, so `onFirstDataRendered` won't refire and
+`isGridRendered` carries over stale from the previous attachment. The toolbar would read
+"ready" slightly before AG Grid finishes applying the new attachment's `rowData`.
+
+This is not reachable today — a message renders at most one grid-type attachment (the
+rest are Chart/Code sample/etc.), so there is never a second grid attachment to switch to.
+If that assumption changes (e.g. multiple grids per message), this reset logic needs to
+key off attachment identity rather than `gridContent == null`, and likely switch the
+readiness signal to `onModelUpdated` (which fires on every row-model change, not just the
+first paint) since the grid instance would no longer remount on every switch.
+
+---
+
 ## Scroll-Position Lock
 
 Even with no collapse, switching between views of different heights (e.g. a short grid → a
@@ -192,3 +296,11 @@ the at-the-bottom + shorter case.
 - Tab switching is local state in `AttachmentRenderer`; it must not trigger a
   `messages`/`isStreaming` change, or `ChatMessages`' `scrollToBottom` effect would fire and
   override the lock.
+- `isGridRendered` must only be cleared in the same branch that sets `isLoading = true`
+  (attachment's grid content going `null`). Clearing it anywhere else without also forcing
+  `AgGridReact` to unmount/remount would leave no path back to `true`, since
+  `onFirstDataRendered` only fires once per grid instance.
+- Any new entry point that opens Advanced View or Table Settings from outside
+  `AttachmentsViewModePanel` must be wired to the same `areActionsDisabled`/`disabled` gate
+  — `RequestLimitMessage`'s link and the onboarding `Tooltip` overlay both needed this after
+  the gate was introduced; a bypass there defeats the button-level gating entirely.


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/300

### Description of changes

For large cross-dataset grids, the Download/Advanced View/Table Settings buttons became clickable as soon as the upstream data finished loading — but AG Grid itself could still be a moment away from actually painting the rows. This adds a second readiness signal (`isGridRendered`, driven by AG Grid's `onFirstDataRendered`) and gates those actions on it, in addition to the existing data-loading flag.

- Buttons stay mounted and simply get the native `disabled` attribute — no layout jump.
- Closed two other paths into the same actions that bypassed the button-level gate: the "refine in advanced view" link in the series-limit banner, and the onboarding tooltip's overlay click.
- Fixed the Advanced View button's disabled style, which previously kept its blue border/icon regardless of the `disabled` attribute.
- Added tests for the new gating logic and updated the relevant system spec (`specs/system/filters/11-attachment-view-switching.md`).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.