### PR TITLE
fix: preserve filters key in system message attachment for disabled datasets

### DIFF
--- a/libs/conversation-view/src/utils/__tests__/system-message.spec.ts
+++ b/libs/conversation-view/src/utils/__tests__/system-message.spec.ts
@@ -63,6 +63,55 @@ describe('prepareSystemMessage', () => {
       expect(data.disabled).toBe(false);
     });
   });
+
+  describe('multi-dataset filters for a dataset missing from queryFiltersMap', () => {
+    it('falls back to the DataQuery own filters when the map has no entry for it', () => {
+      const existingFilters = [{ id: 'REF_AREA', values: ['AU'] }];
+      const dataQueries: DataQuery[] = [
+        {
+          urn: 'TEST:DS(1.0)',
+          disabled: true,
+          metadata: BASE_METADATA,
+          filters: existingFilters as any,
+        },
+      ];
+      const queryFiltersMap = new Map();
+
+      const message = prepareSystemMessage(
+        undefined,
+        undefined,
+        dataQueries,
+        undefined,
+        queryFiltersMap,
+      );
+      const data = JSON.parse(
+        (message.custom_content!.attachments![0] as any).data,
+      );
+
+      expect(data.filters).toEqual(existingFilters);
+    });
+
+    it('defaults to an empty array (never omits the key) when the map has no entry and the DataQuery has no filters either', () => {
+      const dataQueries: DataQuery[] = [
+        { urn: 'TEST:DS(1.0)', disabled: true, metadata: BASE_METADATA },
+      ];
+      const queryFiltersMap = new Map();
+
+      const message = prepareSystemMessage(
+        undefined,
+        undefined,
+        dataQueries,
+        undefined,
+        queryFiltersMap,
+      );
+      const data = JSON.parse(
+        (message.custom_content!.attachments![0] as any).data,
+      );
+
+      expect(data.filters).toEqual([]);
+      expect('filters' in data).toBe(true);
+    });
+  });
 });
 
 describe('updateMessagesWithSystemMessage', () => {

--- a/libs/conversation-view/src/utils/system-message.ts
+++ b/libs/conversation-view/src/utils/system-message.ts
@@ -56,8 +56,10 @@ export const prepareSystemMessage = (
               urn: dataQuery?.urn,
               metadata: dataQuery?.metadata,
               filters: queryFiltersMap
-                ? queryFiltersMap?.get(dataQuery?.urn)
-                : singleDataQueryFilters,
+                ? (queryFiltersMap?.get(dataQuery?.urn) ??
+                  dataQuery?.filters ??
+                  [])
+                : (singleDataQueryFilters ?? []),
               disabled: !!dataQuery?.disabled,
             }),
           };

--- a/specs/system/filters/05-system-message-persistence.md
+++ b/specs/system/filters/05-system-message-persistence.md
@@ -70,6 +70,11 @@ in `attachment.data` as a JSON string. `disabled` is always written as an explic
 Existing conversations that pre-date this field will restore with `disabled` absent; the
 restore path treats absence as `false` — no migration is needed.
 
+`filters` is never omitted, even for a disabled dataset missing from `queryFiltersMap`
+(multi-dataset mode only maps enabled datasets). Missing values fall back to the dataset's
+own saved `filters`, then to `[]` — never `undefined`, which `JSON.stringify` would otherwise
+drop from the payload and the backend would then reject as unparseable.
+
 ### `updateMessagesWithSystemMessage()`
 
 `libs/conversation-view/src/utils/system-message.ts:40`


### PR DESCRIPTION
### Applicable issues

- #465

### Description of changes

In cross-dataset query mode, unchecking a dataset in the "Set filters" → "Dataset" panel and applying caused subsequent messages to fail with a backend 400 error ("Failed to parse system message attachment data as a JSON query").

The disabled dataset's per-dataset filter lookup (`queryFiltersMap.get(urn)`) returned `undefined`, since the map is only populated for enabled datasets. `JSON.stringify` silently drops object keys with an `undefined` value, so the persisted system-message attachment for that dataset ended up missing the `filters` key entirely — which the backend rejects as unparseable.

The fix adds a fallback so `filters` is always resolved to an array: the dataset's own previously-saved filters when it has no entry in the map, then `[]` as a last resort. This mirrors a fallback pattern that already existed elsewhere in the same file for the in-memory return value, just not applied to the JSON-serialization path.

Added regression tests covering both fallback cases, and updated the relevant system-message-persistence spec.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.