### PR TITLE
fix: skip resend when submitting an unedited message

### DIFF
--- a/libs/conversation-view/src/components/ChatMessages/MessageEdit/MessageEdit.tsx
+++ b/libs/conversation-view/src/components/ChatMessages/MessageEdit/MessageEdit.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useEffect, useRef } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useAdvancedView } from '../../../context/AdvancedViewContext';
 import { Button } from '@epam/statgpt-ui-components';
@@ -23,22 +23,37 @@ const MessageEdit: FC<Props> = ({
 }) => {
   const { isOpenedAdvancedView } = useAdvancedView();
   const textRef = useRef<HTMLTextAreaElement>(null);
+  const [isUnchanged, setIsUnchanged] = useState(true);
 
   useEffect(() => {
     const textarea = textRef.current;
-    onInput();
+    resizeTextarea();
     if (textarea) {
       textarea.focus();
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
     }
   }, []);
 
-  const onInput = () => {
+  const resizeTextarea = () => {
     const textarea = textRef.current;
     if (textarea) {
       textarea.style.height = 'auto';
       textarea.style.height = textarea.scrollHeight + 'px';
     }
+  };
+
+  const onInput = () => {
+    resizeTextarea();
+    setIsUnchanged((textRef.current?.value || '').trim() === content.trim());
+  };
+
+  const handleSubmit = () => {
+    const text = textRef.current?.value || '';
+    if (text.trim() === content.trim()) {
+      onCancel();
+      return;
+    }
+    onEditApply(text);
   };
 
   return (
@@ -72,7 +87,8 @@ const MessageEdit: FC<Props> = ({
           buttonClassName="text-button-primary small-icon-button"
           title={editMessageTitles?.send}
           isSmallButton
-          onClick={() => onEditApply(textRef.current?.value || '')}
+          disabled={isUnchanged}
+          onClick={handleSubmit}
         />
       </div>
     </div>


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/343

### Description of changes

Editing a user message and submitting without changing the text used to trigger a full resend/regenerate. `MessageEdit` now tracks whether the edited text differs (trimmed) from the original content, disables the Submit button while unchanged, and additionally guards the submit handler so it closes edit mode instead of resending if the text still matches the original.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.