### PR TITLE
feat: support metadata column width override with centered icon

### DIFF
--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/CrossDatasetGridAttachment.tsx
@@ -67,6 +67,8 @@ interface Props {
   rowHeight?: number;
   /** Overrides the shared `GRID_HEADER_HEIGHT` default for this grid instance only. */
   headerHeight?: number;
+  /** Overrides the metadata column's fixed 32px `width`/`maxWidth` for this grid instance only. */
+  metadataColumnWidth?: number;
 }
 
 const CrossDatasetGridAttachment: FC<Props> = ({
@@ -81,6 +83,7 @@ const CrossDatasetGridAttachment: FC<Props> = ({
   onGridRenderedChange,
   rowHeight = GRID_ROW_HEIGHT,
   headerHeight = GRID_HEADER_HEIGHT,
+  metadataColumnWidth,
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isGridRendered, setIsGridRendered] = useState<boolean>(false);
@@ -104,6 +107,16 @@ const CrossDatasetGridAttachment: FC<Props> = ({
         if (col.colId === CHART_COLUMN_ID) {
           return { ...col, hide: !isChartColumnVisible };
         }
+        if (
+          col.cellRenderer === METADATA_CELL_RENDER &&
+          metadataColumnWidth != null
+        ) {
+          return {
+            ...col,
+            width: metadataColumnWidth,
+            maxWidth: metadataColumnWidth,
+          };
+        }
         return applyMobileColumnWidth(col, isMobile);
       });
 
@@ -111,7 +124,12 @@ const CrossDatasetGridAttachment: FC<Props> = ({
       setColumnDefs(columns);
       setIsLoading(false);
     }
-  }, [attachment.gridContent, isChartColumnVisible, isMobile]);
+  }, [
+    attachment.gridContent,
+    isChartColumnVisible,
+    isMobile,
+    metadataColumnWidth,
+  ]);
 
   useEffect(() => {
     if (rowData) {

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CrossDatasetGrid.stories.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__stories__/CrossDatasetGrid.stories.tsx
@@ -143,11 +143,12 @@ export const WithData: Story = {
 };
 
 export const TallRows: Story = {
-  name: 'Tall Rows (custom 44px row height)',
+  name: 'Tall Rows (44px row height + metadata column width)',
   render: renderWithClickableTriangle,
   args: {
     attachment: sampleAttachment,
     rowHeight: 44,
     headerHeight: 44,
+    metadataColumnWidth: 44,
   },
 };

--- a/libs/conversation-view/src/components/Attachments/CustomAttachments/__tests__/CrossDatasetGridAttachment.spec.tsx
+++ b/libs/conversation-view/src/components/Attachments/CustomAttachments/__tests__/CrossDatasetGridAttachment.spec.tsx
@@ -6,6 +6,7 @@ import { CrossDatasetGridAttachmentType } from '../../../../models/attachments';
 import {
   GRID_HEADER_HEIGHT,
   GRID_ROW_HEIGHT,
+  METADATA_CELL_RENDER,
 } from '../../../../constants/grid';
 
 jest.mock('ag-grid-community', () => ({
@@ -24,6 +25,12 @@ let capturedGridProps: {
   onFirstDataRendered?: () => void;
   rowHeight?: number;
   headerHeight?: number;
+  columnDefs?: Array<{
+    colId?: string;
+    cellRenderer?: string;
+    width?: number;
+    maxWidth?: number;
+  }>;
 } = {};
 
 jest.mock('ag-grid-react', () => ({
@@ -32,6 +39,12 @@ jest.mock('ag-grid-react', () => ({
     onFirstDataRendered?: () => void;
     rowHeight?: number;
     headerHeight?: number;
+    columnDefs?: Array<{
+      colId?: string;
+      cellRenderer?: string;
+      width?: number;
+      maxWidth?: number;
+    }>;
   }) => {
     capturedGridProps = props;
     return <div data-testid="ag-grid-stub" />;
@@ -47,7 +60,15 @@ jest.mock('@epam/statgpt-ui-components', () => ({
 
 const GRID_CONTENT = {
   data: [{ id: '1' }],
-  columns: [{ colId: 'id', field: 'id' }],
+  columns: [
+    {
+      colId: 'metadata',
+      cellRenderer: METADATA_CELL_RENDER,
+      width: 32,
+      maxWidth: 32,
+    },
+    { colId: 'id', field: 'id' },
+  ],
 };
 
 function buildAttachment(
@@ -151,5 +172,30 @@ describe('CrossDatasetGridAttachment', () => {
 
     expect(capturedGridProps.rowHeight).toBe(44);
     expect(capturedGridProps.headerHeight).toBe(44);
+  });
+
+  it('leaves the metadata column at its default 32px width when metadataColumnWidth is not provided', () => {
+    render(<CrossDatasetGridAttachment attachment={buildAttachment()} />);
+
+    const metadataCol = capturedGridProps.columnDefs?.find(
+      (col) => col.cellRenderer === METADATA_CELL_RENDER,
+    );
+    expect(metadataCol?.width).toBe(32);
+    expect(metadataCol?.maxWidth).toBe(32);
+  });
+
+  it('overrides the metadata column width/maxWidth when metadataColumnWidth is provided', () => {
+    render(
+      <CrossDatasetGridAttachment
+        attachment={buildAttachment()}
+        metadataColumnWidth={44}
+      />,
+    );
+
+    const metadataCol = capturedGridProps.columnDefs?.find(
+      (col) => col.cellRenderer === METADATA_CELL_RENDER,
+    );
+    expect(metadataCol?.width).toBe(44);
+    expect(metadataCol?.maxWidth).toBe(44);
   });
 });

--- a/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellRenderer.tsx
+++ b/libs/conversation-view/src/components/Attachments/GridCellRenderers/MetadataCellRenderer.tsx
@@ -219,7 +219,7 @@ const MetadataCellRenderer = (params: MetadataCellRendererParams) => {
 
   return (
     <>
-      <div ref={iconRef}>
+      <div ref={iconRef} className="flex w-full justify-center">
         <IconButton
           title={titles?.metadata || 'View details'}
           buttonClassName="!text-neutrals-1000 !border-none !p-1"

--- a/specs/system/filters/06-cross-dataset-grid.md
+++ b/specs/system/filters/06-cross-dataset-grid.md
@@ -38,7 +38,7 @@ Left to right, as produced by `buildCrossDatasetGridColumns`:
 
 | Column group | Source | Notes |
 |---|---|---|
-| Metadata | `getCrossDatasetMetadataColumn` | Fixed left-anchor column |
+| Metadata | `getCrossDatasetMetadataColumn` | Fixed left-anchor column, 32px wide. Excluded from `applyMobileColumnWidth`'s mobile clamp; `CrossDatasetGridAttachment`'s `metadataColumnWidth` prop overrides its `width`/`maxWidth` for this grid instance only, applied in `CrossDatasetGridAttachment`'s own column-mapping effect (not baked into the column def itself) |
 | Agency | dataset info | String from structural metadata |
 | Dataset name | dataset info | Human-readable dataset title |
 | Country / Region | `dimensions-columns.ts` | One column; value dispatched by row urn |


### PR DESCRIPTION
### Applicable issues


### Description of changes

- Adds an optional `metadataColumnWidth` prop to `CrossDatasetGridAttachment`, overriding the pinned metadata column's fixed 32px `width`/`maxWidth` for that grid instance — mirrors the existing `rowHeight`/`headerHeight` override pattern. The column was previously excluded from `applyMobileColumnWidth`'s mobile clamp, so there was no way to widen it at all.
- Fixes the metadata column's icon button to also center *horizontally* within the column (`flex w-full justify-center` on its wrapper), not just vertically. This was invisible at the original fixed 32px width (the button already filled the full column) and only became visible once the column is widened via the new prop above.
- Updates the `TallRows` Storybook story to demo the 44px row height and the widened metadata column together.
- Updates `specs/system/filters/06-cross-dataset-grid.md`'s Metadata column row per this repo's spec-conventions rule.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.