### PR TITLE
fix: add repository field to package.json for npm provenance verification

### DIFF
--- a/libs/conversation-list/package.json
+++ b/libs/conversation-list/package.json
@@ -2,6 +2,11 @@
   "name": "@epam/statgpt-conversation-list",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git",
+    "directory": "libs/conversation-list"
+  },
   "dependencies": {
     "@epam/statgpt-dial-toolkit": "*",
     "@epam/statgpt-shared-toolkit": "*",

--- a/libs/conversation-view/package.json
+++ b/libs/conversation-view/package.json
@@ -2,6 +2,11 @@
   "name": "@epam/statgpt-conversation-view",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git",
+    "directory": "libs/conversation-view"
+  },
   "dependencies": {
     "@epam/statgpt-conversation-list": "*",
     "@epam/statgpt-dial-toolkit": "*",

--- a/libs/dial-toolkit/package.json
+++ b/libs/dial-toolkit/package.json
@@ -2,6 +2,11 @@
   "name": "@epam/statgpt-dial-toolkit",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git",
+    "directory": "libs/dial-toolkit"
+  },
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/libs/sdmx-toolkit/package.json
+++ b/libs/sdmx-toolkit/package.json
@@ -2,6 +2,11 @@
   "name": "@epam/statgpt-sdmx-toolkit",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git",
+    "directory": "libs/sdmx-toolkit"
+  },
   "sideEffects": false,
   "exports": {
     ".": {

--- a/libs/shared-toolkit/package.json
+++ b/libs/shared-toolkit/package.json
@@ -2,6 +2,11 @@
   "name": "@epam/statgpt-shared-toolkit",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git",
+    "directory": "libs/shared-toolkit"
+  },
   "sideEffects": false,
   "exports": {
     ".": {

--- a/libs/ui-components/package.json
+++ b/libs/ui-components/package.json
@@ -2,6 +2,11 @@
   "name": "@epam/statgpt-ui-components",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git",
+    "directory": "libs/ui-components"
+  },
   "sideEffects": false,
   "dependencies": {
     "@epam/statgpt-shared-toolkit": "*"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "statgpt-portal-frontend",
   "version": "0.6.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/epam/statgpt-portal-frontend.git"
+  },
   "scripts": {
     "build": "nx run-many -t build && npm run build:styles",
     "start": "nx serve portals-example --port=4001",


### PR DESCRIPTION
### Applicable issues

- #

### Description of changes

Adds a `repository` field to the root `package.json` and each published library's `package.json` under `libs/`. npm's sigstore provenance verification checks this field against the GitHub repo the provenance attestation was built from; without it, publishing with provenance fails with a 422 (repository.url mismatch). Each lib's entry also includes a `directory` pointer to its path in the monorepo.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.