### PR TITLE
feat: allow overriding CrossDatasetGridAttachment row/header height

### DIFF
--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
@@ -63,6 +63,10 @@ interface Props {
   showLimitMessage?: (p: boolean) => void;
   onApiReady?: (api: GridApi) => void;
   onGridRenderedChange?: (isRendered: boolean) => void;
+  /** Overrides the shared `GRID_ROW_HEIGHT` default for this grid instance only. */
+  rowHeight?: number;
+  /** Overrides the shared `GRID_HEADER_HEIGHT` default for this grid instance only. */
+  headerHeight?: number;
 }
 
 const CrossDatasetGridAttachment: FC<Props> = ({
@@ -75,6 +79,8 @@ const CrossDatasetGridAttachment: FC<Props> = ({
   showLimitMessage,
   onApiReady,
   onGridRenderedChange,
+  rowHeight = GRID_ROW_HEIGHT,
+  headerHeight = GRID_HEADER_HEIGHT,
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isGridRendered, setIsGridRendered] = useState<boolean>(false);
@@ -109,12 +115,12 @@ const CrossDatasetGridAttachment: FC<Props> = ({
 
   useEffect(() => {
     if (rowData) {
-      setGridHeight(getGridHeight(rowData.length));
+      setGridHeight(getGridHeight(rowData.length, rowHeight, headerHeight));
       showLimitMessage?.(rowData.length >= SERIES_LIMIT);
     } else {
       showLimitMessage?.(false);
     }
-  }, [rowData, showLimitMessage]);
+  }, [rowData, rowHeight, headerHeight, showLimitMessage]);
 
   useEffect(() => {
     if (!columnDefs || !gridApiRef.current) return;
@@ -167,8 +173,8 @@ const CrossDatasetGridAttachment: FC<Props> = ({
     () => (
       <AgGridReact
         defaultColDef={DEFAULT_COL_DEF}
-        headerHeight={GRID_HEADER_HEIGHT}
-        rowHeight={GRID_ROW_HEIGHT}
+        headerHeight={headerHeight}
+        rowHeight={rowHeight}
         rowData={rowData}
         enableCellTextSelection
         columnDefs={columnDefs}
@@ -189,6 +195,8 @@ const CrossDatasetGridAttachment: FC<Props> = ({
       gridComponents,
       handleGridReady,
       handleFirstDataRendered,
+      rowHeight,
+      headerHeight,
     ],
   );
 

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__tests__/CrossDatasetGridAttachment.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__tests__/CrossDatasetGridAttachment.spec.tsx
@@ -3,6 +3,10 @@ import { act, render } from '@testing-library/react';
 import type { GridReadyEvent } from 'ag-grid-community';
 import { CrossDatasetGridAttachment } from '../CrossDatasetGridAttachment';
 import { CrossDatasetGridAttachmentType } from '../../../../models/attachments';
+import {
+  GRID_HEADER_HEIGHT,
+  GRID_ROW_HEIGHT,
+} from '../../../../constants/grid';
 
 jest.mock('ag-grid-community', () => ({
   ModuleRegistry: { registerModules: jest.fn() },
@@ -18,12 +22,16 @@ jest.mock('ag-grid-community', () => ({
 let capturedGridProps: {
   onGridReady?: (event: GridReadyEvent) => void;
   onFirstDataRendered?: () => void;
+  rowHeight?: number;
+  headerHeight?: number;
 } = {};
 
 jest.mock('ag-grid-react', () => ({
   AgGridReact: (props: {
     onGridReady?: (event: GridReadyEvent) => void;
     onFirstDataRendered?: () => void;
+    rowHeight?: number;
+    headerHeight?: number;
   }) => {
     capturedGridProps = props;
     return <div data-testid="ag-grid-stub" />;
@@ -123,5 +131,25 @@ describe('CrossDatasetGridAttachment', () => {
     );
 
     expect(onGridRenderedChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('defaults rowHeight/headerHeight to the shared grid constants', () => {
+    render(<CrossDatasetGridAttachment attachment={buildAttachment()} />);
+
+    expect(capturedGridProps.rowHeight).toBe(GRID_ROW_HEIGHT);
+    expect(capturedGridProps.headerHeight).toBe(GRID_HEADER_HEIGHT);
+  });
+
+  it('passes through custom rowHeight/headerHeight when provided', () => {
+    render(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment()}
+        rowHeight={44}
+        headerHeight={44}
+      />,
+    );
+
+    expect(capturedGridProps.rowHeight).toBe(44);
+    expect(capturedGridProps.headerHeight).toBe(44);
   });
 });

--- a/libs/conversation-view/src/utils/attachments/data-grid/__tests__/grid-height.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/__tests__/grid-height.spec.ts
@@ -1,0 +1,37 @@
+import { getGridHeight } from '../grid-height';
+import {
+  GRID_HEADER_HEIGHT,
+  GRID_HORIZONTAL_SCROLL_GAP,
+  GRID_ROW_HEIGHT,
+} from '../../../../constants/grid';
+
+describe('getGridHeight', () => {
+  it('uses the shared row/header height constants when no overrides are passed', () => {
+    const rowDataLength = 3;
+    expect(getGridHeight(rowDataLength)).toBe(
+      rowDataLength * GRID_ROW_HEIGHT +
+        GRID_HEADER_HEIGHT +
+        GRID_HORIZONTAL_SCROLL_GAP,
+    );
+  });
+
+  it('returns just the header height and scroll gap for zero rows', () => {
+    expect(getGridHeight(0)).toBe(GRID_HEADER_HEIGHT + GRID_HORIZONTAL_SCROLL_GAP);
+  });
+
+  it('uses a custom row height when passed', () => {
+    expect(getGridHeight(2, 44)).toBe(
+      2 * 44 + GRID_HEADER_HEIGHT + GRID_HORIZONTAL_SCROLL_GAP,
+    );
+  });
+
+  it('uses a custom header height when passed', () => {
+    expect(getGridHeight(2, undefined, 44)).toBe(
+      2 * GRID_ROW_HEIGHT + 44 + GRID_HORIZONTAL_SCROLL_GAP,
+    );
+  });
+
+  it('uses both custom row and header heights when passed', () => {
+    expect(getGridHeight(2, 44, 44)).toBe(2 * 44 + 44 + GRID_HORIZONTAL_SCROLL_GAP);
+  });
+});

--- a/libs/conversation-view/src/utils/attachments/data-grid/__tests__/grid-height.spec.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/__tests__/grid-height.spec.ts
@@ -16,7 +16,9 @@ describe('getGridHeight', () => {
   });
 
   it('returns just the header height and scroll gap for zero rows', () => {
-    expect(getGridHeight(0)).toBe(GRID_HEADER_HEIGHT + GRID_HORIZONTAL_SCROLL_GAP);
+    expect(getGridHeight(0)).toBe(
+      GRID_HEADER_HEIGHT + GRID_HORIZONTAL_SCROLL_GAP,
+    );
   });
 
   it('uses a custom row height when passed', () => {
@@ -32,6 +34,8 @@ describe('getGridHeight', () => {
   });
 
   it('uses both custom row and header heights when passed', () => {
-    expect(getGridHeight(2, 44, 44)).toBe(2 * 44 + 44 + GRID_HORIZONTAL_SCROLL_GAP);
+    expect(getGridHeight(2, 44, 44)).toBe(
+      2 * 44 + 44 + GRID_HORIZONTAL_SCROLL_GAP,
+    );
   });
 });

--- a/libs/conversation-view/src/utils/attachments/data-grid/grid-height.ts
+++ b/libs/conversation-view/src/utils/attachments/data-grid/grid-height.ts
@@ -4,10 +4,10 @@ import {
   GRID_ROW_HEIGHT,
 } from '../../../constants/grid';
 
-export const getGridHeight = (rowDataLength: number): number => {
-  return (
-    rowDataLength * GRID_ROW_HEIGHT +
-    GRID_HEADER_HEIGHT +
-    GRID_HORIZONTAL_SCROLL_GAP
-  );
+export const getGridHeight = (
+  rowDataLength: number,
+  rowHeight: number = GRID_ROW_HEIGHT,
+  headerHeight: number = GRID_HEADER_HEIGHT,
+): number => {
+  return rowDataLength * rowHeight + headerHeight + GRID_HORIZONTAL_SCROLL_GAP;
 };


### PR DESCRIPTION
### Applicable issues



### Description of changes

Adds optional `rowHeight`/`headerHeight` props to `CrossDatasetGridAttachment`, defaulting to the existing `GRID_ROW_HEIGHT`/`GRID_HEADER_HEIGHT` constants. No default behavior changes — this just lets a caller opt into taller rows per-instance. Also adds test coverage for `getGridHeight` (previously untested) and the new prop pass-through.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.