### PR TITLE
fix: prevent mobile viewport scroll bounce and full-width advanced view panel

### DIFF
--- a/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
+++ b/apps/portals-example/src/components/ConversationView/ConversationViewWrapper.tsx
@@ -516,7 +516,7 @@ const ConversationViewWrapper: FC<Props> = ({
         className={classNames(
           'flex flex-col h-full',
           isOpenedAdvancedView
-            ? 'w-[422px] border border-neutrals-400'
+            ? 'w-full sm-min:w-[422px] border border-neutrals-400'
             : 'w-full',
           isOpenedAdvancedView && isChatCollapsed && 'hidden',
         )}

--- a/libs/ui-components/src/scss/styles-tailwind.scss
+++ b/libs/ui-components/src/scss/styles-tailwind.scss
@@ -1,7 +1,9 @@
 @layer base {
   html,
   body {
-    @apply h-full w-full text-neutrals-1000 overflow-hidden;
+    @apply w-full text-neutrals-1000 overflow-hidden overscroll-none;
+    height: 100%; // fallback for browsers without dvh support
+    height: 100dvh; // tracks the real mobile viewport as the address bar shows/hides
   }
 
   input {


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/329

### Description of changes

- Fix advanced view chat panel taking a fixed 422px width on small viewports; now full-width below the `sm-min` breakpoint.
- Stop the mobile browser scroll-bounce that revealed content outside the viewport, by adding `overscroll-behavior: none` and switching to dynamic viewport height (`100dvh`, with a `100%` fallback) on `html`/`body`.

### Checklist

- [x] Title of the pull request follows Conventional Commits specification

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.