### PR TITLE
fix: persist conversation-list group collapse state across remounts

### DIFF
--- a/libs/conversation-list/jest.config.js
+++ b/libs/conversation-list/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/conversation-list',
+  setupFiles: ['./jest.polyfills.ts'],
 };

--- a/libs/conversation-list/jest.polyfills.ts
+++ b/libs/conversation-list/jest.polyfills.ts
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;

--- a/libs/conversation-list/src/components/ConversationList/ConversationList.tsx
+++ b/libs/conversation-list/src/components/ConversationList/ConversationList.tsx
@@ -83,6 +83,22 @@ export const ConversationList: FC<Props> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [isExpandedSearch, setIsExpandedSearch] = useState<boolean>(false);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const toggleGroupCollapse = useCallback((groupLabel: string) => {
+    setCollapsedGroups((previousValue) => {
+      const nextValue = new Set(previousValue);
+      if (nextValue.has(groupLabel)) {
+        nextValue.delete(groupLabel);
+      } else {
+        nextValue.add(groupLabel);
+      }
+      return nextValue;
+    });
+  }, []);
+
   const {
     getConversations,
     getSharedConversations,
@@ -273,6 +289,8 @@ export const ConversationList: FC<Props> = ({
                         groupedConversations={conversations}
                         handleConversationClick={handleConversationClick}
                         selectedConversationId={selectedConversationId}
+                        isCollapsed={collapsedGroups.has(groupLabel)}
+                        onToggleCollapse={() => toggleGroupCollapse(groupLabel)}
                       />
                     ),
                 )

--- a/libs/conversation-list/src/components/ConversationList/__tests__/ConversationList.spec.tsx
+++ b/libs/conversation-list/src/components/ConversationList/__tests__/ConversationList.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ConversationInfo } from '@epam/ai-dial-shared';
+import { ConversationList } from '../ConversationList';
+import { ConversationListActions } from '../../../models/conversation-list';
+
+function buildActions(): ConversationListActions {
+  return {
+    getConversations: jest.fn().mockResolvedValue([]),
+    getSharedConversations: jest.fn().mockResolvedValue([]),
+    deleteConversation: jest.fn(),
+    getConversation: jest.fn(),
+    getFileBlob: jest.fn(),
+    renameConversation: jest.fn(),
+  };
+}
+
+function buildEarlierConversation(): ConversationInfo {
+  const updatedAt = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  return {
+    id: 'conv-1',
+    name: 'earlier conversation',
+    updatedAt,
+  } as ConversationInfo;
+}
+
+function buildProps(
+  overrides: Partial<React.ComponentProps<typeof ConversationList>> = {},
+): React.ComponentProps<typeof ConversationList> {
+  return {
+    actions: buildActions(),
+    isCollapsed: false,
+    locale: 'en',
+    conversationStyles: { titles: {} as never },
+    conversations: [buildEarlierConversation()],
+    sharedConversations: [],
+    setConversations: jest.fn(),
+    setSharedConversations: jest.fn(),
+    handleConversationClick: jest.fn(),
+    handleSelectedConversationRemove: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('ConversationList group collapse persistence', () => {
+  it('keeps a group collapsed after the sidebar is hidden and shown again', async () => {
+    const props = buildProps();
+    const { rerender } = render(<ConversationList {...props} />);
+
+    await waitFor(() => expect(screen.getByText('Earlier')).toBeTruthy());
+    expect(screen.getByText('earlier conversation')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Earlier'));
+    expect(screen.queryByText('earlier conversation')).toBeNull();
+
+    rerender(<ConversationList {...props} isCollapsed />);
+    rerender(<ConversationList {...props} isCollapsed={false} />);
+
+    expect(screen.queryByText('earlier conversation')).toBeNull();
+  });
+});

--- a/libs/conversation-list/src/components/ConversationsGroup/ConversationsGroup.tsx
+++ b/libs/conversation-list/src/components/ConversationsGroup/ConversationsGroup.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ConversationInfo } from '@epam/ai-dial-shared';
-import { FC, useCallback, useState } from 'react';
+import { FC } from 'react';
 import classNames from 'classnames';
 import {
   getLabelByGroup,
@@ -16,6 +16,8 @@ interface Props {
   groupedConversations: ConversationInfo[];
   selectedConversationId?: string;
   isDisabled?: boolean;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
   handleConversationClick: (folder: string, conversationId: string) => void;
 }
 
@@ -25,31 +27,28 @@ const ConversationsGroup: FC<Props> = ({
   groupLabel,
   groupedConversations,
   isDisabled,
+  isCollapsed,
+  onToggleCollapse,
 }) => {
   const { titles } = useConversationStyles();
-  const [isGroupCollapsed, setIsGroupCollapsed] = useState<boolean>(false);
-
-  const toggleGroupCollapse = useCallback(() => {
-    setIsGroupCollapsed((previousValue) => !previousValue);
-  }, [setIsGroupCollapsed]);
 
   return (
     <div key={groupLabel}>
       <div
         className="conversation-group-items-title mb-3 inline-flex cursor-pointer items-center gap-1 text-neutrals-700"
-        onClick={toggleGroupCollapse}
+        onClick={onToggleCollapse}
       >
         <IconCaretRightFilled
           className={classNames(
             'w-3 h-3 conversation-group-items-arrow',
-            isGroupCollapsed ? 'rotate-[90deg]' : 'rotate-0',
+            isCollapsed ? 'rotate-[90deg]' : 'rotate-0',
           )}
         />
         <span className="body-3 conversation-group-items-title-text">
           {getLabelByGroup(groupLabel, titles)}
         </span>
       </div>
-      {!isGroupCollapsed && (
+      {!isCollapsed && (
         <div
           className={classNames(
             'flex flex-col gap-y-3',

--- a/libs/conversation-list/src/components/ConversationsGroup/__tests__/ConversationsGroup.spec.tsx
+++ b/libs/conversation-list/src/components/ConversationsGroup/__tests__/ConversationsGroup.spec.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConversationInfo } from '@epam/ai-dial-shared';
+import ConversationsGroup from '../ConversationsGroup';
+import { ConversationStylesContext } from '../../../context/ConversationStylesContext';
+import {
+  ConversationListActionsProvider,
+  ConversationListActionsContextValue,
+} from '../../../context/ConversationListActionsContext';
+import { ConversationStyles } from '../../../models/conversation-list';
+
+const conversationStyles: ConversationStyles = { titles: {} as never };
+
+const conversationListActions: ConversationListActionsContextValue = {
+  locale: 'en',
+  deleteConversation: jest.fn(),
+  renameConversation: jest.fn(),
+  getConversation: jest.fn(),
+  getFileBlob: jest.fn(),
+};
+
+function renderGroup(
+  overrides: Partial<React.ComponentProps<typeof ConversationsGroup>> = {},
+) {
+  const conversation: ConversationInfo = {
+    id: 'conv-1',
+    name: 'conversation 1',
+  } as ConversationInfo;
+
+  const props: React.ComponentProps<typeof ConversationsGroup> = {
+    groupLabel: 'Earlier',
+    groupedConversations: [conversation],
+    handleConversationClick: jest.fn(),
+    isCollapsed: false,
+    onToggleCollapse: jest.fn(),
+    ...overrides,
+  };
+
+  return render(
+    <ConversationListActionsProvider value={conversationListActions}>
+      <ConversationStylesContext.Provider value={conversationStyles}>
+        <ConversationsGroup {...props} />
+      </ConversationStylesContext.Provider>
+    </ConversationListActionsProvider>,
+  );
+}
+
+describe('ConversationsGroup', () => {
+  it('renders conversations when isCollapsed is false', () => {
+    renderGroup({ isCollapsed: false });
+
+    expect(screen.getByText('conversation 1')).toBeTruthy();
+  });
+
+  it('does not render conversations when isCollapsed is true', () => {
+    renderGroup({ isCollapsed: true });
+
+    expect(screen.queryByText('conversation 1')).toBeNull();
+  });
+
+  it('calls onToggleCollapse exactly once when the header is clicked', () => {
+    const onToggleCollapse = jest.fn();
+    renderGroup({ onToggleCollapse });
+
+    fireEvent.click(screen.getByText('Earlier'));
+
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/conversation-list/tsconfig.lib.json
+++ b/libs/conversation-list/tsconfig.lib.json
@@ -3,9 +3,10 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
   "exclude": [
     "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
     "src/**/*.test.ts",
     "jest.config.js",
     "vite.config.ts"

--- a/libs/conversation-list/tsconfig.spec.json
+++ b/libs/conversation-list/tsconfig.spec.json
@@ -8,7 +8,9 @@
   "include": [
     "jest.config.js",
     "src/**/*.test.ts",
+    "src/**/*.test.tsx",
     "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
     "src/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/345

### Description of changes

Sidebar group collapse state lived in `ConversationsGroup`'s local `useState`, which two
code paths in `ConversationList.tsx` (`isLoading` → `<Loader/>`, `isCollapsed` → `null`)
would unmount and reset. Moved the state up into `ConversationList` (`collapsedGroups: Set`,
controlled `isCollapsed`/`onToggleCollapse` props) so it survives both remount paths.

Also fixed a `conversation-list` tsconfig gap that excluded `.tsx` files from typechecking.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.