### PR TITLE
feat: expose chart canvas and DOM styling overrides

### DIFF
--- a/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/AttachmentsContentRenderer.tsx
@@ -103,6 +103,12 @@ const AttachmentsContentRenderer: FC<Props> = ({
           limitationInfoContentClassName={
             attachmentsStyles?.limitationInfoContentClassName
           }
+          transformOption={attachmentsStyles?.chartingStyles?.transformOption}
+          contentClassName={attachmentsStyles?.chartContentClassName}
+          chartAreaClassName={attachmentsStyles?.chartAreaClassName}
+          chartBodyClassName={attachmentsStyles?.chartBodyClassName}
+          sliderClassName={attachmentsStyles?.chartSliderClassName}
+          sidebarClassName={attachmentsStyles?.chartSidebarClassName}
         />
       )}
       {isUrlAttachment(selectedAttachment) && (

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/ChartSidebar.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/ChartSidebar.tsx
@@ -2,19 +2,21 @@
 
 import { FC } from 'react';
 import { DimensionInfo } from '../../../models/charting';
-import classNames from 'classnames';
+import { mergeClasses } from '../../../utils/mergeClasses';
 
 interface Props {
   dimensionsInfo: DimensionInfo[];
   isNarrow?: boolean;
+  className?: string;
 }
 
-const ChartSidebar: FC<Props> = ({ dimensionsInfo, isNarrow }) => {
+const ChartSidebar: FC<Props> = ({ dimensionsInfo, isNarrow, className }) => {
   return (
     <div
-      className={classNames(
+      className={mergeClasses(
         'sidebar flex min-h-0 flex-col gap-3 overflow-auto',
         isNarrow ? 'max-h-[120px] w-full shrink-0' : 'w-[176px]',
+        className,
       )}
     >
       {dimensionsInfo.map((dim) => (

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CustomChartAttachment.tsx
@@ -24,6 +24,8 @@ import {
 import { OnboardingElements } from '../../../constants/onboarding-elements';
 import ResponsiveEChart from './ResponsiveChart';
 import DatasetIcon from '../../../assets/icons/dataset.svg';
+import { mergeClasses } from '../../../utils/mergeClasses';
+import { EChartsOption } from 'echarts-for-react/src/types';
 
 interface Props {
   attachment: CustomChartAttachmentType;
@@ -34,6 +36,15 @@ interface Props {
   fillHeight?: boolean;
   limitationInfoPrefixIcon?: ReactNode;
   limitationInfoContentClassName?: string;
+  transformOption?: (
+    option: EChartsOption,
+    ctx: { isMobile: boolean },
+  ) => EChartsOption;
+  contentClassName?: string;
+  chartAreaClassName?: string;
+  chartBodyClassName?: string;
+  sliderClassName?: string;
+  sidebarClassName?: string;
 }
 
 interface FlatChartUnit {
@@ -50,6 +61,12 @@ export const CustomChartAttachment: FC<Props> = ({
   fillHeight,
   limitationInfoPrefixIcon,
   limitationInfoContentClassName,
+  transformOption,
+  contentClassName,
+  chartAreaClassName,
+  chartBodyClassName,
+  sliderClassName,
+  sidebarClassName,
 }) => {
   const { titles } = useConversationViewStyles();
   const isNarrowChart = useIsMobile(MOBILE_BREAKPOINT);
@@ -196,7 +213,12 @@ export const CustomChartAttachment: FC<Props> = ({
   return (
     <div className="chart-attachment size-full" ref={chartAttachmentRef}>
       {chartingData && (
-        <div className="flex size-full flex-col gap-4">
+        <div
+          className={mergeClasses(
+            'flex size-full flex-col gap-4',
+            contentClassName,
+          )}
+        >
           {flatUnits.length == 0 || selectedUnit == null ? (
             <h4 className="ml-1">{titles?.chartInfo || 'No data'}</h4>
           ) : (
@@ -210,10 +232,11 @@ export const CustomChartAttachment: FC<Props> = ({
                 </span>
               </div>
               <div
-                className={classNames(
+                className={mergeClasses(
                   'chart-area flex gap-4',
                   chartLayoutClass,
                   chartHeightClass,
+                  chartAreaClassName,
                 )}
               >
                 <div
@@ -231,7 +254,12 @@ export const CustomChartAttachment: FC<Props> = ({
                       </h4>
                     </div>
                   )}
-                  <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
+                  <div
+                    className={mergeClasses(
+                      'flex min-h-0 min-w-0 flex-1 flex-col gap-4',
+                      chartBodyClassName,
+                    )}
+                  >
                     <div
                       className={classNames(
                         'min-h-0 min-w-0 flex-1',
@@ -240,6 +268,8 @@ export const CustomChartAttachment: FC<Props> = ({
                     >
                       <ResponsiveEChart
                         option={selectedUnit.config}
+                        transformOption={transformOption}
+                        fillHeight={fillHeight}
                         style={{
                           width: '100%',
                           height: '100%',
@@ -262,6 +292,7 @@ export const CustomChartAttachment: FC<Props> = ({
                         totalCount={flatUnits.length}
                         onNext={nextChart}
                         onPrev={prevChart}
+                        className={sliderClassName}
                       ></Slider>
                     )}
                   </div>
@@ -269,6 +300,7 @@ export const CustomChartAttachment: FC<Props> = ({
                 <ChartSidebar
                   dimensionsInfo={selectedUnit.dimensions}
                   isNarrow={isNarrowChart}
+                  className={sidebarClassName}
                 ></ChartSidebar>
               </div>
             </>

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/ResponsiveChart.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/ResponsiveChart.tsx
@@ -21,6 +21,11 @@ import { MOBILE_BREAKPOINT, useIsMobile } from '@epam/statgpt-ui-components';
 interface Props {
   option: EChartsOption;
   style?: CSSProperties;
+  fillHeight?: boolean;
+  transformOption?: (
+    option: EChartsOption,
+    ctx: { isMobile: boolean },
+  ) => EChartsOption;
 }
 
 const MOBILE_LEGEND_HEIGHT = 44;
@@ -28,15 +33,28 @@ const MOBILE_GRID_BOTTOM = 56;
 const MOBILE_CHART_HEIGHT = 280;
 const MOBILE_AXIS_LABEL_WIDTH = 52;
 
-const ResponsiveEChart: FC<Props> = ({ option, style }) => {
+const ResponsiveEChart: FC<Props> = ({
+  option,
+  style,
+  fillHeight,
+  transformOption,
+}) => {
   const chartRef = useRef<ReactEChartsRef>(null);
   const isMobileChart = useIsMobile(MOBILE_BREAKPOINT);
   const [adjustedOption, setAdjustedOption] = useState<EChartsOption>(option);
 
   useEffect(() => {
-    setAdjustedOption(getBaseOption(option, isMobileChart));
-  }, [option, isMobileChart]);
+    setAdjustedOption(getBaseOption(option, isMobileChart, transformOption));
+  }, [option, isMobileChart, transformOption]);
 
+  /**
+   * Measures the actually rendered legend and sets grid.bottom to fit it, on
+   * desktop, regardless of transformOption — legend row count depends on
+   * item count/label length/container width, none of which a consumer can
+   * know in advance, so this stays library-owned rather than guessable.
+   * transformOption still applies afterwards on top of this: it can style
+   * the legend/axis (colors, fonts) but not override this measurement.
+   */
   const adjustGrid = useCallback(() => {
     const chart = chartRef.current?.getEchartsInstance?.() as
       | ECharts
@@ -92,16 +110,23 @@ const ResponsiveEChart: FC<Props> = ({ option, style }) => {
       lazyUpdate={false}
       ref={chartRef}
       option={adjustedOption}
-      style={getChartStyle(style, isMobileChart)}
+      style={getChartStyle(style, isMobileChart, fillHeight)}
     />
   );
 };
 
+/**
+ * fillHeight already means "trust the parent's own height" on the
+ * surrounding CustomChartAttachment layout (it skips that component's fixed
+ * mobile min-heights) — the fixed mobile pixel height here would otherwise
+ * silently override that intent and leave dead space in a taller parent.
+ */
 function getChartStyle(
   style: CSSProperties | undefined,
   isMobileChart: boolean,
+  fillHeight?: boolean,
 ): CSSProperties | undefined {
-  if (!isMobileChart) {
+  if (!isMobileChart || fillHeight) {
     return style;
   }
 
@@ -115,9 +140,18 @@ function getChartStyle(
 function getBaseOption(
   option: EChartsOption,
   isMobileChart: boolean,
+  transformOption?: (
+    option: EChartsOption,
+    ctx: { isMobile: boolean },
+  ) => EChartsOption,
 ): EChartsOption {
   const nextOption = cloneDeep(option);
-  return isMobileChart ? applyMobileChartOption(nextOption) : nextOption;
+  const baseOption = isMobileChart
+    ? applyMobileChartOption(nextOption)
+    : nextOption;
+  return transformOption
+    ? transformOption(baseOption, { isMobile: isMobileChart })
+    : baseOption;
 }
 
 function applyMobileChartOption(option: EChartsOption): EChartsOption {

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/Slider.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/Slider.tsx
@@ -9,6 +9,7 @@ import { OnboardingElements } from '../../../constants/onboarding-elements';
 import { useOnboarding } from '../../../context/OnboardingContext';
 import { useConversationViewStyles } from '../../../context/ConversationViewStylesContext';
 import { MOBILE_BREAKPOINT, useIsMobile } from '@epam/statgpt-ui-components';
+import { mergeClasses } from '../../../utils/mergeClasses';
 
 const MAX_SLIDER_WIDTH = 200;
 const BASE_ITEM_WIDTH = 8;
@@ -20,6 +21,7 @@ interface Props {
   icons?: Record<ChartingIcon, ReactNode>;
   onPrev: () => void;
   onNext: () => void;
+  className?: string;
 }
 
 const Slider: FC<Props> = ({
@@ -28,6 +30,7 @@ const Slider: FC<Props> = ({
   icons,
   onPrev,
   onNext,
+  className,
 }) => {
   const { titles } = useConversationViewStyles();
   const isMobile = useIsMobile(MOBILE_BREAKPOINT);
@@ -77,9 +80,10 @@ const Slider: FC<Props> = ({
 
   return (
     <div
-      className={classNames(
+      className={mergeClasses(
         'flex w-full flex-row items-center justify-center gap-2',
         isMobile && 'min-w-0',
+        className,
       )}
     >
       <div
@@ -99,7 +103,7 @@ const Slider: FC<Props> = ({
       >
         <div
           className={classNames(
-            'relative h-[4px] rounded-full bg-neutral-300',
+            'relative h-[4px] rounded-full bg-neutrals-300',
             isMobile && 'w-full',
           )}
           style={

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomChart.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CustomChart.stories.tsx
@@ -1,4 +1,5 @@
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { CustomChartAttachment } from '../CustomChartAttachment';
 import { CustomChartAttachmentType } from '../../../../models/attachments';
@@ -6,6 +7,7 @@ import { ChartUnit } from '../../../../models/charting';
 import { ChartingIcon } from '../../../../types/charting-icon';
 import { ConversationViewStylesProvider } from '../../../../context/ConversationViewStylesContext';
 import { OnboardingProvider } from '../../../../context/OnboardingContext';
+import { EChartsOption } from 'echarts-for-react/src/types';
 
 const withProviders: Decorator = (Story) => (
   <ConversationViewStylesProvider>
@@ -15,12 +17,88 @@ const withProviders: Decorator = (Story) => (
   </ConversationViewStylesProvider>
 );
 
+const DARK_SCHEME_STYLE: CSSProperties = {
+  background: '#1B1B1D',
+  color: '#F5F5F5',
+  padding: 16,
+  ['--neutrals-1000' as string]: '#F5F5F5',
+  ['--neutrals-900' as string]: '#E0E0E2',
+  ['--neutrals-800' as string]: '#B8B8BB',
+  ['--neutrals-700' as string]: '#9C9C9F',
+};
+
+const withDarkColorScheme: Decorator = (Story) => (
+  <div style={DARK_SCHEME_STYLE}>
+    <Story />
+  </div>
+);
+
+const LEGEND_BAND_HEIGHT = 20;
+const LEGEND_GAP_ABOVE = 12;
+const GRID_TOP = 12;
+
+function compactChartLayout(
+  option: EChartsOption,
+  ctx: { isMobile: boolean },
+): EChartsOption {
+  if (!ctx.isMobile) {
+    return { ...option, grid: { ...option.grid, top: GRID_TOP } };
+  }
+  const legend = Array.isArray(option.legend)
+    ? option.legend[0]
+    : option.legend;
+  return {
+    ...option,
+    grid: {
+      ...option.grid,
+      top: GRID_TOP,
+      bottom: LEGEND_BAND_HEIGHT + LEGEND_GAP_ABOVE,
+    },
+    legend: { ...legend, height: LEGEND_BAND_HEIGHT },
+  };
+}
+
+function darkenChartOption(
+  option: EChartsOption,
+  ctx: { isMobile: boolean },
+): EChartsOption {
+  const compacted = compactChartLayout(option, ctx);
+  const legend = Array.isArray(compacted.legend)
+    ? compacted.legend[0]
+    : compacted.legend;
+  const xAxis = Array.isArray(compacted.xAxis)
+    ? compacted.xAxis[0]
+    : compacted.xAxis;
+  const yAxis = Array.isArray(compacted.yAxis)
+    ? compacted.yAxis[0]
+    : compacted.yAxis;
+  return {
+    ...compacted,
+    legend: {
+      ...legend,
+      textStyle: { ...legend?.textStyle, color: '#F5F5F5' },
+    },
+    xAxis: {
+      ...xAxis,
+      axisLabel: { color: '#C7C7C9' },
+      axisLine: { lineStyle: { color: '#4A4A4D' } },
+      nameTextStyle: { color: '#C7C7C9' },
+    },
+    yAxis: {
+      ...yAxis,
+      axisLabel: { color: '#C7C7C9' },
+      splitLine: { lineStyle: { color: '#333336' } },
+      nameTextStyle: { color: '#C7C7C9' },
+    },
+  };
+}
+
 const years = ['2019', '2020', '2021', '2022', '2023'];
 
 const ukraineUnit: ChartUnit = {
   config: {
     xAxis: { type: 'category', data: years },
-    yAxis: { type: 'value', name: 'USD bn' },
+    yAxis: { type: 'value' },
     series: [
       {
         type: 'line',
@@ -45,7 +123,7 @@ const ukraineUnit: ChartUnit = {
 const polandUnit: ChartUnit = {
   config: {
     xAxis: { type: 'category', data: years },
-    yAxis: { type: 'value', name: 'USD bn' },
+    yAxis: { type: 'value' },
     series: [
       {
         type: 'line',
@@ -65,6 +143,61 @@ const polandUnit: ChartUnit = {
   })),
   limitedByRowsAmountTo: undefined,
   isPlottable: true,
+};
+
+function buildMultiCountryUnit(
+  countrySeries: { name: string; data: number[] }[],
+): ChartUnit {
+  return {
+    config: {
+      xAxis: { type: 'category', data: years },
+      yAxis: { type: 'value' },
+      series: countrySeries.map((series) => ({
+        type: 'line',
+        name: series.name,
+        data: series.data,
+      })),
+      tooltip: { trigger: 'axis' },
+    },
+    dimensions: [
+      {
+        id: 'REF_AREA',
+        title: 'Countries',
+        value: countrySeries.map((series) => series.name).join(', '),
+      },
+      { id: 'INDICATOR', title: 'Indicator', value: 'GDP at current prices' },
+    ],
+    rows: years.map((y, i) => ({
+      year: y,
+      ...Object.fromEntries(
+        countrySeries.map((series) => [series.name, series.data[i]]),
+      ),
+    })),
+    limitedByRowsAmountTo: undefined,
+    isPlottable: true,
+  };
+}
+
+const westernEuropeUnit = buildMultiCountryUnit([
+  { name: 'Ukraine', data: [153.9, 155.6, 200.1, 160.5, 173.4] },
+  { name: 'Poland', data: [596.1, 596.9, 679.4, 688.1, 749.0] },
+  { name: 'Germany', data: [3888.2, 3846.4, 4260.3, 4082.5, 4456.1] },
+  { name: 'France', data: [2716.3, 2647.9, 2957.9, 2796.3, 3030.9] },
+  { name: 'Italy', data: [2011.3, 1900.5, 2119.6, 2074.1, 2255.5] },
+]);
+
+const easternEuropeUnit = buildMultiCountryUnit([
+  { name: 'Czechia', data: [251.7, 245.3, 281.8, 296.0, 344.8] },
+  { name: 'Slovakia', data: [105.9, 105.7, 116.4, 126.0, 141.6] },
+  { name: 'Hungary', data: [163.5, 157.5, 182.2, 178.8, 213.5] },
+  { name: 'Romania', data: [250.1, 248.7, 284.1, 301.6, 349.9] },
+  { name: 'Bulgaria', data: [69.9, 68.6, 84.1, 92.2, 107.6] },
+]);
+
+const multiCountryMultiUnitAttachment: CustomChartAttachmentType = {
+  type: 'application/json',
+  title: 'GDP by Country',
+  charting_data: { units: [westernEuropeUnit, easternEuropeUnit] },
 };
 
 const singleUnitAttachment: CustomChartAttachmentType = {
@@ -146,5 +279,24 @@ export const NarrowCard: Story = {
   },
   parameters: {
     viewport: { defaultViewport: 'mobile2' },
+  },
+};
+
+export const CustomStylesDark: Story = {
+  name: 'Custom Styles / Dark',
+  decorators: [withDarkColorScheme],
+  render: (args) => (
+    <div style={{ height: 480 }}>
+      <CustomChartAttachment {...args} />
+    </div>
+  ),
+  args: {
+    attachment: multiCountryMultiUnitAttachment,
+    transformOption: darkenChartOption,
+    fillHeight: true,
+    contentClassName: 'gap-2',
+    chartBodyClassName: 'gap-1',
+    chartAreaClassName: 'gap-2',
+    sliderClassName: 'w-fit self-center',
   },
 };

--- a/libs/conversation-view/src/models/attachments-styles.ts
+++ b/libs/conversation-view/src/models/attachments-styles.ts
@@ -2,6 +2,7 @@
 import { ReactNode } from 'react';
 import { ChartingIcon } from '../types/charting-icon';
 import { DownloadTitles } from '@statgpt/download-panel/src/models/titles';
+import { EChartsOption } from 'echarts-for-react/src/types';
 
 export interface AttachmentsStyles {
   showTabIcon?: boolean;
@@ -46,10 +47,30 @@ export interface AttachmentsStyles {
   copyHoverTooltip?: string;
   limitationInfoIcon?: ReactNode;
   limitationInfoContentClassName?: string;
+  chartContentClassName?: string;
+  chartAreaClassName?: string;
+  chartBodyClassName?: string;
+  chartSliderClassName?: string;
+  chartSidebarClassName?: string;
 }
 
 export interface ChartingStyles {
   colors?: string[];
   ticksColor?: string;
   labelsColor?: string;
+  /**
+   * Runs last, after any built-in responsive (mobile) adjustments, so it always has final say
+   * over the option ECharts renders. Give it a new identity (e.g. via useCallback keyed on a
+   * theme value) to make the chart react to a host theme change.
+   *
+   * On desktop (ctx.isMobile === false), grid.bottom is always re-measured from the actually
+   * rendered legend afterwards and will overwrite anything set here — legend row count depends
+   * on item count/label length/container width, none of which can be guessed in advance, so it
+   * stays library-owned. Use this for colors/fonts/formatting, not spacing. On mobile the legend
+   * is forced to a single non-wrapping row, so grid.bottom/legend sizing set here is respected.
+   */
+  transformOption?: (
+    option: EChartsOption,
+    ctx: { isMobile: boolean },
+  ) => EChartsOption;
 }


### PR DESCRIPTION
### Applicable issues
N/A – no linked issue

### Description of changes

Adds an optional customization surface to `CustomChartAttachment` so a consumer can restyle the chart (colors, spacing) for its own theme, without affecting existing consumers — all new props are optional and unused by the current portal apps.

- **`ChartingStyles.transformOption`**: a callback that runs last, after any built-in mobile/responsive adjustments, letting a consumer restyle the ECharts canvas (legend, axis labels/lines, colors, fonts). Receives `{ isMobile }` so behavior can vary by breakpoint, and can get a new identity (e.g. via `useCallback`) to react to a live theme change.
- **New className overrides** on `CustomChartAttachment` (and the matching `AttachmentsStyles` fields, threaded through `AttachmentsContentRenderer`): `contentClassName`, `chartAreaClassName`, `chartBodyClassName`, `sliderClassName`, `chartSidebarClassName` — cover the DOM gaps/padding around the title block, chart area, canvas, slider, and country/indicator sidebar. All merged via the existing `mergeClasses` (twMerge) utility, matching the pattern already used by `ChartLimitationInfo`/`CodeAttachment`.
- **`fillHeight` fix**: `ResponsiveChart`'s mobile canvas height was previously hardcoded regardless of the `fillHeight` prop, silently overriding it and leaving dead space in taller containers. It now respects `fillHeight`.
- **Bug fix**: `Slider`'s progress-bar track used `bg-neutral-300` (Tailwind's built-in gray) instead of this project's themed `bg-neutrals-300` token, so it never responded to `--neutrals-*` theme overrides.
- **Storybook**: added a "Custom Styles / Dark" story (`Conversation View/Chart/CustomChart`) demonstrating the full customization surface — dark background, multi-series/multi-slide data, compacted spacing.

### Checklist
- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.