### PR TITLE
feat: support custom icon for metadata grid column

### DIFF
--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellIconContext.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellIconContext.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { createContext, ReactNode, useContext, useMemo } from 'react';
+
+export interface MetadataCellIconConfig {
+  icon?: ReactNode;
+}
+
+const MetadataCellIconContext = createContext<MetadataCellIconConfig | null>(
+  null,
+);
+
+export interface MetadataCellIconProviderProps {
+  value?: MetadataCellIconConfig;
+  children: ReactNode;
+}
+
+/**
+ * MetadataCellIconProvider supplies an optional override for the icon
+ * rendered by MetadataCellRenderer's pinned grid column button. The icon is
+ * rendered raw (no sizing wrapper) — size it around `size-5` (20px) to fit
+ * the pinned 32px column cleanly.
+ *
+ * @example
+ * ```tsx
+ * <MetadataCellIconProvider value={{ icon: <MyMetadataIcon className="size-5" /> }}>
+ *   <MyLayout />
+ * </MetadataCellIconProvider>
+ * ```
+ *
+ * @param value - Optional customization config; omitted keys fall back to MetadataCellRenderer's defaults.
+ * @param children - Subtree that gains access to the customization config.
+ */
+export function MetadataCellIconProvider({
+  value,
+  children,
+}: MetadataCellIconProviderProps) {
+  const memo = useMemo(() => value ?? {}, [value]);
+
+  return (
+    <MetadataCellIconContext.Provider value={memo}>
+      {children}
+    </MetadataCellIconContext.Provider>
+  );
+}
+
+/**
+ * Returns the current MetadataCellIconConfig, or null when called outside a
+ * MetadataCellIconProvider.
+ */
+export function useMetadataCellIconConfig() {
+  return useContext(MetadataCellIconContext);
+}

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellRenderer.tsx
@@ -12,6 +12,7 @@ import { IconButton } from '@epam/statgpt-ui-components';
 
 import { ICellRendererParams } from 'ag-grid-community';
 import MetadataIcon from '../../../assets/icons/metadata.svg';
+import { useMetadataCellIconConfig } from './MetadataCellIconContext';
 import Metadata from '../../AdvancedView/Metadata/Metadata';
 import SidePanelMetadataContent from '../../AdvancedView/Metadata/SidePanel/SidePanelMetadataContent';
 import { getExternalLinkFromContext } from './helpers/get-external-link-from-context';
@@ -59,6 +60,7 @@ const MetadataCellRenderer = (params: MetadataCellRendererParams) => {
   const sidePanel = useConversationViewSidePanelOptional();
   const { isMetadataInSidePanel } = useConversationViewFeatureToggles();
   const { getDatasetLastUpdated } = useDatasetDimensionsMetadataMap();
+  const metadataCellIconConfig = useMetadataCellIconConfig();
   const [isMetadataClosed, setIsMetadataClosed] = useState(false);
   const rowUrn = params?.data?.dataset?.urn as string | undefined;
   const externalLink = getExternalLinkFromContext(params?.context, rowUrn);
@@ -221,7 +223,9 @@ const MetadataCellRenderer = (params: MetadataCellRendererParams) => {
         <IconButton
           title={titles?.metadata || 'View details'}
           buttonClassName="!text-neutrals-1000 !border-none !p-1"
-          icon={<MetadataIcon className="size-5" />}
+          icon={
+            metadataCellIconConfig?.icon ?? <MetadataIcon className="size-5" />
+          }
           onClick={openMetadata}
         />
       </div>

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/__tests__/MetadataCellIconContext.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/__tests__/MetadataCellIconContext.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import {
+  MetadataCellIconProvider,
+  useMetadataCellIconConfig,
+} from '../MetadataCellIconContext';
+
+function ConfigProbe() {
+  const config = useMetadataCellIconConfig();
+  return (
+    <div data-testid="probe">
+      {config === null ? 'null' : JSON.stringify(Object.keys(config))}
+    </div>
+  );
+}
+
+describe('MetadataCellIconContext', () => {
+  it('returns null outside a provider', () => {
+    render(<ConfigProbe />);
+    expect(screen.getByTestId('probe').textContent).toBe('null');
+  });
+
+  it('returns the supplied value inside a provider', () => {
+    render(
+      <MetadataCellIconProvider value={{ icon: <span>icon</span> }}>
+        <ConfigProbe />
+      </MetadataCellIconProvider>,
+    );
+    expect(screen.getByTestId('probe').textContent).toBe(
+      JSON.stringify(['icon']),
+    );
+  });
+
+  it('defaults to an empty object when value is omitted', () => {
+    render(
+      <MetadataCellIconProvider>
+        <ConfigProbe />
+      </MetadataCellIconProvider>,
+    );
+    expect(screen.getByTestId('probe').textContent).toBe(JSON.stringify([]));
+  });
+});

--- a/libs/conversation-view/src/index.ts
+++ b/libs/conversation-view/src/index.ts
@@ -64,6 +64,12 @@ export {
 export type { DatasetInfoDetailsConfig } from './components/AdvancedView/Metadata/SidePanel/DatasetInfoDetailsContext';
 
 export {
+  MetadataCellIconProvider,
+  useMetadataCellIconConfig,
+} from './components/Attachments/GridCellRenderers/MetadataCellIconContext';
+export type { MetadataCellIconConfig } from './components/Attachments/GridCellRenderers/MetadataCellIconContext';
+
+export {
   ConversationViewFeatureTogglesProvider,
   useConversationViewFeatureToggles,
 } from './context/ConversationViewFeatureTogglesContext';


### PR DESCRIPTION
### Applicable issues

-

### Description of changes

Adds `MetadataCellIconProvider`/`useMetadataCellIconConfig` so a consuming app can override the icon rendered by `MetadataCellRenderer`'s pinned grid column button, read at render time. Falls back to the current default icon when no provider is present. Exported from the library's public barrel alongside a context test.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.