### PR TITLE
feat: enlarge metadata-indicator tap target across grid cell renderers

### DIFF
--- a/apps/storybook/.storybook/brand-configs/brand1/metadata.scss
+++ b/apps/storybook/.storybook/brand-configs/brand1/metadata.scss
@@ -1,0 +1,60 @@
+.ag-cell {
+  .metadata-indicator {
+    @apply absolute top-0 right-0;
+    @apply border-transparent border-r-gradients-light;
+    @apply border-r-[10px] border-b-[10px];
+    @apply cursor-pointer;
+  }
+
+  &.ag-cell-focus:not(.ag-cell-range-selected):focus-within {
+    .metadata-indicator {
+      @apply border-r-gradients-middle;
+    }
+  }
+}
+
+.metadata {
+  @apply pb-5;
+  @apply max-h-[664px];
+
+  &-heading {
+    @apply text-base font-bold;
+  }
+
+  &-content {
+    @apply flex flex-col;
+    @apply px-6;
+    @apply border-t border-t-neutrals-500;
+  }
+
+  &-description {
+    @apply flex flex-col gap-y-2;
+    @apply pt-7 pb-5;
+    @apply border-b border-b-neutrals-500;
+  }
+
+  &-list {
+    @apply mt-4;
+  }
+
+  &-item {
+    @apply pb-5;
+
+    &-title {
+      @apply mb-1;
+    }
+
+    &-key,
+    &-value {
+      @apply body-2;
+    }
+
+    &-value {
+      @apply text-neutrals-1000;
+    }
+  }
+
+  &-empty {
+    @apply body-2;
+  }
+}

--- a/apps/storybook/.storybook/brand-configs/brand1/styles.scss
+++ b/apps/storybook/.storybook/brand-configs/brand1/styles.scss
@@ -6,3 +6,4 @@
 @import './input';
 @import './grid';
 @import './chart';
+@import './metadata';

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CrossDatasetGrid.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CrossDatasetGrid.stories.tsx
@@ -1,0 +1,153 @@
+import type { ComponentProps } from 'react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import { CrossDatasetGridAttachment } from '../CrossDatasetGridAttachment';
+import { CrossDatasetGridAttachmentType } from '../../../../models/attachments';
+import {
+  METADATA_CELL_RENDER,
+  MERGED_DIMENSION_CELL_RENDER,
+  CELL_PADDING_0,
+} from '../../../../constants/grid';
+import {
+  COUNTRY_COL_ID,
+  INDICATOR_COL_ID,
+} from '../../../../constants/cross-dataset-grid';
+import { ConversationViewStylesProvider } from '../../../../context/ConversationViewStylesContext';
+import { OnboardingProvider } from '../../../../context/OnboardingContext';
+import { ConversationViewFeatureTogglesProvider } from '../../../../context/ConversationViewFeatureTogglesContext';
+import {
+  ConversationViewSidePanelProvider,
+  ConversationViewSidePanelOutlet,
+} from '../../../ConversationView/SidePanel/ConversationViewSidePanelContext';
+import { AdvancedViewProvider } from '../../../../context/AdvancedViewContext';
+
+const withProviders: Decorator = (Story) => (
+  <ConversationViewStylesProvider>
+    <OnboardingProvider>
+      <AdvancedViewProvider>
+        <ConversationViewFeatureTogglesProvider isMetadataInSidePanel>
+          <ConversationViewSidePanelProvider>
+            <Story />
+          </ConversationViewSidePanelProvider>
+        </ConversationViewFeatureTogglesProvider>
+      </AdvancedViewProvider>
+    </OnboardingProvider>
+  </ConversationViewStylesProvider>
+);
+
+const emptyStructuresMap = new Map();
+const emptyDatasetDimensionsSchemesMap = new Map();
+
+const sampleAttachment: CrossDatasetGridAttachmentType = {
+  type: 'application/json',
+  title: 'Cross-dataset comparison',
+  gridContent: {
+    columns: [
+      {
+        headerName: '',
+        pinned: true,
+        width: 32,
+        maxWidth: 32,
+        cellClass: CELL_PADDING_0,
+        cellRenderer: METADATA_CELL_RENDER,
+        cellRendererParams: {
+          structuresMap: emptyStructuresMap,
+          attributesDataMap: new Map(),
+          locale: 'en',
+        },
+      },
+      {
+        headerName: 'Country dimensions',
+        field: COUNTRY_COL_ID,
+        colId: COUNTRY_COL_ID,
+        flex: 1,
+        minWidth: 200,
+        cellClass: CELL_PADDING_0,
+        cellRenderer: MERGED_DIMENSION_CELL_RENDER,
+        cellRendererParams: {
+          structuresMap: emptyStructuresMap,
+          datasetDimensionsSchemesMap: emptyDatasetDimensionsSchemesMap,
+          locale: 'en',
+          colId: COUNTRY_COL_ID,
+        },
+      },
+      {
+        headerName: 'Indicator dimensions',
+        field: INDICATOR_COL_ID,
+        colId: INDICATOR_COL_ID,
+        flex: 1,
+        minWidth: 200,
+        cellClass: CELL_PADDING_0,
+        cellRenderer: MERGED_DIMENSION_CELL_RENDER,
+        cellRendererParams: {
+          structuresMap: emptyStructuresMap,
+          datasetDimensionsSchemesMap: emptyDatasetDimensionsSchemesMap,
+          locale: 'en',
+          colId: INDICATOR_COL_ID,
+        },
+      },
+    ],
+    data: [
+      {
+        dataset: { urn: 'urn:sdmx:example:1' },
+        [COUNTRY_COL_ID]: 'Ukraine',
+        [INDICATOR_COL_ID]: 'GDP, current prices',
+      },
+      {
+        dataset: { urn: 'urn:sdmx:example:2' },
+        [COUNTRY_COL_ID]: 'Poland',
+        [INDICATOR_COL_ID]: 'GDP, current prices',
+      },
+      {
+        dataset: { urn: 'urn:sdmx:example:3' },
+        [COUNTRY_COL_ID]: 'Germany',
+        [INDICATOR_COL_ID]: 'Unemployment rate',
+      },
+    ],
+  },
+};
+
+/**
+ * Shared base for every story in this file: lays the grid out beside a real
+ * `ConversationViewSidePanelOutlet` so the metadata-indicator triangle is
+ * clickable and opens the actual side panel in every variant, not just one.
+ * @param args - Props forwarded to `CrossDatasetGridAttachment`.
+ */
+function renderWithClickableTriangle(
+  args: ComponentProps<typeof CrossDatasetGridAttachment>,
+) {
+  return (
+    <div style={{ display: 'flex' }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <CrossDatasetGridAttachment {...args} />
+      </div>
+      <ConversationViewSidePanelOutlet scope="conversation" />
+    </div>
+  );
+}
+
+const meta: Meta<typeof CrossDatasetGridAttachment> = {
+  title: 'Conversation View/Grid/CrossDatasetGrid',
+  component: CrossDatasetGridAttachment,
+  decorators: [withProviders],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CrossDatasetGridAttachment>;
+
+export const WithData: Story = {
+  render: renderWithClickableTriangle,
+  args: {
+    attachment: sampleAttachment,
+  },
+};
+
+export const TallRows: Story = {
+  name: 'Tall Rows (custom 44px row height)',
+  render: renderWithClickableTriangle,
+  args: {
+    attachment: sampleAttachment,
+    rowHeight: 44,
+    headerHeight: 44,
+  },
+};

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/DatasetDetailCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/DatasetDetailCellRenderer.tsx
@@ -20,6 +20,7 @@ import { useAdvancedView } from '../../../context/AdvancedViewContext';
 import { useDatasetDimensionsMetadataMap } from '../../../context/DatasetDimensionsMetadataMapContext';
 import { getDateFormattedValue } from '../../../utils/date-format';
 import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
+import { MetadataIndicatorWithHitArea } from './helpers/MetadataIndicatorWithHitArea';
 
 interface DatasetDetailCellRendererParams extends ICellRendererParams {
   structuresMap: Map<string, StructuralData | undefined>;
@@ -93,11 +94,10 @@ const DatasetDetailCellRenderer: FC<DatasetDetailCellRendererParams> = (
   ]);
 
   return (
-    <div className="relative size-full p-2">
+    <div className="p-2">
       {params.valueFormatted ?? params.value}
       {showIndicator && (
-        <div
-          className="metadata-indicator"
+        <MetadataIndicatorWithHitArea
           title={titles?.metadata || 'View details'}
           onClick={openMetadata}
         />

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/MergedDimensionCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/MergedDimensionCellRenderer.tsx
@@ -29,6 +29,7 @@ import { useTableSettingsContextOptional } from '../../AdvancedView/TableSetting
 import { getDimensionValue } from '../../../utils/attachments/cross-dataset-grid/dimensions-columns';
 import { applyDimensionKeyCustomization } from '../../AdvancedView/TableSettings/helpers/crossDatasetEnrichment';
 import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
+import { MetadataIndicatorWithHitArea } from './helpers/MetadataIndicatorWithHitArea';
 
 interface MergedDimensionCellRendererParams extends ICellRendererParams {
   structuresMap: Map<string, StructuralData | undefined>;
@@ -59,6 +60,12 @@ function getPanelTitle(colId: string, titles?: ConversationViewTitles): string {
 
 const METADATA_SIDE_PANEL_ID = 'merged-dimension-metadata-side-panel';
 
+/**
+ * Renders per-dimension values with a metadata indicator in the corner; see
+ * `MetadataIndicatorWithHitArea` for how that indicator is positioned and
+ * why it doesn't need the root wrapper below to be `relative`/`absolute`.
+ * @param params - ag-grid cell renderer params for this column.
+ */
 const MergedDimensionCellRenderer: FC<MergedDimensionCellRendererParams> = (
   params,
 ) => {
@@ -160,11 +167,10 @@ const MergedDimensionCellRenderer: FC<MergedDimensionCellRendererParams> = (
   ]);
 
   return (
-    <div className="relative size-full p-2">
+    <div className="p-2">
       {displayValue}
       {showTriangle && (
-        <div
-          className="metadata-indicator"
+        <MetadataIndicatorWithHitArea
           title={titles?.metadata || 'View details'}
           onClick={openMetadata}
         />

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellWithMetadata.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/ObservationValueCellWithMetadata.tsx
@@ -3,6 +3,7 @@ import { FC, useCallback, useState } from 'react';
 import Metadata from '../../AdvancedView/Metadata/Metadata';
 import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
 import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
+import { MetadataIndicatorWithHitArea } from './helpers/MetadataIndicatorWithHitArea';
 import { getObsAttributesFromParams } from '../../../utils/attachments/metadata';
 import { useConversationViewFeatureToggles } from '../../../context/ConversationViewFeatureTogglesContext';
 import { useConversationViewSidePanelOptional } from '../../ConversationView/SidePanel/ConversationViewSidePanelContext';
@@ -80,13 +81,12 @@ const ObservationValueCellWithMetadata: FC<
 
   return (
     <>
-      <div className="relative size-full p-2 text-end">
+      <div className="p-2 text-end">
         {params?.valueFormatted || params?.value}
-        <div
-          className="metadata-indicator"
+        <MetadataIndicatorWithHitArea
           title={titles?.metadata || 'View details'}
           onClick={openMetadata}
-        ></div>
+        />
       </div>
       {metadataContent && (
         <Metadata

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/helpers/MetadataIndicatorWithHitArea.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/helpers/MetadataIndicatorWithHitArea.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { FC } from 'react';
+
+const HIT_AREA_STYLE = {
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  right: 0,
+  width: 'min(44px, 100%)',
+} as const;
+
+interface MetadataIndicatorWithHitAreaProps {
+  title: string;
+  onClick: () => void;
+}
+
+/**
+ * Corner indicator opening per-dimension/dataset/observation metadata:
+ * `.metadata-indicator` (app-styled triangle) plus an invisible, larger
+ * click target — both call `onClick` independently, but the triangle's own
+ * handler is only ever reached if a consumer's CSS repositions the hit area
+ * away from it; by default the hit area (rendered after the triangle,
+ * absolutely positioned over it) always wins the pointer event.
+ *
+ * The hit area is sized via inline `style`, not a CSS class: this ships
+ * inside a compiled npm package with no CSS of its own, and a new class
+ * would need matching SCSS added in every consuming repo to ever take
+ * effect.
+ *
+ * Renders both elements as direct children of a `position: static` cell
+ * root. They rely on `position: absolute` with no positioned ancestor
+ * before ag-grid's own `.ag-cell` (always `position: absolute; height:
+ * 100%`), so they anchor to the real cell box on any row height.
+ * @param title - Tooltip text shown on hover.
+ * @param onClick - Handler invoked when either element is clicked.
+ */
+export const MetadataIndicatorWithHitArea: FC<
+  MetadataIndicatorWithHitAreaProps
+> = ({ title, onClick }) => (
+  <>
+    <div className="metadata-indicator" onClick={onClick} />
+    <div
+      className="cursor-pointer"
+      style={HIT_AREA_STYLE}
+      title={title}
+      onClick={onClick}
+    />
+  </>
+);


### PR DESCRIPTION
### Applicable issues

_None._

### Description of changes

- Extracted a shared `MetadataIndicatorWithHitArea` component (`GridCellRenderers/helpers/`) rendering the existing `.metadata-indicator` triangle plus a new, larger invisible tap target next to it, and adopted it in all three grid cell renderers that use this pattern: `MergedDimensionCellRenderer`, `DatasetDetailCellRenderer`, `ObservationValueCellWithMetadata`.
- The tap target is sized via inline styles rather than a new CSS class, so it ships fully functional as part of the compiled package with no matching SCSS required in any consuming app.
- Each renderer's root cell wrapper no longer sets its own `position`, so the indicator/hit-area correctly anchor to the real ag-grid cell box (fixing vertical centering on tall/custom row heights) instead of a wrapper whose height could collapse to its text content.
- Added a Storybook story for the cross-dataset grid exercising the clickable indicator against a real side panel.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.