### PR TITLE
feat: make side panel close control, styles, and dataset info details overridable

### DIFF
--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/DatasetInfoDetails.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/DatasetInfoDetails.tsx
@@ -3,6 +3,7 @@
 import { FC } from 'react';
 import { StructureComponentValue } from '../../../../models/structure-component';
 import { IconDatabase, IconExternalLink } from '@tabler/icons-react';
+import { useDatasetInfoDetailsConfig } from './DatasetInfoDetailsContext';
 
 interface Props {
   dataset: StructureComponentValue;
@@ -19,18 +20,27 @@ const DatasetInfoDetails: FC<Props> = ({
   externalLink,
   formatValue,
 }) => {
+  const config = useDatasetInfoDetailsConfig();
+  const datasetIcon = config?.icon ?? (
+    <IconDatabase className="size-4 text-neutrals-700" />
+  );
+  const ExternalLink = config?.externalLink;
+
   return (
     <div className="mb-6 flex flex-col gap-2">
       <div className="flex items-center gap-2">
-        <IconDatabase className="size-4 text-neutrals-700" />
+        {datasetIcon}
         <p className="h4 break-words text-neutrals-1000">
           {formatValue(dataset?.value)}
         </p>
-        {externalLink && (
-          <a href={externalLink} target="_blank" rel="noopener noreferrer">
-            <IconExternalLink className="size-4 shrink-0 cursor-pointer text-primary" />
-          </a>
-        )}
+        {externalLink &&
+          (ExternalLink ? (
+            <ExternalLink url={externalLink} />
+          ) : (
+            <a href={externalLink} target="_blank" rel="noopener noreferrer">
+              <IconExternalLink className="size-4 shrink-0 cursor-pointer text-primary" />
+            </a>
+          ))}
       </div>
       {agency && (
         <div className="body-3 flex gap-1">

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/DatasetInfoDetailsContext.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/DatasetInfoDetailsContext.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import {
+  ComponentType,
+  createContext,
+  ReactNode,
+  useContext,
+  useMemo,
+} from 'react';
+
+export interface DatasetInfoDetailsConfig {
+  icon?: ReactNode;
+  externalLink?: ComponentType<{ url: string }>;
+}
+
+const DatasetInfoDetailsContext =
+  createContext<DatasetInfoDetailsConfig | null>(null);
+
+export interface DatasetInfoDetailsProviderProps {
+  value?: DatasetInfoDetailsConfig;
+  children: ReactNode;
+}
+
+/**
+ * DatasetInfoDetailsProvider supplies optional overrides for the dataset
+ * row's leading icon and the external-link element rendered by
+ * DatasetInfoDetails inside the metadata side panel.
+ *
+ * @example
+ * ```tsx
+ * <DatasetInfoDetailsProvider value={{ icon: <MyDatasetIcon /> }}>
+ *   <MyLayout />
+ * </DatasetInfoDetailsProvider>
+ * ```
+ *
+ * @param value - Optional customization config; omitted keys fall back to DatasetInfoDetails's defaults.
+ * @param children - Subtree that gains access to the customization config.
+ */
+export function DatasetInfoDetailsProvider({
+  value,
+  children,
+}: DatasetInfoDetailsProviderProps) {
+  const memo = useMemo(() => value ?? {}, [value]);
+
+  return (
+    <DatasetInfoDetailsContext.Provider value={memo}>
+      {children}
+    </DatasetInfoDetailsContext.Provider>
+  );
+}
+
+/**
+ * Returns the current DatasetInfoDetailsConfig, or null when called outside
+ * a DatasetInfoDetailsProvider.
+ */
+export function useDatasetInfoDetailsConfig() {
+  return useContext(DatasetInfoDetailsContext);
+}

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__stories__/DatasetInfoDetails.stories.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__stories__/DatasetInfoDetails.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconBuildingBank } from '@tabler/icons-react';
+import DatasetInfoDetails from '../DatasetInfoDetails';
+import { DatasetInfoDetailsProvider } from '../DatasetInfoDetailsContext';
+import { StructureComponentValue } from '../../../../../models/structure-component';
+
+const formatValue = (value: StructureComponentValue['value']) =>
+  String(value ?? '');
+
+const dataset: StructureComponentValue = {
+  title: 'Dataset',
+  value: 'GDP at current prices',
+};
+const agency: StructureComponentValue = { title: 'Agency', value: 'IMF' };
+const lastUpdated: StructureComponentValue = {
+  title: 'Last updated',
+  value: '2026-06-01',
+};
+
+const meta: Meta<typeof DatasetInfoDetails> = {
+  title: 'Conversation View/SidePanel/DatasetInfoDetails',
+  component: DatasetInfoDetails,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DatasetInfoDetails>;
+
+export const Default: Story = {
+  args: {
+    dataset,
+    agency,
+    lastUpdated,
+    externalLink: 'https://example.com/dataset',
+    formatValue,
+  },
+};
+
+export const WithoutExternalLink: Story = {
+  name: 'Without External Link',
+  args: {
+    dataset,
+    agency,
+    lastUpdated,
+    formatValue,
+  },
+};
+
+export const CustomDatasetIcon: Story = {
+  name: 'Custom Dataset Icon',
+  render: (args) => (
+    <DatasetInfoDetailsProvider
+      value={{ icon: <IconBuildingBank className="size-4 text-primary" /> }}
+    >
+      <DatasetInfoDetails {...args} />
+    </DatasetInfoDetailsProvider>
+  ),
+  args: {
+    dataset,
+    agency,
+    lastUpdated,
+    externalLink: 'https://example.com/dataset',
+    formatValue,
+  },
+};
+
+function ButtonExternalLink({ url }: { url: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => alert(`Custom navigation handler called with: ${url}`)}
+      className="rounded bg-neutrals-300 px-2 py-0.5 text-neutrals-1000"
+    >
+      View source
+    </button>
+  );
+}
+
+export const CustomExternalLink: Story = {
+  name: 'Custom External Link (no new tab)',
+  render: (args) => (
+    <DatasetInfoDetailsProvider value={{ externalLink: ButtonExternalLink }}>
+      <DatasetInfoDetails {...args} />
+    </DatasetInfoDetailsProvider>
+  ),
+  args: {
+    dataset,
+    agency,
+    lastUpdated,
+    externalLink: 'https://example.com/dataset',
+    formatValue,
+  },
+};

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/DatasetInfoDetails.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/DatasetInfoDetails.spec.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import DatasetInfoDetails from '../DatasetInfoDetails';
+import { DatasetInfoDetailsProvider } from '../DatasetInfoDetailsContext';
+import { StructureComponentValue } from '../../../../../models/structure-component';
+
+const formatValue = (value: StructureComponentValue['value']) =>
+  String(value ?? '');
+
+const dataset = { value: 'GDP', title: 'Dataset' } as StructureComponentValue;
+
+describe('DatasetInfoDetails', () => {
+  it('renders the default dataset icon and native external-link anchor with no provider', () => {
+    const { container } = render(
+      <DatasetInfoDetails
+        dataset={dataset}
+        externalLink="https://example.com/dataset"
+        formatValue={formatValue}
+      />,
+    );
+
+    const anchor = container.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/dataset');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('does not render any external link element when externalLink is not provided', () => {
+    const { container } = render(
+      <DatasetInfoDetails dataset={dataset} formatValue={formatValue} />,
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('renders a custom dataset icon from provider config', () => {
+    render(
+      <DatasetInfoDetailsProvider
+        value={{ icon: <span data-testid="custom-icon">icon</span> }}
+      >
+        <DatasetInfoDetails dataset={dataset} formatValue={formatValue} />
+      </DatasetInfoDetailsProvider>,
+    );
+
+    expect(screen.getByTestId('custom-icon')).toBeTruthy();
+  });
+
+  it('renders a custom externalLink component with the correct url prop instead of the default anchor', () => {
+    function CustomLink({ url }: { url: string }) {
+      return <button type="button" data-testid="custom-link" data-url={url} />;
+    }
+
+    const { container } = render(
+      <DatasetInfoDetailsProvider value={{ externalLink: CustomLink }}>
+        <DatasetInfoDetails
+          dataset={dataset}
+          externalLink="https://example.com/dataset"
+          formatValue={formatValue}
+        />
+      </DatasetInfoDetailsProvider>,
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+    const link = screen.getByTestId('custom-link');
+    expect(link.getAttribute('data-url')).toBe('https://example.com/dataset');
+  });
+});

--- a/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/DatasetInfoDetailsContext.spec.tsx
+++ b/libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/__tests__/DatasetInfoDetailsContext.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import {
+  DatasetInfoDetailsProvider,
+  useDatasetInfoDetailsConfig,
+} from '../DatasetInfoDetailsContext';
+
+function ConfigProbe() {
+  const config = useDatasetInfoDetailsConfig();
+  return (
+    <div data-testid="probe">
+      {config === null ? 'null' : JSON.stringify(Object.keys(config))}
+    </div>
+  );
+}
+
+describe('DatasetInfoDetailsContext', () => {
+  it('returns null outside a provider', () => {
+    render(<ConfigProbe />);
+    expect(screen.getByTestId('probe').textContent).toBe('null');
+  });
+
+  it('returns the supplied value inside a provider', () => {
+    render(
+      <DatasetInfoDetailsProvider value={{ icon: <span>icon</span> }}>
+        <ConfigProbe />
+      </DatasetInfoDetailsProvider>,
+    );
+    expect(screen.getByTestId('probe').textContent).toBe(
+      JSON.stringify(['icon']),
+    );
+  });
+
+  it('defaults to an empty object when value is omitted', () => {
+    render(
+      <DatasetInfoDetailsProvider>
+        <ConfigProbe />
+      </DatasetInfoDetailsProvider>,
+    );
+    expect(screen.getByTestId('probe').textContent).toBe(JSON.stringify([]));
+  });
+});

--- a/libs/conversation-view/src/components/ConversationView/SidePanel/ConversationViewSidePanel.tsx
+++ b/libs/conversation-view/src/components/ConversationView/SidePanel/ConversationViewSidePanel.tsx
@@ -3,6 +3,7 @@
 import { IconX } from '@tabler/icons-react';
 import { mergeClasses } from '../../../utils/mergeClasses';
 import { ReactNode } from 'react';
+import { useSidePanelCustomizationConfig } from './SidePanelCustomizationContext';
 
 /**
  * ConversationViewSidePanel renders a fixed-width side panel with a header,
@@ -11,6 +12,10 @@ import { ReactNode } from 'react';
  * The header displays an optional title on the left and places any
  * `headerExtension` content to the left of the close button, separated by a
  * thin vertical divider when the extension is present.
+ *
+ * The close button and the panel/header/body classes can be overridden
+ * globally via `SidePanelCustomizationProvider`; per-instance props here
+ * still take precedence over that provider config.
  *
  * @example
  * Basic side panel with a title
@@ -45,16 +50,21 @@ export function ConversationViewSidePanel({
   panelClassName?: string;
   children: ReactNode;
 }) {
+  const config = useSidePanelCustomizationConfig();
+  const CloseControl = config?.closeControl;
+
   return (
     <div
       className={mergeClasses(
         'h-full w-[362px] bg-white border-l border-neutrals-500 flex flex-col overflow-hidden',
+        config?.classes?.panel,
         panelClassName,
       )}
     >
       <div
         className={mergeClasses(
           'flex justify-between px-5 py-6',
+          config?.classes?.header,
           headerClassName,
         )}
       >
@@ -62,14 +72,19 @@ export function ConversationViewSidePanel({
         <div className="flex items-center gap-2">
           {headerExtension}
           {headerExtension && <div className="h-3 w-px bg-neutrals-600" />}
-          <button type="button" onClick={onClose}>
-            <IconX className="size-5 text-neutrals-1000" />
-          </button>
+          {CloseControl ? (
+            <CloseControl onClose={onClose} />
+          ) : (
+            <button type="button" onClick={onClose}>
+              <IconX className="size-5 text-neutrals-1000" />
+            </button>
+          )}
         </div>
       </div>
       <div
         className={mergeClasses(
           'flex-1 min-h-0 overflow-hidden',
+          config?.classes?.body,
           bodyClassName,
         )}
       >

--- a/libs/conversation-view/src/components/ConversationView/SidePanel/SidePanelCustomizationContext.tsx
+++ b/libs/conversation-view/src/components/ConversationView/SidePanel/SidePanelCustomizationContext.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {
+  ComponentType,
+  createContext,
+  ReactNode,
+  useContext,
+  useMemo,
+} from 'react';
+
+export interface SidePanelCustomizationConfig {
+  closeControl?: ComponentType<{ onClose: () => void }>;
+  classes?: {
+    panel?: string;
+    header?: string;
+    body?: string;
+  };
+}
+
+const SidePanelCustomizationContext =
+  createContext<SidePanelCustomizationConfig | null>(null);
+
+export interface SidePanelCustomizationProviderProps {
+  value?: SidePanelCustomizationConfig;
+  children: ReactNode;
+}
+
+/**
+ * SidePanelCustomizationProvider supplies optional overrides for
+ * ConversationViewSidePanel's chrome (close control, panel/header/body
+ * classes) to its subtree. Distinct from ConversationViewSidePanelProvider,
+ * which manages which panel is currently open, not how it's styled.
+ *
+ * @example
+ * ```tsx
+ * <SidePanelCustomizationProvider value={{ classes: { panel: 'w-full' } }}>
+ *   <MyLayout />
+ * </SidePanelCustomizationProvider>
+ * ```
+ *
+ * @param value - Optional customization config; omitted keys fall back to ConversationViewSidePanel's defaults.
+ * @param children - Subtree that gains access to the customization config.
+ */
+export function SidePanelCustomizationProvider({
+  value,
+  children,
+}: SidePanelCustomizationProviderProps) {
+  const memo = useMemo(() => value ?? {}, [value]);
+
+  return (
+    <SidePanelCustomizationContext.Provider value={memo}>
+      {children}
+    </SidePanelCustomizationContext.Provider>
+  );
+}
+
+/**
+ * Returns the current SidePanelCustomizationConfig, or null when called
+ * outside a SidePanelCustomizationProvider.
+ */
+export function useSidePanelCustomizationConfig() {
+  return useContext(SidePanelCustomizationContext);
+}

--- a/libs/conversation-view/src/components/ConversationView/SidePanel/__stories__/ConversationViewSidePanel.stories.tsx
+++ b/libs/conversation-view/src/components/ConversationView/SidePanel/__stories__/ConversationViewSidePanel.stories.tsx
@@ -1,0 +1,85 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import { ConversationViewSidePanel } from '../ConversationViewSidePanel';
+import { SidePanelCustomizationProvider } from '../SidePanelCustomizationContext';
+
+const withFixedHeight: Decorator = (Story) => (
+  <div style={{ height: 500, display: 'flex' }}>
+    <Story />
+  </div>
+);
+
+const meta: Meta<typeof ConversationViewSidePanel> = {
+  title: 'Conversation View/SidePanel/ConversationViewSidePanel',
+  component: ConversationViewSidePanel,
+  decorators: [withFixedHeight],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConversationViewSidePanel>;
+
+export const Default: Story = {
+  args: {
+    title: 'Dataset Details',
+    onClose: () => {},
+    children: <p className="px-5">Panel content goes here.</p>,
+  },
+};
+
+export const WithHeaderExtension: Story = {
+  name: 'With Header Extension',
+  args: {
+    title: 'Dataset Details',
+    onClose: () => {},
+    headerExtension: (
+      <button type="button" className="text-primary">
+        Expand
+      </button>
+    ),
+    children: <p className="px-5">Panel content goes here.</p>,
+  },
+};
+
+function CollapseCloseControl({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      className="rounded bg-neutrals-300 px-2 py-1 text-neutrals-1000"
+    >
+      Collapse
+    </button>
+  );
+}
+
+export const CustomCloseControl: Story = {
+  name: 'Custom Close Control',
+  render: (args) => (
+    <SidePanelCustomizationProvider
+      value={{ closeControl: CollapseCloseControl }}
+    >
+      <ConversationViewSidePanel {...args} />
+    </SidePanelCustomizationProvider>
+  ),
+  args: {
+    title: 'Dataset Details',
+    onClose: () => {},
+    children: <p className="px-5">Panel content goes here.</p>,
+  },
+};
+
+export const FullWidth: Story = {
+  name: 'Full Width (mobile override)',
+  render: (args) => (
+    <SidePanelCustomizationProvider
+      value={{ classes: { panel: 'w-full border-l-0' } }}
+    >
+      <ConversationViewSidePanel {...args} />
+    </SidePanelCustomizationProvider>
+  ),
+  args: {
+    title: 'Dataset Details',
+    onClose: () => {},
+    children: <p className="px-5">Panel content goes here.</p>,
+  },
+};

--- a/libs/conversation-view/src/components/ConversationView/SidePanel/__tests__/ConversationViewSidePanel.spec.tsx
+++ b/libs/conversation-view/src/components/ConversationView/SidePanel/__tests__/ConversationViewSidePanel.spec.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ConversationViewSidePanel } from '../ConversationViewSidePanel';
+import { SidePanelCustomizationProvider } from '../SidePanelCustomizationContext';
+
+describe('ConversationViewSidePanel', () => {
+  it('renders the default close button and calls onClose when no provider is present', () => {
+    const onClose = jest.fn();
+    render(
+      <ConversationViewSidePanel title="Details" onClose={onClose}>
+        <p>Body</p>
+      </ConversationViewSidePanel>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a custom closeControl from provider config instead of the default button', () => {
+    const onClose = jest.fn();
+    function CustomClose({ onClose }: { onClose: () => void }) {
+      return (
+        <button type="button" onClick={onClose} data-testid="custom-close">
+          Dismiss
+        </button>
+      );
+    }
+
+    render(
+      <SidePanelCustomizationProvider value={{ closeControl: CustomClose }}>
+        <ConversationViewSidePanel title="Details" onClose={onClose}>
+          <p>Body</p>
+        </ConversationViewSidePanel>
+      </SidePanelCustomizationProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('custom-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges provider classes.panel under the default panel classes, with panelClassName prop still winning', () => {
+    const { container, rerender } = render(
+      <SidePanelCustomizationProvider value={{ classes: { panel: 'w-full' } }}>
+        <ConversationViewSidePanel title="Details" onClose={() => {}}>
+          <p>Body</p>
+        </ConversationViewSidePanel>
+      </SidePanelCustomizationProvider>,
+    );
+
+    const panel = container.firstChild as HTMLElement;
+    expect(panel.className).toContain('w-full');
+    expect(panel.className).not.toContain('w-[362px]');
+
+    rerender(
+      <SidePanelCustomizationProvider value={{ classes: { panel: 'w-full' } }}>
+        <ConversationViewSidePanel
+          title="Details"
+          onClose={() => {}}
+          panelClassName="w-[480px]"
+        >
+          <p>Body</p>
+        </ConversationViewSidePanel>
+      </SidePanelCustomizationProvider>,
+    );
+
+    const panelAfter = container.firstChild as HTMLElement;
+    expect(panelAfter.className).toContain('w-[480px]');
+    expect(panelAfter.className).not.toContain('w-full');
+  });
+});

--- a/libs/conversation-view/src/components/ConversationView/SidePanel/__tests__/SidePanelCustomizationContext.spec.tsx
+++ b/libs/conversation-view/src/components/ConversationView/SidePanel/__tests__/SidePanelCustomizationContext.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import {
+  SidePanelCustomizationProvider,
+  useSidePanelCustomizationConfig,
+} from '../SidePanelCustomizationContext';
+
+function ConfigProbe() {
+  const config = useSidePanelCustomizationConfig();
+  return (
+    <div data-testid="probe">
+      {config === null ? 'null' : JSON.stringify(Object.keys(config))}
+    </div>
+  );
+}
+
+describe('SidePanelCustomizationContext', () => {
+  it('returns null outside a provider', () => {
+    render(<ConfigProbe />);
+    expect(screen.getByTestId('probe').textContent).toBe('null');
+  });
+
+  it('returns the supplied value inside a provider', () => {
+    const closeControl = () => null;
+    render(
+      <SidePanelCustomizationProvider value={{ closeControl }}>
+        <ConfigProbe />
+      </SidePanelCustomizationProvider>,
+    );
+    expect(screen.getByTestId('probe').textContent).toBe(
+      JSON.stringify(['closeControl']),
+    );
+  });
+
+  it('defaults to an empty object when value is omitted', () => {
+    render(
+      <SidePanelCustomizationProvider>
+        <ConfigProbe />
+      </SidePanelCustomizationProvider>,
+    );
+    expect(screen.getByTestId('probe').textContent).toBe(JSON.stringify([]));
+  });
+});

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -52,6 +52,18 @@ export type {
 } from './components/ConversationView/SidePanel/ConversationViewSidePanelContext';
 
 export {
+  SidePanelCustomizationProvider,
+  useSidePanelCustomizationConfig,
+} from './components/ConversationView/SidePanel/SidePanelCustomizationContext';
+export type { SidePanelCustomizationConfig } from './components/ConversationView/SidePanel/SidePanelCustomizationContext';
+
+export {
+  DatasetInfoDetailsProvider,
+  useDatasetInfoDetailsConfig,
+} from './components/AdvancedView/Metadata/SidePanel/DatasetInfoDetailsContext';
+export type { DatasetInfoDetailsConfig } from './components/AdvancedView/Metadata/SidePanel/DatasetInfoDetailsContext';
+
+export {
   ConversationViewFeatureTogglesProvider,
   useConversationViewFeatureToggles,
 } from './context/ConversationViewFeatureTogglesContext';

--- a/specs/changes/2026-07-29-side-panel-customization-design.md
+++ b/specs/changes/2026-07-29-side-panel-customization-design.md
@@ -1,0 +1,136 @@
+# Side Panel Customization — Design
+
+**Date:** 2026-07-29
+**Status:** Approved, not yet implemented
+
+---
+
+## Problem
+
+The conversation-view side panel (`ConversationViewSidePanel` / `ConversationViewSidePanelContext`, in `libs/conversation-view/src/components/ConversationView/SidePanel/`) and the metadata dataset details it renders (`DatasetInfoDetails.tsx`, same folder tree) are fully closed for extension today:
+
+- The panel's close button is hardcoded to a `<button><IconX/></button>` — no way to swap it for a different icon, label, or component.
+- The panel's width/spacing is only overridable via `panelClassName`/`headerClassName`/`bodyClassName` props passed at the `openPanel()` call site — but those call sites (`DatasetDetailCellRenderer`, `MetadataCellRenderer`, `MergedDimensionCellRenderer`, `ObservationValueCellWithMetadata`, `AdvancedAttachmentRenderer`, `DatasetInfo.tsx`) all live *inside* `conversation-view` itself. A consuming app has no way to reach them to pass different props.
+- `DatasetInfoDetails.tsx` hardcodes the dataset row's leading icon (`IconDatabase`) and the entire external-link element (`<a target="_blank" rel="noopener noreferrer"><IconExternalLink/></a>`). Some consumers need a different dataset icon, and need full control over the external-link element itself — up to and including guaranteeing no new tab ever opens, which a native `<a target="_blank">` cannot do: middle-click, Ctrl/Cmd-click, and the browser's own "open link in new tab" context-menu entry all bypass any `onClick` handler and act on `href`/`target` directly.
+
+Since the internal call sites can't be reached, the only way to let a consuming app customize any of this without forking `conversation-view` is a provider-based override that those internal components read from, at render time — the same shape already established by `InlineAlertProvider`.
+
+## Approach
+
+Two new, independent contexts, following the exact `InlineAlertProvider`/`useInlineAlertConfig()` precedent (`libs/ui-components/src/components/InlineAlert/InlineAlertContext.tsx`):
+
+- **`SidePanelCustomizationProvider` / `useSidePanelCustomizationConfig()`** — panel chrome only (close control, panel/header/body classes). Consumed by `ConversationViewSidePanel`. Named distinctly from the existing `ConversationViewSidePanelProvider` (which manages *which panel is open*, an unrelated concern) to avoid confusion between the two.
+- **`DatasetInfoDetailsProvider` / `useDatasetInfoDetailsConfig()`** — the dataset icon and the external-link element, both rendered by `DatasetInfoDetails`.
+
+Kept as two separate contexts rather than one: `DatasetInfoDetails` renders no panel chrome at all (no close button, no panel width), so coupling it to a context named for the panel would be a naming/responsibility mismatch. Its own two customizable elements (dataset icon, external-link element) are bundled into one config scoped to that component, rather than one context per icon, since both live in the same row of the same component.
+
+Both `closeControl` and `externalLink` follow the same **full component-replacement** shape rather than narrower icon/handler props: the consumer's component owns the entire rendered element, not just a prop layered onto library-owned markup. This was chosen over an icon-swap-plus-`onClick`-intercept approach specifically because the latter cannot fully suppress a native anchor's new-tab behavior (see Problem above) — only owning the element outright can guarantee that.
+
+Both contexts are **fully optional** at every level. With no provider mounted, `useContext` returns `null`, every read is optional-chained, and both components fall back to their exact current hardcoded behavior. This is purely additive — no changes required in any consuming app unless it chooses to opt in.
+
+## Config shapes
+
+```ts
+// libs/conversation-view/src/components/ConversationView/SidePanel/SidePanelCustomizationContext.tsx
+export interface SidePanelCustomizationConfig {
+  closeControl?: React.ComponentType<{ onClose: () => void }>;
+  classes?: {
+    panel?: string;
+    header?: string;
+    body?: string;
+  };
+}
+
+export const SidePanelCustomizationContext = createContext<SidePanelCustomizationConfig | null>(null);
+export const SidePanelCustomizationProvider = ({
+  value,
+  children,
+}: {
+  value?: SidePanelCustomizationConfig;
+  children: ReactNode;
+}) => (
+  <SidePanelCustomizationContext.Provider value={useMemo(() => value ?? {}, [value])}>
+    {children}
+  </SidePanelCustomizationContext.Provider>
+);
+export const useSidePanelCustomizationConfig = () => useContext(SidePanelCustomizationContext);
+```
+
+```ts
+// libs/conversation-view/src/components/AdvancedView/Metadata/SidePanel/DatasetInfoDetailsContext.tsx
+export interface DatasetInfoDetailsConfig {
+  icon?: React.ReactNode; // dataset row's leading icon, default IconDatabase
+  externalLink?: React.ComponentType<{ url: string }>; // replaces the default <a target="_blank"> entirely
+}
+
+export const DatasetInfoDetailsContext = createContext<DatasetInfoDetailsConfig | null>(null);
+export const DatasetInfoDetailsProvider = ({
+  value,
+  children,
+}: {
+  value?: DatasetInfoDetailsConfig;
+  children: ReactNode;
+}) => (
+  <DatasetInfoDetailsContext.Provider value={useMemo(() => value ?? {}, [value])}>
+    {children}
+  </DatasetInfoDetailsContext.Provider>
+);
+export const useDatasetInfoDetailsConfig = () => useContext(DatasetInfoDetailsContext);
+```
+
+## Component wiring
+
+**`ConversationViewSidePanel.tsx`** — resolves `closeControl` from `useSidePanelCustomizationConfig()`:
+
+```tsx
+const config = useSidePanelCustomizationConfig();
+const CloseControl = config?.closeControl;
+
+{CloseControl ? (
+  <CloseControl onClose={onClose} />
+) : (
+  <button type="button" onClick={onClose}>
+    <IconX className="size-5 text-neutrals-1000" />
+  </button>
+)}
+```
+
+`config?.classes?.panel/header/body` merge into the existing `panelClassName`/`headerClassName`/`bodyClassName` props via the existing `mergeClasses` util, at a new middle precedence tier: component default classes < provider `classes.*` < per-call prop. `mergeClasses` (tailwind-merge based) already dedupes conflicting utilities correctly, so this requires no new merge logic — just one more argument in the existing `mergeClasses(...)` calls.
+
+**`DatasetInfoDetails.tsx`** — resolves the dataset icon and the external-link component from `useDatasetInfoDetailsConfig()`:
+
+```tsx
+const config = useDatasetInfoDetailsConfig();
+const DatasetIcon = config?.icon ?? <IconDatabase className="size-4 text-neutrals-700" />;
+const ExternalLink = config?.externalLink;
+
+{DatasetIcon}
+...
+{ExternalLink ? (
+  <ExternalLink url={url} />
+) : (
+  <a href={url} target="_blank" rel="noopener noreferrer">
+    <IconExternalLink className="size-4 shrink-0 cursor-pointer text-primary" />
+  </a>
+)}
+```
+
+With no override, behavior is byte-identical to today. With an override, the consumer's component receives only `url` and owns the entire element — icon, wrapper (`<button>`, a differently-configured `<a>`, anything), and click handling. A consumer that renders a `<button>` with no `href` guarantees no new tab can open through any native mechanism (middle-click, Ctrl/Cmd-click, right-click context menu), since none of those act on a plain button.
+
+**Exports** — add `SidePanelCustomizationProvider`, `useSidePanelCustomizationConfig`, `SidePanelCustomizationConfig`, `DatasetInfoDetailsProvider`, `useDatasetInfoDetailsConfig`, `DatasetInfoDetailsConfig` to `libs/conversation-view/src/index.ts`, alongside the existing `ConversationViewSidePanelOutlet` exports.
+
+**Scope note**: the external-link anchor pattern is currently duplicated in three places (`DatasetInfoDetails.tsx`, `DatasetInfo.tsx`'s non-panel dataset header, `ChatMessages.tsx`), and `DatasetInfo.tsx` also renders its own `IconDatabase`-style dataset icon. This design scopes `DatasetInfoDetailsProvider` consumption to `DatasetInfoDetails.tsx` only, matching the reported problem. The other duplicated icon/anchor in `DatasetInfo.tsx` and `ChatMessages.tsx` are left as-is — out of scope for this change.
+
+## Testing
+
+Following `InlineAlert.spec.tsx` conventions (`libs/ui-components/src/components/InlineAlert/InlineAlert.spec.tsx`):
+
+- **`SidePanelCustomizationContext.spec.tsx`** / **`DatasetInfoDetailsContext.spec.tsx`** — hook returns `null` outside a provider; returns the supplied `value` inside one.
+- **`ConversationViewSidePanel.spec.tsx`** (extend existing) — default `IconX` button + `onClose` call with no provider; custom `closeControl` rendered and its `onClose` invoked when provider supplies one; provider `classes.panel` merges correctly under an existing `panelClassName` prop (prop wins).
+- **`DatasetInfoDetails.spec.tsx`** (extend existing, or add if none exist) — default `IconDatabase` dataset icon and default `IconExternalLink` + native `target="_blank"` anchor with no provider; custom dataset icon rendered when provided; custom `externalLink` component rendered with the correct `url` prop instead of the default anchor when provided.
+
+Existing specs for both components must continue passing unmodified — the no-provider path is untouched.
+
+## Backward compatibility
+
+Zero required changes in any consuming app. Purely additive: a consuming app opts in by wrapping `SidePanelCustomizationProvider` and/or `DatasetInfoDetailsProvider` (independently) around its tree — most naturally alongside the existing `InlineAlertProvider` in its own `ComponentsConfig.tsx` — and supplying only the config keys it needs; everything else keeps today's default behavior.


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-mcp-app-frontend/issues/55
- https://github.com/epam/statgpt-mcp-app-frontend/issues/50
- https://github.com/epam/statgpt-mcp-app-frontend/issues/42

### Description of changes

Adds two new optional, provider-based customization contexts to `@epam/statgpt-conversation-view`, following the same pattern as `InlineAlertProvider`:

- `SidePanelCustomizationProvider` / `useSidePanelCustomizationConfig()` — lets a consuming app override `ConversationViewSidePanel`'s close control (full component replacement) and its panel/header/body classes.
- `DatasetInfoDetailsProvider` / `useDatasetInfoDetailsConfig()` — lets a consuming app override the dataset row's leading icon and the external-link element (full component replacement) rendered by `DatasetInfoDetails`.

Both contexts are fully optional. With no provider mounted, both components fall back to their exact current hardcoded markup, so no other consuming app needs to change anything.

Also adds Storybook stories for both components demonstrating the default and customized variants.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.