### PR TITLE
chore: fix nanoid high-severity vulnerability and renew trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,16 +1,17 @@
 # node:24-alpine vulnerabilities in https://hub.docker.com/layers/library/node/24-alpine
 
 # undici
-CVE-2026-12151 exp:2026-08-20
+CVE-2026-12151 exp:2026-09-14
 
 # tar
-CVE-2026-59873 exp:2026-08-20
-CVE-2026-59874 exp:2026-08-20
+CVE-2026-59873 exp:2026-09-14
+CVE-2026-59874 exp:2026-09-14
+CVE-2026-73566 exp:2026-09-14
 
 # brace-expansion
-CVE-2026-13149 exp:2026-08-20
-CVE-2026-14257 exp:2026-08-20
-CVE-2026-69152 exp:2026-08-20
+CVE-2026-13149 exp:2026-09-14
+CVE-2026-14257 exp:2026-09-14
+CVE-2026-69152 exp:2026-09-14
 
 # ip-address
-CVE-2026-69192 exp:2026-08-20
+CVE-2026-69192 exp:2026-09-14

--- a/package-lock.json
+++ b/package-lock.json
@@ -24596,9 +24596,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "undici": "7.29.0",
     "brace-expansion": "5.0.9",
     "minimatch": "10.2.3",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "less": "4.8.1",
     "sockjs": {
       "uuid": "11.1.1"


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

- Bump `nanoid` override from `3.3.17` to `3.3.18` to fix CVE-2026-67213 (high-severity DoS in `npm audit`).
- Renew expired `.trivyignore` entries (undici, tar, brace-expansion, ip-address — all vulnerabilities bundled into npm's own dependencies inside the `node:24-alpine` base image, unrelated to our own dependency tree) with a new expiry of 2026-09-14.
- Add newly reported `CVE-2026-73566` for `tar` to `.trivyignore`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.